### PR TITLE
PROD-162 PROD-404 Only include value in new search right click

### DIFF
--- a/src/js/components/LogCell/rightClick.js
+++ b/src/js/components/LogCell/rightClick.js
@@ -57,7 +57,7 @@ export const freshInclude = (field: Field) => ({
   onClick: (dispatch: Dispatch, e: Event) => {
     e.stopPropagation()
     dispatch(clearSearchBar())
-    dispatch(appendQueryInclude(field))
+    dispatch(changeSearchBarInput(field.value))
     dispatch(submitSearchBar())
   }
 })


### PR DESCRIPTION
Selecting "New search with this value" on the right click menu will only include the value in the search bar, not the fieldName=value.