### PR TITLE
PROD-654 Undesired Infinite Scroll

### DIFF
--- a/src/js/viewer/viewerHandler.js
+++ b/src/js/viewer/viewerHandler.js
@@ -42,9 +42,14 @@ export default function(
       case "SearchEnd":
         dispatchResultsSteady.cancel()
         dispatchResults()
-        if (count < PER_PAGE) dispatch(setViewerStatus("COMPLETE"))
-        else if (count === ANALYTIC_MAX_RESULTS)
+
+        if (count === PER_PAGE) {
+          dispatch(setViewerStatus("INCOMPLETE"))
+        } else if (count === ANALYTIC_MAX_RESULTS) {
           dispatch(setViewerStatus("LIMIT"))
+        } else {
+          dispatch(setViewerStatus("COMPLETE"))
+        }
         break
     }
   }


### PR DESCRIPTION
There was a bug during marking of a search as "incomplete" (more pages ahead), "complete" (no more results to fetch), and "limit" (you've reached the max number of results for this page).

This bug happened when the number of analytic results was between 500 (the per page limit) and 10,000 (the max analytics limit).

It is now fixed.