### PR TITLE
0.1.26 release to point to new Lookytalk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "looky-desktop",
-  "version": "0.1.24",
+  "version": "0.1.26",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8587,7 +8587,7 @@
     },
     "lookytalk": {
       "version": "git+https://github.com/looky-cloud/lookytalk.git#02b25e4864de98dc8e9a48d999a82b7f95acc653",
-      "from": "git+https://github.com/looky-cloud/lookytalk.git#v0.1.6",
+      "from": "git+https://github.com/looky-cloud/lookytalk.git#v0.1.7",
       "requires": {
         "pegjs": "^0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Brim Desktop App",
   "repository": "https://github.com/looky/looky-desktop",
   "license": "ISC",
-  "version": "0.1.24",
+  "version": "0.1.26",
   "main": "dist/js/electron/main.js",
   "author": "Looky Labs, Inc.",
   "bin": {
@@ -104,7 +104,7 @@
     "electron-is-dev": "^1.0.1",
     "fs-extra": "^7.0.0",
     "lodash": "^4.17.10",
-    "lookytalk": "git+https://github.com/looky-cloud/lookytalk.git#v0.1.6",
+    "lookytalk": "git+https://github.com/looky-cloud/lookytalk.git#v0.1.7",
     "md5": "^2.2.1",
     "moment": "^2.24.0",
     "moment-timezone": "^0.5.21",


### PR DESCRIPTION
I didn't use the `npm version patch` tool because there was a gap in the version numbers.

I'll manually tag the release once this PR gets approved/merged.