### PR TITLE
PROD-331 Include the query params when fetching

### DIFF
--- a/src/js/BoomClient/client/Base.test.js
+++ b/src/js/BoomClient/client/Base.test.js
@@ -1,4 +1,5 @@
 import BoomClient from "../"
+import "whatwg-fetch"
 
 let boom
 beforeEach(() => {
@@ -23,4 +24,16 @@ test("#inspectSearch", () => {
       span: {ts: "0.000000", dur: "0.01"}
     }
   })
+})
+
+test("#searching with BrowserFetch adapter includes options", () => {
+  const fetchFunc = jest.spyOn(window, "fetch")
+  boom.setOptions({adapter: "BrowserFetch", enableCache: false})
+
+  boom.search("*")
+
+  expect(fetchFunc).toBeCalledWith(
+    "http://boom.com:123/search?rewrite=f",
+    expect.any(Object)
+  )
 })


### PR DESCRIPTION
I now include the enable cache and index options in the query params of the desktop client.

<img width="654" alt="screen shot 2019-03-04 at 1 54 07 pm" src="https://user-images.githubusercontent.com/3460638/53765505-03647b00-3e85-11e9-8307-770d78ed547f.png">
