### PR TITLE
Mention newer node versions are probably ok

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install
 npm start
 ```
 
-Newer version of Node are probably ok, too. For instance, the version installing on macOS via `brew` as of October, 2018 is `10.12.0` and seems to run the desktop client fine.
+Newer versions of Node are probably ok, too. For instance, the version installing on macOS via `brew` as of October, 2018 is `10.12.0` and seems to run the desktop client fine.
 
 Running `npm start` will compile files in `./src` to `./dist` and open the app. When a file is changed, it will recompile it and reload the app.
 


### PR DESCRIPTION
Just a one-liner to reassure newbies that strict adherence to a particular Node version is probably not necessary. I pestered @jameskerr with this question when I joined, so want to spare him the same inquiry from future generations. If we ever get bitten by version-specific glitch, we can change our tune on this.