### PR TITLE
PROD-575 Warning about non-boolean attributes

### DIFF
--- a/src/js/components/Typography.js
+++ b/src/js/components/Typography.js
@@ -4,6 +4,7 @@ import * as React from "react"
 import classNames from "classnames"
 
 import {capitalize} from "../lib/Str"
+import {extract} from "../stdlib/object"
 
 type Props = {
   children?: React.Node,
@@ -55,23 +56,13 @@ const VARIATIONS = [
 ]
 
 function createTypeEl(tag, name) {
-  const TypeComp = function({children, ...props}: Props) {
-    return React.createElement(
-      tag,
-      {...props, className: createClassName(name, props)},
-      children
-    )
+  function TypeComponent({children, className: passClass, ...props}: Props) {
+    let className = classNames(name, passClass, extract(props, ...VARIATIONS))
+    let elProps = {...props, className}
+    return React.createElement(tag, elProps, children)
   }
-  TypeComp.displayName = capitalize(name)
-  return TypeComp
-}
-
-function createClassName(name, props) {
-  function reducer(obj, name) {
-    obj[name] = props[name]
-    return obj
-  }
-  return classNames(name, props.className, VARIATIONS.reduce(reducer, {}))
+  TypeComponent.displayName = capitalize(name)
+  return TypeComponent
 }
 
 export const Header = createTypeEl("h2", "header")

--- a/src/js/stdlib/object.js
+++ b/src/js/stdlib/object.js
@@ -11,3 +11,12 @@ export function deleteIf(obj: *, condFn: (prop: *) => boolean) {
   }
   return newObj
 }
+
+export function extract(obj: Object, ...props: string[]) {
+  let newObj = {}
+  for (let key of props) {
+    newObj[key] = obj[key]
+    delete obj[key]
+  }
+  return newObj
+}

--- a/src/js/stdlib/object.test.js
+++ b/src/js/stdlib/object.test.js
@@ -1,0 +1,18 @@
+/* @flow */
+import {extract} from "./object"
+
+test("extract properties that exist", () => {
+  let obj = {name: "james", age: 24, colors: ["blue", "green"]}
+  let newObj = extract(obj, "name", "colors")
+
+  expect(obj).toEqual({age: 24})
+  expect(newObj).toEqual({name: "james", colors: ["blue", "green"]})
+})
+
+test("extract keys that don't exist", () => {
+  let obj = {name: "james", age: 24, colors: ["blue", "green"]}
+  let newObj = extract(obj, "a", "b", "c", "name")
+
+  expect(newObj).toEqual({name: "james"})
+  expect(obj).toEqual({age: 24, colors: ["blue", "green"]})
+})


### PR DESCRIPTION
The warnings were caused by passing non-standard props to basic html elements. Before rendering the raw html tag, remove those special props.