### PR TITLE
PROD-403 No more races when aborting a request

### DIFF
--- a/src/js/BoomClient/lib/Handler.js
+++ b/src/js/BoomClient/lib/Handler.js
@@ -9,6 +9,7 @@ export default class Handler {
   abortCallbacks: Function[]
   isDone: boolean
   isAborted: boolean
+  shouldCallbackAbort: boolean
 
   constructor(abortFunc: Function) {
     this.abortFunc = abortFunc
@@ -19,10 +20,12 @@ export default class Handler {
     this.eachCallbacks = []
     this.errorCallbacks = []
     this.abortCallbacks = []
+    this.shouldCallbackAbort = true
   }
 
-  abortRequest() {
+  abortRequest(fireEvent: boolean = true) {
     if (!this.isDone) {
+      this.shouldCallbackAbort = fireEvent
       this.abortFunc()
     }
   }
@@ -71,7 +74,9 @@ export default class Handler {
 
   onAbort() {
     this.isAborted = true
-    this.abortCallbacks.forEach(cb => cb())
+    if (this.shouldCallbackAbort) {
+      this.abortCallbacks.forEach(cb => cb())
+    }
   }
 
   receive(payload: *) {

--- a/src/js/actions/boomSearches.js
+++ b/src/js/actions/boomSearches.js
@@ -38,10 +38,14 @@ export const clearBoomSearches = () => ({
 export const killBoomSearches = (): Thunk => (_dispatch, getState) => {
   const state = getState()
   const searches = getBoomSearches(state)
+  for (let name in searches) searches[name].handler.abortRequest()
+}
 
-  for (let name in searches) {
-    searches[name].handler.abortRequest()
-  }
+export const cancelBoomSearches = (): Thunk => (dispatch, getState) => {
+  const state = getState()
+  const searches = getBoomSearches(state)
+  for (let name in searches) searches[name].handler.abortRequest(false)
+  dispatch(clearBoomSearches())
 }
 
 export const issueBoomSearch = (search: BaseSearch): Thunk => (

--- a/src/js/actions/mainSearch.js
+++ b/src/js/actions/mainSearch.js
@@ -1,12 +1,8 @@
 /* @flow */
 
 import type {Thunk} from "../reducers/types"
+import {cancelBoomSearches, issueBoomSearch} from "./boomSearches"
 import {clearAnalysis} from "./analysis"
-import {
-  clearBoomSearches,
-  issueBoomSearch,
-  killBoomSearches
-} from "./boomSearches"
 import {clearLogs} from "./logs"
 import {getInnerTimeWindow, getOuterTimeWindow} from "../reducers/timeWindow"
 import {getSearchProgram} from "../selectors/searchBar"
@@ -27,15 +23,14 @@ export const fetchMainSearch = ({
   dispatch(updateTab(state))
   if (saveToHistory) dispatch(pushSearchHistory())
 
-  dispatch(killBoomSearches())
+  dispatch(cancelBoomSearches())
   dispatch(clearLogs())
-  dispatch(clearBoomSearches())
   dispatch(clearAnalysis())
-  setTimeout(() => {
-    const program = getSearchProgram(state)
-    const innerSpan = getInnerTimeWindow(state)
-    const outerSpan = getOuterTimeWindow(state)
-    const searches = SearchFactory.createAll(program, innerSpan, outerSpan)
-    searches.forEach(search => dispatch(issueBoomSearch(search)))
-  })
+
+  const program = getSearchProgram(state)
+  const innerSpan = getInnerTimeWindow(state)
+  const outerSpan = getOuterTimeWindow(state)
+  const searches = SearchFactory.createAll(program, innerSpan, outerSpan)
+
+  searches.forEach(search => dispatch(issueBoomSearch(search)))
 }

--- a/src/js/reducers/__snapshots__/boomSearches.test.js.snap
+++ b/src/js/reducers/__snapshots__/boomSearches.test.js.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`boomSearches reducer #setBoomSearchStats for search that does not exist 1`] = `"Trying to update search that does not exist: NoSearchHere"`;
+
+exports[`boomSearches reducer #setBoomSearchStatus for search that does not exist 1`] = `"Trying to update search that does not exist: NoSearchHere"`;

--- a/src/js/reducers/boomSearches.js
+++ b/src/js/reducers/boomSearches.js
@@ -24,16 +24,26 @@ export default createReducer(initialState, {
     ...state,
     [search.name]: search
   }),
-  BOOM_SEARCHES_SET_STATUS: (state, {name, status}) => ({
-    ...state,
-    [name]: {...state[name], status}
-  }),
-  BOOM_SEARCHES_SET_STATS: (state, {name, stats}) => ({
-    ...state,
-    [name]: {...state[name], stats}
-  }),
+  BOOM_SEARCHES_SET_STATUS: (state, {name, status}) => {
+    if (!state[name]) throwUpdateError(name)
+    return {
+      ...state,
+      [name]: {...state[name], status}
+    }
+  },
+  BOOM_SEARCHES_SET_STATS: (state, {name, stats}) => {
+    if (!state[name]) throwUpdateError(name)
+    return {
+      ...state,
+      [name]: {...state[name], stats}
+    }
+  },
   BOOM_SEARCHES_CLEAR: () => ({...initialState})
 })
+
+const throwUpdateError = name => {
+  throw new Error(`Trying to update search that does not exist: ${name}`)
+}
 
 export const getBoomSearches = (state: State) => {
   return state.boomSearches


### PR DESCRIPTION
I separated out the concept of aborting a request into two ideas.

The first is manually killing a request. This should run the
"aborted" callback.

The second is issuing a search before the previous search was
finished. This should not run the aborted callback.

This solves alot of the headaches.