### PR TITLE
PROD-353: interactive desktop test

### DIFF
--- a/itest/poc.test.js
+++ b/itest/poc.test.js
@@ -82,7 +82,7 @@ describe("Application launch", () => {
       // TODO: Don't use selectors as literals in tests. These definitions
       // should be defined in a single place and ideally be tested to ensure
       // they can be found.
-      .getText("//header[@class='looky-header']/h1")
+      .getText(".looky-header h1")
       .then(headerText => {
         expect(headerText).toBe("LOOKY")
         done()


### PR DESCRIPTION
The test demonstrates filling out login and waiting for a few key elements to appear. The test attempts to start some better notions of abstraction for common tasks. Note the test is disabled here: it won't work without a boomd with a space.

I also found it was easy to reset the state of the desktop app before every test, so another commit handles that.

Last, after an in-person discussion, James said he prefers CSS selectors over Xpaths, so I've changed all Xpaths to CSS selectors.