### PR TITLE
Add eslint rules for jest

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -16,6 +16,7 @@ extends:
   - eslint:recommended
   - plugin:react/recommended
   - plugin:flowtype/recommended
+  - plugin:jest/recommended
 
 settings:
   react:

--- a/src/js/BoomClient/adapters/download.test.js
+++ b/src/js/BoomClient/adapters/download.test.js
@@ -18,7 +18,7 @@ describe.skip("downloading packets", () => {
       .then(file => {
         stat(file)
           .then(stats => {
-            expect(stats.isFile())
+            expect(stats.isFile()).toBeTruthy()
             done()
           })
           .catch(done)

--- a/src/js/BoomClient/client/Base.test.js
+++ b/src/js/BoomClient/client/Base.test.js
@@ -52,7 +52,7 @@ test("#searching with BrowserFetch adapter includes options", () => {
 
   boom.search("*")
 
-  expect(fetchFunc).toBeCalledWith(
+  expect(fetchFunc).toHaveBeenCalledWith(
     "http://boom.com:123/search?rewrite=f",
     expect.any(Object)
   )

--- a/src/js/BoomClient/index.test.js
+++ b/src/js/BoomClient/index.test.js
@@ -100,7 +100,7 @@ describe.skip("external tests (need a running boomd)", () => {
 
     boom.search("* | count()")
 
-    expect(request).toBeCalledWith(
+    expect(request).toHaveBeenCalledWith(
       "http://localhost:9867/search",
       expect.any(Object)
     )
@@ -116,7 +116,7 @@ describe.skip("external tests (need a running boomd)", () => {
 
     boom.search("* | count()")
 
-    expect(request).toBeCalledWith(
+    expect(request).toHaveBeenCalledWith(
       "http://localhost:9867/search?rewrite=f&useindex=f",
       expect.any(Object)
     )

--- a/src/js/BoomClient/lib/Handler.test.js
+++ b/src/js/BoomClient/lib/Handler.test.js
@@ -9,6 +9,6 @@ test("#channel accepts multiple callbacks for same number", () => {
   handler.channel(1, cb2)
   handler.channelCallback(1, "payload")
 
-  expect(cb1).toBeCalled()
-  expect(cb2).toBeCalled()
+  expect(cb1).toHaveBeenCalled()
+  expect(cb2).toHaveBeenCalled()
 })

--- a/src/js/BoomClient/lib/toAst.test.js
+++ b/src/js/BoomClient/lib/toAst.test.js
@@ -2,5 +2,7 @@
 import toAst from "./toAst"
 
 test("parsing with a bare sort proc", () => {
-  expect(toAst("192.168.0.51 _path=http | count() by method | sort"))
+  expect(toAst("192.168.0.51 _path=http | count() by method | sort")).toEqual(
+    expect.any(Object)
+  )
 })

--- a/src/js/actions/logViewer.test.js
+++ b/src/js/actions/logViewer.test.js
@@ -96,7 +96,7 @@ test("#fetchAhead adds 1ms to ts of last change", () => {
   store.dispatch(logViewer.fetchAhead())
 
   const lastChangeTs = tuples[1][1]
-  expect(search).toBeCalledWith(
+  expect(search).toHaveBeenCalledWith(
     expect.any(String),
     expect.objectContaining({
       searchSpan: [new Date(0), new Date(+lastChangeTs * 1000 + 1)]
@@ -110,7 +110,7 @@ test("#fetchAhead when there is only 1 event", () => {
   store.dispatch(spliceLogs())
   store.dispatch(logViewer.fetchAhead())
 
-  expect(search).toBeCalledWith(
+  expect(search).toHaveBeenCalledWith(
     expect.any(String),
     expect.objectContaining({
       searchSpan: [new Date(0), new Date(10 * 1000)]

--- a/src/js/actions/mainSearch.test.js
+++ b/src/js/actions/mainSearch.test.js
@@ -59,7 +59,7 @@ test("analytics always use the outer time window", done => {
   ])
 
   setTimeout(() => {
-    expect(stream).toBeCalledWith(
+    expect(stream).toHaveBeenCalledWith(
       expect.any(Object),
       expect.objectContaining({
         searchSpan: [new Date(2000, 0, 1), new Date(3000, 0, 1)]
@@ -82,7 +82,7 @@ test("search with inner time window if set", done => {
   ])
 
   setTimeout(() => {
-    expect(stream).toBeCalledWith(
+    expect(stream).toHaveBeenCalledWith(
       expect.any(Object),
       expect.objectContaining({
         searchSpan: [new Date(2015, 2, 10), new Date(2015, 2, 11)]
@@ -105,7 +105,7 @@ test("search with inner time", done => {
   ])
 
   setTimeout(() => {
-    expect(search).toBeCalledWith(
+    expect(search).toHaveBeenCalledWith(
       `_path = conn | head ${PER_PAGE}`,
       expect.any(Object)
     )
@@ -127,7 +127,7 @@ test("search with outerTimeWindow if no inner", done => {
   ])
 
   setTimeout(() => {
-    expect(stream).toBeCalledWith(
+    expect(stream).toHaveBeenCalledWith(
       expect.any(Object),
       expect.objectContaining({
         searchSpan: [new Date(2000, 0, 1), new Date(3000, 0, 1)]
@@ -137,7 +137,7 @@ test("search with outerTimeWindow if no inner", done => {
   })
 })
 
-test.only("fetching a regular search", done => {
+test("fetching a regular search", done => {
   boom.stubStream("stream")
   const actions = [
     setSpaceInfo(spaceInfo),

--- a/src/js/actions/packets.test.js
+++ b/src/js/actions/packets.test.js
@@ -20,7 +20,7 @@ test("fetching packets is a success", done => {
   store
     .dispatch(fetchPackets(conn()))
     .then(() => {
-      expect(packets).toBeCalledWith(
+      expect(packets).toHaveBeenCalledWith(
         expect.objectContaining({
           dst_host: "239.255.255.250",
           dst_port: "1900",
@@ -56,7 +56,7 @@ test("fetching packets is a failure", done => {
   store
     .dispatch(fetchPackets(conn()))
     .then(() => {
-      expect(packets).toBeCalledWith(
+      expect(packets).toHaveBeenCalledWith(
         expect.objectContaining({
           dst_host: "239.255.255.250",
           dst_port: "1900",

--- a/src/js/lib/MouseoverWatch.test.js
+++ b/src/js/lib/MouseoverWatch.test.js
@@ -34,7 +34,7 @@ test("runs the condition", done => {
   document.dispatchEvent(new MouseEvent("mousemove"))
 
   setTimeout(() => {
-    expect(condition).toBeCalled()
+    expect(condition).toHaveBeenCalled()
     done()
   })
 })
@@ -46,7 +46,7 @@ test("onEnter is called when entering", () => {
     .onEnter(enter)
     .run([42, 42])
 
-  expect(enter).toBeCalled()
+  expect(enter).toHaveBeenCalled()
 })
 
 test("fires onEnter once when it enters", () => {
@@ -59,7 +59,7 @@ test("fires onEnter once when it enters", () => {
     .run([42, 42])
     .run([42, 42])
 
-  expect(enter).toBeCalledTimes(1)
+  expect(enter).toHaveBeenCalledTimes(1)
 })
 
 test("onExit is called when leaving", () => {
@@ -71,7 +71,7 @@ test("onExit is called when leaving", () => {
     .run([1, 1])
     .run([2, 2])
 
-  expect(exit).toBeCalled()
+  expect(exit).toHaveBeenCalled()
 })
 
 test("onExit is called once when outside", () => {
@@ -84,7 +84,7 @@ test("onExit is called once when outside", () => {
     .run([2, 2])
     .run([2, 2])
 
-  expect(exit).toBeCalledTimes(1)
+  expect(exit).toHaveBeenCalledTimes(1)
 })
 
 test("exit delay", done => {
@@ -100,11 +100,11 @@ test("exit delay", done => {
     .run([42, 42])
     .run([0, 0])
 
-  expect(enter).toBeCalled()
-  expect(exit).not.toBeCalled()
+  expect(enter).toHaveBeenCalled()
+  expect(exit).not.toHaveBeenCalled()
 
   setTimeout(() => {
-    expect(exit).toBeCalledTimes(1)
+    expect(exit).toHaveBeenCalledTimes(1)
     done()
   }, 10)
 })
@@ -123,10 +123,10 @@ test("exiting with a delay then re-entering cancels timeout", done => {
     .run([0, 0])
     .run([42, 42])
 
-  expect(enter).toBeCalledTimes(1)
+  expect(enter).toHaveBeenCalledTimes(1)
 
   setTimeout(() => {
-    expect(exit).not.toBeCalled()
+    expect(exit).not.toHaveBeenCalled()
     done()
   }, 10)
 })

--- a/src/js/lib/Time.test.js
+++ b/src/js/lib/Time.test.js
@@ -142,7 +142,7 @@ test("parseFromBoom", () => {
   expect(date.getTime()).toEqual(1428917793750)
 })
 
-test("parseFromBoom", () => {
+test("parseFromBoom with no ns", () => {
   const timeObj = {
     sec: 1428917793,
     ns: 0

--- a/src/js/lib/TimeWindow.test.js
+++ b/src/js/lib/TimeWindow.test.js
@@ -32,7 +32,7 @@ test("humanDuration", () => {
   expect(duration).toBe("3 hours")
 })
 
-test("inSameUnit", () => {
+test("inSameUnit when false", () => {
   const window = [
     new Date(2000, 1, 15, 12, 30, 0, 0),
     new Date(2000, 1, 15, 15, 30, 45, 0)
@@ -42,7 +42,7 @@ test("inSameUnit", () => {
   expect(duration).toBe(false)
 })
 
-test("inSameUnit", () => {
+test("inSameUnit when true", () => {
   const window = [
     new Date(2000, 1, 15, 12, 30, 0, 0),
     new Date(2000, 1, 15, 15, 30, 45, 0)

--- a/src/js/lib/drillDown.test.js
+++ b/src/js/lib/drillDown.test.js
@@ -26,12 +26,6 @@ test("removes *", () => {
   expect(drillDown(program, result)).toBe("id.orig_h=192.168.0.54")
 })
 
-test("removes *", () => {
-  const program = "* | count() by id.orig_h"
-
-  expect(drillDown(program, result)).toBe("id.orig_h=192.168.0.54")
-})
-
 test("easy peasy", () => {
   const program = "names james | count() by proto"
 

--- a/src/js/models/InputHistory.test.js
+++ b/src/js/models/InputHistory.test.js
@@ -44,7 +44,7 @@ test("going back twice", () => {
   expect(history.getCurrentEntry()).toEqual("a")
 })
 
-test("going back twice", () => {
+test("going back twice then forward twice", () => {
   const history = new InputHistory()
 
   history.push("a")

--- a/src/js/models/Log.test.js
+++ b/src/js/models/Log.test.js
@@ -45,7 +45,7 @@ test("getNs on a time field", () => {
   expect(log.getNs("ts")).toEqual(369843000)
 })
 
-test("getNs on a time field", () => {
+test("getNs on an inverval field", () => {
   const log = conn()
   // "2.000293"
   expect(log.getNs("duration")).toEqual(293000)

--- a/src/js/models/NavHistory.test.js
+++ b/src/js/models/NavHistory.test.js
@@ -84,13 +84,6 @@ test("#canGoForward when two then back", () => {
   expect(history.canGoForward()).toBe(true)
 })
 
-test("#canGoForward when two then back", () => {
-  history.push("a")
-  history.push("b")
-  history.goBack()
-  expect(history.canGoForward()).toBe(true)
-})
-
 test("#push after going back", () => {
   history.push("a")
   history.push("b")
@@ -99,18 +92,6 @@ test("#push after going back", () => {
   history.push("d")
   expect(history.getEntries()).toEqual(["a", "b", "d"])
   expect(history.getCurrentEntry()).toEqual("d")
-})
-
-test("#push after going back", () => {
-  history.push("a")
-  history.push("b")
-  history.push("c")
-  history.goBack()
-  history.goBack()
-  history.push("d")
-  expect(history.getEntries()).toEqual(["a", "d"])
-  history.goBack()
-  expect(history.getCurrentEntry()).toEqual("a")
 })
 
 test("#goBack can be called many times", () => {

--- a/src/js/reducers/boomSearches.test.js
+++ b/src/js/reducers/boomSearches.test.js
@@ -89,7 +89,7 @@ describe("boomSearches reducer", () => {
       killBoomSearches()
     ])
 
-    expect(killFunc).toBeCalledTimes(2)
+    expect(killFunc).toHaveBeenCalledTimes(2)
   })
 
   test("#killBoomSearches by tag", () => {
@@ -107,7 +107,7 @@ describe("boomSearches reducer", () => {
       killBoomSearches("viewer")
     ])
 
-    expect(killFunc).toBeCalledTimes(1)
+    expect(killFunc).toHaveBeenCalledTimes(1)
   })
 
   test("#killBoomSearches runs abort callback", () => {
@@ -121,7 +121,7 @@ describe("boomSearches reducer", () => {
       killBoomSearches()
     ])
 
-    expect(func).toBeCalledWith()
+    expect(func).toHaveBeenCalledWith()
   })
 
   test("#cancelBoomSearches does not run abort callback", () => {
@@ -135,6 +135,6 @@ describe("boomSearches reducer", () => {
       cancelBoomSearches()
     ])
 
-    expect(func).toBeCalledWith(false)
+    expect(func).toHaveBeenCalledWith(false)
   })
 })

--- a/src/js/reducers/boomd.test.js
+++ b/src/js/reducers/boomd.test.js
@@ -35,7 +35,7 @@ test("setting use analytics cache", () => {
   expect(getUseBoomCache(store.getState())).toEqual(false)
 })
 
-test("setting use analytics cache", () => {
+test("setting use index", () => {
   const store = initTestStore()
 
   store.dispatch(useBoomIndex(true))


### PR DESCRIPTION
This came out of @mikesbrown finding a stray ".only()" in the tests. These rules now lint for those among other things. 