### PR TITLE
Use passthrough props on Header

### DIFF
--- a/src/js/components/Viewer/Header.js
+++ b/src/js/components/Viewer/Header.js
@@ -7,7 +7,6 @@ import {XColResizer} from "./ColResizer"
 import * as Styler from "./Styler"
 import TableColumns from "../../models/TableColumns"
 import columnKey from "../../lib/columnKey"
-import {reactElementProps} from "../../test/integration"
 
 type Props = {
   dimens: ViewerDimens,
@@ -17,23 +16,19 @@ type Props = {
 
 export default class Header extends React.PureComponent<Props> {
   render() {
-    const {dimens, scrollLeft} = this.props
+    const {dimens, scrollLeft, columns, ...rest} = this.props
 
     if (dimens.rowWidth !== "auto") {
       return (
-        <header
-          style={Styler.header(dimens, scrollLeft)}
-          // Cannot get this.props.locator because property locator is missing in Props
-          {...reactElementProps(this.props.locator)}
-        >
-          {this.props.columns.getVisible().map((column) => (
+        <header style={Styler.header(dimens, scrollLeft)} {...rest}>
+          {columns.getVisible().map((column) => (
             <div
               className="header-cell"
               key={columnKey(column)}
               style={{width: column.width || 300}}
             >
               {column.name}
-              <XColResizer column={column} tableId={this.props.columns.id} />
+              <XColResizer column={column} tableId={columns.id} />
             </div>
           ))}
         </header>

--- a/src/js/components/Viewer/Viewer.js
+++ b/src/js/components/Viewer/Viewer.js
@@ -93,7 +93,7 @@ export default class Viewer extends React.PureComponent<Props, State> {
           columns={tableColumns}
           dimens={dimens}
           scrollLeft={scrollLeft}
-          locator="viewer_header"
+          {...reactElementProps("viewer_header")}
         />
         <div
           className="view"


### PR DESCRIPTION
Passing the rest of the props with `...rest` to the underlying html
element that a component is based will allow you to add any normal
html attributes to that component.