### PR TITLE
Measure the columns as soon as the PhonyViewer mounts

### DIFF
--- a/src/js/components/Viewer/PhonyViewer.js
+++ b/src/js/components/Viewer/PhonyViewer.js
@@ -27,6 +27,10 @@ export default class PhonyViewer extends React.Component<Props> {
     )
   }
 
+  componentDidMount() {
+    this.measureColWidths()
+  }
+
   componentDidUpdate() {
     this.measureColWidths()
   }


### PR DESCRIPTION
If there is already enough data, it does not need to update.