### PR TITLE
ensure that 'reset state' in-app works (PROD-397)

### DIFF
--- a/itest/poc.test.js
+++ b/itest/poc.test.js
@@ -89,20 +89,20 @@ const verifyPathClassRect = (app, pathClass) =>
 
 const logIn = (app) => {
   return app.client
-    .setValue("[name=host]", "localhost")
-    .setValue("[name=port]", "9867")
-    .click("button")
+    .setValue(selectors.login.host, "localhost")
+    .setValue(selectors.login.port, "9867")
+    .click(selectors.login.button)
 }
 
 const waitForLoginAvailable = (app) => {
   const waitForHostname = () => {
-    return app.client.waitForExist("[name=host]")
+    return app.client.waitForExist(selectors.login.host)
   }
   const waitForPort = () => {
-    return app.client.waitForExist("[name=port]")
+    return app.client.waitForExist(selectors.login.port)
   }
   const waitForButton = () => {
-    return app.client.waitForExist("button")
+    return app.client.waitForExist(selectors.login.button)
   }
   return waitForHostname()
     .then(() => waitForPort())
@@ -418,11 +418,11 @@ describe("Application launch", () => {
         })
         .then(() => app.webContents.send("resetState"))
         .then(() => waitForLoginAvailable(app))
-        .then(() => app.client.getValue("[name=host]"))
+        .then(() => app.client.getValue(selectors.login.host))
         .then((host) => {
           expect(host).toBe("")
         })
-        .then(() => app.client.getValue("[name=port]"))
+        .then(() => app.client.getValue(selectors.login.port))
         .then((port) => {
           expect(port).toBe("")
         })

--- a/src/js/components/LoginForm.js
+++ b/src/js/components/LoginForm.js
@@ -3,6 +3,7 @@ import React from "react"
 
 import type {Credentials} from "../lib/Credentials"
 import AppError from "../models/AppError"
+import {reactElementProps} from "../test/integration"
 
 type Props = {
   credentials: Credentials,
@@ -31,7 +32,11 @@ export default function LoginForm(props: Props) {
   }
 
   return (
-    <form className="admin-form" onSubmit={onSubmit}>
+    <form
+      className="admin-form"
+      onSubmit={onSubmit}
+      {...reactElementProps("login")}
+    >
       <LoginFormField
         name="host"
         value={host || ""}

--- a/src/js/test/integration.js
+++ b/src/js/test/integration.js
@@ -9,6 +9,7 @@ const dataAttrs = {
   // into the DOM.
   // [1] https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/data-*
   histogram: "histogram-chart",
+  login: "login",
   notification: "notification-header",
   search_input: "search_input",
   search_button: "search_button",
@@ -47,6 +48,11 @@ export const selectors = {
     topLevel: dataAttrSelector("histogram"),
     gElem: dataAttrSelector("histogram") + " g",
     rectElem: dataAttrSelector("histogram") + " rect"
+  },
+  login: {
+    host: dataAttrSelector("login") + " [name=host]",
+    port: dataAttrSelector("login") + " [name=port]",
+    button: dataAttrSelector("login") + " button"
   },
   notification: dataAttrSelector("notification"),
   search: {


### PR DESCRIPTION
This test attempts to catch bugs like PROD-515 and PROD-539. We run a search and then reset the state of the app. At that point, we look for an empty login page, and if we receive one, we log in again. We finally ensure that the search input is empty again.

I also did some refactoring around identifying elements in the login form.