### PR TITLE
implement 60s test timeout PROD-440

### DIFF
--- a/itest/poc.test.js
+++ b/itest/poc.test.js
@@ -80,42 +80,54 @@ describe("Application launch", () => {
 
   // TODO: Parallel runs across files are not supported due to chromebrowser
   // port contention. Support that later.
-  test("shows a window with the correct title", done => {
-    app.client
-      .waitForExist("title")
-      .then(() => app.client.getTitle())
-      .then(title => {
-        // TODO: Looky shouldn't be hardcoded but instead read from a title
-        // defined elsewhere.
-        expect(title).toBe("Looky")
-        done()
-      })
-      .catch(done)
-  }, TestTimeout)
+  test(
+    "shows a window with the correct title",
+    done => {
+      app.client
+        .waitForExist("title")
+        .then(() => app.client.getTitle())
+        .then(title => {
+          // TODO: Looky shouldn't be hardcoded but instead read from a title
+          // defined elsewhere.
+          expect(title).toBe("Looky")
+          done()
+        })
+        .catch(done)
+    },
+    TestTimeout
+  )
 
-  test("shows a window with the correct header text", done => {
-    app.client
-      .waitForExist(".looky-header h1")
-      // TODO: Don't use selectors as literals in tests. These definitions
-      // should be defined in a single place and ideally be tested to ensure
-      // they can be found.
-      .then(() => app.client.getText(".looky-header h1"))
-      .then(headerText => {
-        expect(headerText).toBe("LOOKY")
-        done()
-      })
-      .catch(done)
-  }, TestTimeout)
+  test(
+    "shows a window with the correct header text",
+    done => {
+      app.client
+        .waitForExist(".looky-header h1")
+        // TODO: Don't use selectors as literals in tests. These definitions
+        // should be defined in a single place and ideally be tested to ensure
+        // they can be found.
+        .then(() => app.client.getText(".looky-header h1"))
+        .then(headerText => {
+          expect(headerText).toBe("LOOKY")
+          done()
+        })
+        .catch(done)
+    },
+    TestTimeout
+  )
 
-  test("log in and see Search and Histogram", done => {
-    waitForLoginAvailable(app)
-      .then(() => logIn(app))
-      .then(() => waitForHistogram(app))
-      .then(() => waitForSearch(app))
-      .then(val => {
-        expect(val).toBeDefined()
-        done()
-      })
-      .catch(done)
-  }, TestTimeout)
+  test(
+    "log in and see Search and Histogram",
+    done => {
+      waitForLoginAvailable(app)
+        .then(() => logIn(app))
+        .then(() => waitForHistogram(app))
+        .then(() => waitForSearch(app))
+        .then(val => {
+          expect(val).toBeDefined()
+          done()
+        })
+        .catch(done)
+    },
+    TestTimeout
+  )
 })


### PR DESCRIPTION
Jest has a default test timeout of 5s. Given that there are element waits of also 5 seconds, this leads to a timing issue if some elements are slow: there is a race between the whole test timing out and waiting for an element to time out. Making the test timeout much longer should alleviate that test timeout conflict. This is preferred because we get better detail on the failure if the test doesn't time out with a generic message.

The additional test parameter caused `prettier` to radically alter the format of the tests, so that's in a separate commit.