### PR TITLE
PROD-78 Open Wireshark Automatically

### DIFF
--- a/src/js/actions/packets.js
+++ b/src/js/actions/packets.js
@@ -49,7 +49,7 @@ export const fetchPackets = (log: Log) => (
     })
     .then(file => {
       dispatch(receivePackets(log.get("uid"), file))
-      System.open(file.path).catch(e => console.log(e))
+      System.open(file).catch(e => console.log(e))
     })
     .catch(error => {
       dispatch(errorPackets(log.get("uid"), error))

--- a/src/js/actions/packets.test.js
+++ b/src/js/actions/packets.test.js
@@ -10,7 +10,7 @@ test("fetching packets is a success", done => {
   const log = conn()
   const dispatch = jest.fn()
   const getState = jest.fn(() => state)
-  const packetsFn = jest.fn(() => new Promise(res => res({path: "file.pcap"})))
+  const packetsFn = jest.fn(() => new Promise(res => res("file.pcap")))
 
   actions
     .fetchPackets(log)(dispatch, getState, {packets: packetsFn})


### PR DESCRIPTION
The boom-js-client changed the return value of it's "packets()" method. This downstream dependent did not pick it up. 