### PR TITLE
PROD-72 Separate field actions from log actions

### DIFF
--- a/src/js/components/LogCell/__snapshots__/LogCellActions.test.js.snap
+++ b/src/js/components/LogCell/__snapshots__/LogCellActions.test.js.snap
@@ -199,12 +199,12 @@ ShallowWrapper {
         <MenuItem
           onClick={[Function]}
         >
-          View log details
+          Download PCAPS
         </MenuItem>,
         <MenuItem
           onClick={[Function]}
         >
-          Download PCAPS
+          View log details
         </MenuItem>,
       ],
       "onOutsideClick": [Function],
@@ -265,11 +265,11 @@ ShallowWrapper {
         "key": "4",
         "nodeType": "function",
         "props": Object {
-          "children": "View log details",
+          "children": "Download PCAPS",
           "onClick": [Function],
         },
         "ref": null,
-        "rendered": "View log details",
+        "rendered": "Download PCAPS",
         "type": [Function],
       },
       Object {
@@ -277,11 +277,11 @@ ShallowWrapper {
         "key": "5",
         "nodeType": "function",
         "props": Object {
-          "children": "Download PCAPS",
+          "children": "View log details",
           "onClick": [Function],
         },
         "ref": null,
-        "rendered": "Download PCAPS",
+        "rendered": "View log details",
         "type": [Function],
       },
     ],
@@ -313,12 +313,12 @@ ShallowWrapper {
           <MenuItem
             onClick={[Function]}
           >
-            View log details
+            Download PCAPS
           </MenuItem>,
           <MenuItem
             onClick={[Function]}
           >
-            Download PCAPS
+            View log details
           </MenuItem>,
         ],
         "onOutsideClick": [Function],
@@ -379,11 +379,11 @@ ShallowWrapper {
           "key": "4",
           "nodeType": "function",
           "props": Object {
-            "children": "View log details",
+            "children": "Download PCAPS",
             "onClick": [Function],
           },
           "ref": null,
-          "rendered": "View log details",
+          "rendered": "Download PCAPS",
           "type": [Function],
         },
         Object {
@@ -391,11 +391,11 @@ ShallowWrapper {
           "key": "5",
           "nodeType": "function",
           "props": Object {
-            "children": "Download PCAPS",
+            "children": "View log details",
             "onClick": [Function],
           },
           "ref": null,
-          "rendered": "Download PCAPS",
+          "rendered": "View log details",
           "type": [Function],
         },
       ],

--- a/src/js/components/LogCell/__snapshots__/buildMenu.test.js.snap
+++ b/src/js/components/LogCell/__snapshots__/buildMenu.test.js.snap
@@ -1,0 +1,113 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`conn log with pcap support 1`] = `
+Array [
+  Object {
+    "onClick": [Function],
+    "text": "Filter out these values",
+    "type": "action",
+  },
+  Object {
+    "onClick": [Function],
+    "text": "Only show these values",
+    "type": "action",
+  },
+  Object {
+    "onClick": [Function],
+    "text": "Count by id.orig_h",
+    "type": "action",
+  },
+  Object {
+    "type": "seperator",
+  },
+  Object {
+    "onClick": [Function],
+    "text": "Download PCAPS",
+    "type": "action",
+  },
+  Object {
+    "onClick": [Function],
+    "text": "View log details",
+    "type": "action",
+  },
+]
+`;
+
+exports[`dns log 1`] = `
+Array [
+  Object {
+    "onClick": [Function],
+    "text": "Filter out these values",
+    "type": "action",
+  },
+  Object {
+    "onClick": [Function],
+    "text": "Only show these values",
+    "type": "action",
+  },
+  Object {
+    "onClick": [Function],
+    "text": "Count by query",
+    "type": "action",
+  },
+  Object {
+    "type": "seperator",
+  },
+  Object {
+    "onClick": [Function],
+    "text": "View log details",
+    "type": "action",
+  },
+]
+`;
+
+exports[`time field for conn log 1`] = `
+Array [
+  Object {
+    "onClick": [Function],
+    "text": "Use as \\"start\\" time",
+    "type": "action",
+  },
+  Object {
+    "onClick": [Function],
+    "text": "Use as \\"end\\" time",
+    "type": "action",
+  },
+  Object {
+    "type": "seperator",
+  },
+  Object {
+    "onClick": [Function],
+    "text": "Download PCAPS",
+    "type": "action",
+  },
+  Object {
+    "onClick": [Function],
+    "text": "View log details",
+    "type": "action",
+  },
+]
+`;
+
+exports[`time field for weird log 1`] = `
+Array [
+  Object {
+    "onClick": [Function],
+    "text": "Use as \\"start\\" time",
+    "type": "action",
+  },
+  Object {
+    "onClick": [Function],
+    "text": "Use as \\"end\\" time",
+    "type": "action",
+  },
+  Object {
+    "type": "seperator",
+  },
+  Object {
+    "onClick": [Function],
+    "text": "View log details",
+    "type": "action",
+  },
+]
+`;

--- a/src/js/components/LogCell/buildMenu.test.js
+++ b/src/js/components/LogCell/buildMenu.test.js
@@ -1,0 +1,45 @@
+/* @flow */
+
+import buildMenu from "./buildMenu"
+import * as mockLogs from "../../test/mockLogs"
+import mockSpace from "../../test/mockSpace"
+
+test("conn log with pcap support", () => {
+  const log = mockLogs.conn()
+  const dispatch = jest.fn()
+  const field = log.getField("id.orig_h")
+  const space = mockSpace()
+  const menu = buildMenu({log, dispatch, field, space})
+
+  expect(menu).toMatchSnapshot()
+})
+
+test("dns log", () => {
+  const log = mockLogs.dns()
+  const dispatch = jest.fn()
+  const field = log.getField("query")
+  const space = mockSpace()
+  const menu = buildMenu({log, dispatch, field, space})
+
+  expect(menu).toMatchSnapshot()
+})
+
+test("time field for weird log", () => {
+  const log = mockLogs.weird()
+  const dispatch = jest.fn()
+  const field = log.getField("ts")
+  const space = mockSpace()
+  const menu = buildMenu({log, dispatch, field, space})
+
+  expect(menu).toMatchSnapshot()
+})
+
+test("time field for conn log", () => {
+  const log = mockLogs.conn()
+  const dispatch = jest.fn()
+  const field = log.getField("ts")
+  const space = mockSpace()
+  const menu = buildMenu({log, dispatch, field, space})
+
+  expect(menu).toMatchSnapshot()
+})

--- a/src/js/test/mockSpace.js
+++ b/src/js/test/mockSpace.js
@@ -2,7 +2,7 @@
 
 import type {Space} from "../lib/Space"
 
-export default (props: $Shape<Space>): Space => ({
+export default (props: $Shape<Space> = {}): Space => ({
   name: "default",
   compression: "none",
   flush_timeout: 500,


### PR DESCRIPTION
Fixes a bug where the time field options were not appearing on the conn logs. Added some snapshot tests as well.