### PR TITLE
PROD-284 Catch unathorized errors and redirect to the connect page

### DIFF
--- a/src/js/components/ErrorTemplate.js
+++ b/src/js/components/ErrorTemplate.js
@@ -81,8 +81,13 @@ const LookytalkVersionErrorTemplate = ({error, onClose}: Props) => {
 
 const print = rawError => {
   const error = tryParse(rawError)
-  if (isObject(error)) return JSON.stringify(error, null, 2)
-  else return error
+  if (isObject(error)) {
+    if (error instanceof Error) {
+      return error.message
+    } else {
+      return JSON.stringify(error, null, 2)
+    }
+  } else return error
 }
 
 const tryParse = string => {

--- a/src/js/components/Search.js
+++ b/src/js/components/Search.js
@@ -1,26 +1,28 @@
 /* @flow */
 
-import React from "react"
 import {AutoSizer} from "react-virtualized"
-import {XTitleBar} from "./TitleBar"
+import {Redirect} from "react-router-dom"
+import {connect} from "react-redux"
+import React from "react"
+
+import {type DispatchProps, type State as S} from "../reducers/types"
+import {UnauthorizedError} from "../models/Errors"
 import {XControlBar} from "./ControlBar"
+import {XDownloadProgress} from "./DownloadProgress"
 import {XHistogram} from "./Histogram"
 import {XLeftPane} from "./LeftPane"
 import {XRightPane} from "../components/RightPane"
-import {XDownloadProgress} from "./DownloadProgress"
-import * as searchPage from "../actions/searchPage"
 import {XSearchResults} from "./SearchResults"
-import ColumnChooser from "./ColumnChooser"
-import {XWhoisModal} from "./WhoisModal"
 import {XStatusBar} from "./StatusBar"
-import {connect} from "react-redux"
-import * as view from "../reducers/view"
-import {type DispatchProps} from "../reducers/types"
-import dispatchToProps from "../lib/dispatchToProps"
-import {type State as S} from "../reducers/types"
-import ErrorFactory from "../models/ErrorFactory"
+import {XTitleBar} from "./TitleBar"
+import {XWhoisModal} from "./WhoisModal"
 import AppError from "../models/AppError"
+import ColumnChooser from "./ColumnChooser"
+import ErrorFactory from "../models/ErrorFactory"
 import StartupError from "./StartupError"
+import dispatchToProps from "../lib/dispatchToProps"
+import * as searchPage from "../actions/searchPage"
+import * as view from "../reducers/view"
 
 type StateProps = {|
   logsTab: boolean
@@ -47,8 +49,10 @@ export default class Search extends React.Component<Props, State> {
   }
 
   render() {
-    if (this.state.error) return <StartupError error={this.state.error} />
-    if (!this.state.ready) return null
+    const {ready, error} = this.state
+    if (error instanceof UnauthorizedError) return <Redirect to="/connect " />
+    if (error) return <StartupError error={error} />
+    if (!ready) return null
 
     return (
       <div className="search-page-wrapper">

--- a/src/js/components/Search.test.js
+++ b/src/js/components/Search.test.js
@@ -1,9 +1,12 @@
 /* @flow */
 
 import React from "react"
+
 import {shallow} from "enzyme"
-import Search, {stateToProps} from "./Search"
+
+import {UnauthorizedError} from "../models/Errors"
 import AppError from "../models/AppError"
+import Search, {stateToProps} from "./Search"
 import initStore from "../test/initStore"
 
 let props
@@ -43,6 +46,13 @@ test("no chargs when results are not logs", () => {
   comp.setState({ready: true})
 
   expect(comp.find(".search-page-header-charts")).toHaveLength(0)
+})
+
+test("redirects when unauthorized error", () => {
+  const comp = shallow(<Search {...props} />)
+  comp.setState({error: new UnauthorizedError("")})
+
+  expect(comp.find("Redirect")).toHaveLength(1)
 })
 
 test("stateToProps", () => {

--- a/src/js/models/Errors.js
+++ b/src/js/models/Errors.js
@@ -7,6 +7,10 @@ import {type RawError} from "./AppError"
 
 export class UnauthorizedError extends AppError {
   static is(e: RawError) {
+    if (e instanceof Error) {
+      if (e.message.match(/Need boom credentials/)) return true
+    }
+
     try {
       return JSON.parse(e).code === "UNAUTHORIZED"
     } catch (e) {


### PR DESCRIPTION
The cause of this bug was:

1. Reseting the state which clears the credentials.
2. The app trying to connect to the server with no credentials.
3. Receive an Unathorized error.
4. Failing to redirect back to the login page upon receiving that error.

The fix:

It now redirects back to the login page when it receives an Unauthorized Error.

