### PR TITLE
PROD-452 FilterProc and CutProc

### DIFF
--- a/src/js/lib/Program.js
+++ b/src/js/lib/Program.js
@@ -1,23 +1,17 @@
 /* @flow */
 
+import {HEAD_PROC, TAIL_PROC, TUPLE_PROCS, getProcNames, getProcs} from "./ast"
 import {LookyTalk} from "../BoomClient"
 import {first, same} from "./Array"
 import {onlyWhitespace, trim} from "./Str"
 import Log from "../models/Log"
 
-type Program = string
-
-const HEAD_PROC = "HeadProc"
-const TAIL_PROC = "TailProc"
-const SORT_PROC = "SortProc"
-const FILTER_PROC = "FilterProc"
-const TUPLE_PROCS = [HEAD_PROC, TAIL_PROC, SORT_PROC, FILTER_PROC]
-const COMPOUND_PROCS = ["ParallelProc", "SequentialProc"]
+export type Program = string
 
 export const hasAnalytics = (string: Program) => {
   const [ast] = parse(string)
-  for (let op of getProcNames(ast)) {
-    if (!TUPLE_PROCS.includes(op)) return true
+  for (let proc of getProcs(ast)) {
+    if (!TUPLE_PROCS.includes(proc.op)) return true
   }
   return false
 }
@@ -57,17 +51,8 @@ export const hasGroupByProc = (program: Program) => {
   return !!getGroupByProc(ast)
 }
 
-export const getProcs = (ast: *) => {
-  if (!ast || !ast.proc) return []
-  return COMPOUND_PROCS.includes(ast.proc.op) ? ast.proc.procs : [ast.proc]
-}
-
 export const getGroupByProc = (ast: *) => {
   return getProcs(ast).find(p => p.op === "GroupByProc")
-}
-
-const getProcNames = ast => {
-  return getProcs(ast).map(p => p.op)
 }
 
 function joinProcs(procs: string[]) {

--- a/src/js/lib/ast.js
+++ b/src/js/lib/ast.js
@@ -1,0 +1,29 @@
+/* @flow */
+
+export const HEAD_PROC = "HeadProc"
+export const TAIL_PROC = "TailProc"
+export const SORT_PROC = "SortProc"
+export const FILTER_PROC = "FilterProc"
+export const PARALLEL_PROC = "ParallelProc"
+export const SEQUENTIAL_PROC = "SequentialProc"
+export const TUPLE_PROCS = [HEAD_PROC, TAIL_PROC, SORT_PROC, FILTER_PROC]
+export const COMPOUND_PROCS = [PARALLEL_PROC, SEQUENTIAL_PROC]
+
+export function getProcNames(ast: *) {
+  if (!ast || !ast.proc) return []
+
+  return extractNames(ast.proc)
+}
+
+function extractNames(proc) {
+  let names = [proc.op]
+  for (let proc of proc.procs || []) {
+    names = [...names, ...extractNames(proc)]
+  }
+  return names
+}
+
+export function getProcs(ast: *) {
+  if (!ast || !ast.proc) return []
+  return COMPOUND_PROCS.includes(ast.proc.op) ? ast.proc.procs : [ast.proc]
+}

--- a/src/js/lib/ast.test.js
+++ b/src/js/lib/ast.test.js
@@ -1,0 +1,22 @@
+/* @flow */
+
+import {first} from "./Array"
+import {getProcNames} from "./ast"
+import {parse} from "./Program"
+
+describe("#getProcNames", () => {
+  function run(program) {
+    return getProcNames(first(parse(program)))
+  }
+
+  test("nested procs", () => {
+    const program = "* | (cut uid; cut uid, ts) | tail 1"
+    expect(run(program)).toEqual([
+      "SequentialProc",
+      "ParallelProc",
+      "CutProc",
+      "CutProc",
+      "TailProc"
+    ])
+  })
+})


### PR DESCRIPTION
The filter and cut procs both work now. Parallel procs display an error saying they are not supported. If we care to support parallel procs, we'd need to design a UI for them. I'd guess some tabs where each tab is the results table for one of the outputs.

<img width="515" alt="Screen Shot 2019-04-02 at 12 05 38 PM" src="https://user-images.githubusercontent.com/3460638/55429362-2a73a280-5540-11e9-86a7-48a8ac1505ae.png">
<img width="444" alt="Screen Shot 2019-04-02 at 12 05 46 PM" src="https://user-images.githubusercontent.com/3460638/55429363-2a73a280-5540-11e9-9bb1-8fd79efe3219.png">
