### PR TITLE
Put a background behind the y-axis label

### DIFF
--- a/src/css/_count-by-time.scss
+++ b/src/css/_count-by-time.scss
@@ -50,6 +50,15 @@
     display: block;
   }
 
+  .y-axis text {
+    fill: white;
+  }
+
+  .y-axis .tick-bg {
+    opacity: 0.85;
+    fill: $gray-2;
+  }
+
   .time-cursor {
     stroke-width: 1px;
     stroke: $gray-5;

--- a/src/js/components/CountByTime.js
+++ b/src/js/components/CountByTime.js
@@ -162,14 +162,52 @@ export default class CountByTime extends React.Component<Props, State> {
 
   drawAxes() {
     const {scales} = this
+    const {innerWidth} = this.state
     d3.select(".x-axis").call(d3.axisBottom(scales.time))
     d3.select(".x-axis-drag").attr("width", this.state.innerWidth)
-    d3.select(".y-axis").call(
-      d3
-        .axisRight(scales.y)
-        .ticks(1)
-        .tickValues(scales.y.domain().map(d3.format("d")))
-    )
+    d3.select(".y-axis")
+      .call(
+        d3
+          .axisRight(scales.y)
+          .ticks(1)
+          .tickValues(scales.y.domain().map(d3.format("d")))
+      )
+      .selectAll(".tick")
+      .each(function() {
+        // This is all just to put a little background on the y axis number.
+        // There very well might be a better way to do this when you re-write
+        // this component.
+        let {width, height, x, y} = this.querySelector("text").getBBox()
+        const arrow = 5
+        width += x + 5
+        height += 4
+        y -= 2
+
+        d3.select(this)
+          .selectAll("polygon")
+          .remove()
+
+        d3.select(this)
+          .selectAll("line")
+          .attr("x2", innerWidth)
+
+        d3.select(this)
+          .insert("polygon", "text")
+          .attr("class", "tick-bg")
+          .attr("transform", `translate(0, ${y})`)
+          .attr(
+            "points",
+            [
+              [0, 0],
+              [width, 0],
+              [width + arrow, height / 2],
+              [width, height],
+              [0, height]
+            ]
+              .map(a => a.join(","))
+              .join(" ")
+          )
+      })
   }
 
   drawBrush() {


### PR DESCRIPTION
The Y-Axis tick values were being obscured by tall bars. This places a background color behind the text to make it visible always. I have new designs for the histogram coming soon. But this is a commit will fill the gap for this bug.

![image](https://user-images.githubusercontent.com/3460638/47757307-faf3fd80-dc62-11e8-8270-9955c1024a30.png)
