### PR TITLE
PROD-53 Program#hasAnalytics becomes more sophisticated

### DIFF
--- a/src/js/lib/Program.js
+++ b/src/js/lib/Program.js
@@ -1,15 +1,26 @@
 /* @flow */
 
-import Ast from "../models/Ast"
 import {LookyTalk} from "boom-js-client"
 
 type Program = string
 
+const TUPLE_PROCS = ["HeadProc", "SortProc"]
+const COMPOUND_PROCS = ["ParallelProc", "SequentialProc"]
+
 export const hasAnalytics = (string: Program) => {
-  const ast = new Ast(string).toJSON()
-  if (!ast) return false
-  if (ast.proc) return true
-  else return false
+  const [ast] = parse(string)
+  if (!ast || !ast.proc) return false
+
+  const ops = COMPOUND_PROCS.includes(ast.proc.op)
+    ? ast.proc.procs.map(p => p.op)
+    : [ast.proc.op]
+
+  for (let op of ops) {
+    if (!TUPLE_PROCS.includes(op)) {
+      return true
+    }
+  }
+  return false
 }
 
 export const parse = (string: Program) => {

--- a/src/js/lib/Program.test.js
+++ b/src/js/lib/Program.test.js
@@ -1,0 +1,39 @@
+/* @flow */
+
+import * as Program from "./Program"
+
+test("#hasAnalytics head proc does not have analytics", () => {
+  expect(Program.hasAnalytics("* | head 2")).toBe(false)
+})
+
+test("#hasAnalytics sort proc does not have analytics", () => {
+  expect(Program.hasAnalytics("* | sort -r id.resp_p")).toBe(false)
+})
+
+test("#hasAnalytics every proc does contain analytics", () => {
+  expect(Program.hasAnalytics("* | every 1hr count()")).toBe(true)
+})
+
+test("#hasAnalytics parallel procs when one does have analytics", () => {
+  expect(
+    Program.hasAnalytics("* | every 1hr count(); count() by id.resp_h")
+  ).toBe(true)
+})
+
+test("#hasAnalytics parallel procs when both do not have analytics", () => {
+  expect(Program.hasAnalytics("* | head 100; head 200")).toBe(false)
+})
+
+test("#hasAnalytics when there are no procs", () => {
+  expect(Program.hasAnalytics("*")).toBe(false)
+})
+
+test("#hasAnalytics for a crappy string", () => {
+  expect(Program.hasAnalytics("-r")).toBe(false)
+})
+
+test("#hasAnalytics for sequential proc", () => {
+  expect(Program.hasAnalytics("*google* | head 3 | sort -r id.resp_p")).toBe(
+    false
+  )
+})


### PR DESCRIPTION
Looking at the search program before searching determines what type of request to make to the server; analytics or logs. The function `Program.hasAnalytics(string)` determines this. It just got more sophicsticated.

I told it to not only check if a proc exists, but to look at all the procs being used. SortProcs and HeadProcs are not analytics procs. If those exist, still treat the program as a logs query.