### PR TITLE
PROD-405 Put a head on analytics

### DIFF
--- a/src/js/actions/mainSearch.test.js
+++ b/src/js/actions/mainSearch.test.js
@@ -112,24 +112,6 @@ test("search with inner time", done => {
   })
 })
 
-test("search with a provided head proc", done => {
-  boom.stubStream("search")
-  const search = jest.spyOn(boom, "search")
-
-  store.dispatchAll([
-    setSpaceInfo(spaceInfo),
-    setCurrentSpaceName("ranch-logs"),
-    init(),
-    changeSearchBarInput("_path = conn | head 45"),
-    fetchMainSearch()
-  ])
-
-  setTimeout(() => {
-    expect(search).toBeCalledWith("_path = conn | head 45", expect.any(Object))
-    done()
-  })
-})
-
 test("search with outerTimeWindow if no inner", done => {
   boom.stubStream("stream")
   const stream = jest.spyOn(boom, "stream")
@@ -154,22 +136,6 @@ test("search with outerTimeWindow if no inner", done => {
   })
 })
 
-test("fetching an analytics does not put any procs on the query", done => {
-  boom.stubStream("search")
-  const search = jest.spyOn(boom, "search")
-
-  store.dispatchAll([
-    setSpaceInfo(spaceInfo),
-    setCurrentSpaceName("ranch-logs"),
-    changeSearchBarInput("* | count()"),
-    fetchMainSearch()
-  ])
-  setTimeout(() => {
-    expect(search).toBeCalledWith("* | count()", expect.any(Object))
-    done()
-  })
-})
-
 test("fetching a regular search", done => {
   boom.stubStream("stream")
   const actions = [
@@ -190,24 +156,6 @@ test("fetching a regular search", done => {
         "SHOW_LOGS_TAB"
       ])
     )
-    done()
-  })
-})
-
-test("fetching a regular search puts procs on the end", done => {
-  boom.stubStream("search")
-  const search = jest.spyOn(boom, "search")
-
-  store.dispatchAll([
-    setSpaceInfo(spaceInfo),
-    setCurrentSpaceName("ranch-logs"),
-    init(),
-    changeSearchBarInput(""),
-    fetchMainSearch()
-  ])
-
-  setTimeout(() => {
-    expect(search).toBeCalledWith(`* | head ${PER_PAGE}`, expect.any(Object))
     done()
   })
 })

--- a/src/js/models/searches/AnalyticSearch.js
+++ b/src/js/models/searches/AnalyticSearch.js
@@ -5,13 +5,17 @@ import throttle from "lodash/throttle"
 import type {Dispatch} from "../../reducers/types"
 import {Handler} from "../../BoomClient"
 import type {Payload} from "../../receivers/types"
+import {addHeadProc} from "../../lib/Program"
 import {setAnalysis} from "../../actions/analysis"
 import BaseSearch from "./BaseSearch"
 
 export default class AnalyticSearch extends BaseSearch {
+  getProgram() {
+    return addHeadProc(this.program, 10000)
+  }
+
   receiveData(handler: Handler, dispatch: Dispatch) {
     const THROTTLE_DELAY = 200
-
     let tuples = []
     let descriptor = []
 
@@ -28,7 +32,7 @@ export default class AnalyticSearch extends BaseSearch {
       .channel(0, (payload: Payload) => {
         switch (payload.type) {
           case "SearchEnd":
-            dispatchSteady.cancel
+            dispatchSteady.cancel()
             dispatchNow()
             break
           case "SearchResult":

--- a/src/js/models/searches/AnalyticSearch.test.js
+++ b/src/js/models/searches/AnalyticSearch.test.js
@@ -11,6 +11,10 @@ describe("AnalyticSearch", () => {
     search = new AnalyticSearch(program, span)
   })
 
+  test("#getProgram", () => {
+    expect(search.getProgram()).toEqual("* | count() by _path | head 10000")
+  })
+
   test("#getName", () => {
     expect(search.getName()).toEqual("AnalyticSearch")
   })

--- a/src/js/selectors/tableColumnSets.test.js
+++ b/src/js/selectors/tableColumnSets.test.js
@@ -8,7 +8,9 @@ import {
 } from "./tableColumnSets"
 import {receiveDescriptor} from "../actions/descriptors"
 import {receiveLogTuples} from "../actions/logs"
+import {setAnalysis} from "../actions/analysis"
 import {setCurrentSpaceName} from "../actions/spaces"
+import {showAnalyticsTab} from "../actions/view"
 import TableColumns from "../models/TableColumns"
 import initStore from "../test/initStore"
 
@@ -51,18 +53,32 @@ describe("#getCurrentTableColumnsId", () => {
 
 describe("#getCurrentUniqColumns", () => {
   test("contains no duplicate columns", () => {
+    const td1 = {name: "_td", type: "integer"}
+    const td2 = {name: "_td", type: "integer"}
     const a = {name: "a", type: "string"}
     const b = {name: "b", type: "string"}
     const b2 = {name: "b2", type: "integer"}
     const c = {name: "c", type: "time"}
     const state = store.dispatchAll([
       setCurrentSpaceName("default"),
-      receiveDescriptor("default", "1", [a, b, b2]),
-      receiveDescriptor("default", "2", [a, b, c]),
+      receiveDescriptor("default", "1", [td1, a, b, b2]),
+      receiveDescriptor("default", "2", [td2, a, b, c]),
       receiveLogTuples([["1"], ["2"]])
     ])
 
-    expect(getCurrentUniqColumns(state)).toEqual([a, b, b2, c])
+    expect(getCurrentUniqColumns(state)).toEqual([td1, a, b, b2, c])
+  })
+
+  test("analyic results returns the descriptor", () => {
+    const a = {name: "a", type: "string"}
+    const b = {name: "b", type: "string"}
+    const state = store.dispatchAll([
+      setCurrentSpaceName("default"),
+      showAnalyticsTab(),
+      setAnalysis([a, b], [["A", "B"]])
+    ])
+
+    expect(getCurrentUniqColumns(state)).toEqual([a, b])
   })
 })
 


### PR DESCRIPTION
Optimized getUniqColumns which was taking a very long time in
the performance measurments. It is faster now.

Also added a head of 10,000 to analytic results in case something
comes back way too big.

The query described in the ticket is now fast and doesn't hang.