### PR TITLE
PROD-327 Tail Proc in the App

### DIFF
--- a/src/js/lib/Program.js
+++ b/src/js/lib/Program.js
@@ -5,7 +5,9 @@ import {LookyTalk} from "boom-js-client"
 type Program = string
 
 const HEAD_PROC = "HeadProc"
-const TUPLE_PROCS = [HEAD_PROC, "SortProc"]
+const TAIL_PROC = "TailProc"
+const SORT_PROC = "SortProc"
+const TUPLE_PROCS = [HEAD_PROC, TAIL_PROC, SORT_PROC]
 const COMPOUND_PROCS = ["ParallelProc", "SequentialProc"]
 
 export const hasAnalytics = (string: Program) => {
@@ -38,9 +40,9 @@ export const getHeadCount = (program: Program) => {
   return head ? head.count : 0
 }
 
-export const hasHeadProc = (program: Program) => {
+export const hasHeadOrTailProc = (program: Program) => {
   const [ast] = parse(program)
-  return !!getProcs(ast).find(({op}) => op === HEAD_PROC)
+  return !!getProcs(ast).find(({op}) => op === HEAD_PROC || op === TAIL_PROC)
 }
 
 const getProcs = ast => {

--- a/src/js/lib/Program.test.js
+++ b/src/js/lib/Program.test.js
@@ -73,9 +73,9 @@ test("#getHeadCount with no head", () => {
 })
 
 test("#hasHeadCount when false", () => {
-  expect(Program.hasHeadProc("*")).toBe(false)
+  expect(Program.hasHeadOrTailProc("*")).toBe(false)
 })
 
 test("#hasHeadCount when true", () => {
-  expect(Program.hasHeadProc("* | head 1")).toBe(true)
+  expect(Program.hasHeadOrTailProc("* | head 1")).toBe(true)
 })

--- a/src/js/lib/SearchFactory.js
+++ b/src/js/lib/SearchFactory.js
@@ -22,7 +22,7 @@ export const getType = (state: State) => {
     return "ANALYTICS"
   } else if (getInnerTimeWindow(state)) {
     return "LOGS_SUBSET"
-  } else if (Program.hasHeadProc(getSearchProgram(state))) {
+  } else if (Program.hasHeadOrTailProc(getSearchProgram(state))) {
     return "LOGS_HEAD"
   } else {
     return "LOGS_PAGED"
@@ -70,10 +70,7 @@ export const logsSubsetArgs = (dispatch: Dispatch, state: State) => {
 }
 
 export const logsHeadArgs = (dispatch: Dispatch, state: State) => {
-  const program =
-    Program.addHeadProc(getSearchProgram(state), PER_PAGE) +
-    "; " +
-    getCountByTimeProc(state)
+  const program = getSearchProgram(state) + "; " + getCountByTimeProc(state)
   return {
     space: getCurrentSpaceName(state),
     program,


### PR DESCRIPTION
The tail proc needs to be handled in a special way just like the head proc. This is because I secretly add a "head" proc if the use does not specific one. This is how pagination is done. So now if a user types in "tail", I won't add the pagination logic. 