### PR TITLE
itests: fix test names to be more clear on queries

### DIFF
--- a/itest/tests/__snapshots__/query.test.js.snap
+++ b/itest/tests/__snapshots__/query.test.js.snap
@@ -1,20 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Query tests query * | count(); switch to whole space 1`] = `
+exports[`Query tests query "* | count()"; switch to whole space 1`] = `
 Array [
   "count",
   "959",
 ]
 `;
 
-exports[`Query tests query * | count(); switch to whole space 2`] = `
+exports[`Query tests query "* | count()"; switch to whole space 2`] = `
 Array [
   "count",
   "1,031,683",
 ]
 `;
 
-exports[`Query tests query _path=http | count() by id.resp_p | sort 1`] = `
+exports[`Query tests query "_path=http | count() by id.resp_p | sort" 1`] = `
 Array [
   "id.resp_p",
   "count",
@@ -25,7 +25,14 @@ Array [
 ]
 `;
 
-exports[`Query tests query _path=http | every 5m count() 1`] = `
+exports[`Query tests query "_path=http | count()" 1`] = `
+Array [
+  "count",
+  "61",
+]
+`;
+
+exports[`Query tests query "_path=http | every 5m count()" 1`] = `
 Array [
   "ts",
   "count",
@@ -48,14 +55,7 @@ Array [
 ]
 `;
 
-exports[`Query tests query path=_http | count() 1`] = `
-Array [
-  "count",
-  "61",
-]
-`;
-
-exports[`Query tests query path=weird | sort 1`] = `
+exports[`Query tests query "_path=weird | sort" 1`] = `
 Array [
   "ts",
   "_path",

--- a/itest/tests/query.test.js
+++ b/itest/tests/query.test.js
@@ -42,7 +42,7 @@ describe("Query tests", () => {
     }
   })
 
-  stdTest("query path=weird | sort", (done) => {
+  stdTest('query "_path=weird | sort"', (done) => {
     waitForLoginAvailable(app)
       .then(() => logIn(app))
       .then(() => waitForHistogram(app))
@@ -70,7 +70,7 @@ describe("Query tests", () => {
       })
   })
 
-  stdTest("query path=_http | count()", (done) => {
+  stdTest('query "_path=http | count()"', (done) => {
     waitForLoginAvailable(app)
       .then(() => logIn(app))
       .then(() => waitForHistogram(app))
@@ -98,7 +98,7 @@ describe("Query tests", () => {
       })
   })
 
-  stdTest("query _path=http | count() by id.resp_p | sort", (done) => {
+  stdTest('query "_path=http | count() by id.resp_p | sort"', (done) => {
     waitForLoginAvailable(app)
       .then(() => logIn(app))
       .then(() => waitForHistogram(app))
@@ -126,7 +126,7 @@ describe("Query tests", () => {
       })
   })
 
-  stdTest("query _path=http | every 5m count()", (done) => {
+  stdTest('query "_path=http | every 5m count()"', (done) => {
     waitForLoginAvailable(app)
       .then(() => logIn(app))
       .then(() => waitForHistogram(app))
@@ -154,7 +154,7 @@ describe("Query tests", () => {
       })
   })
 
-  stdTest("query * | count(); switch to whole space", (done) => {
+  stdTest('query "* | count()"; switch to whole space', (done) => {
     waitForLoginAvailable(app)
       .then(() => logIn(app))
       .then(() => waitForHistogram(app))


### PR DESCRIPTION
@henridf Had a pre-merge CI run fail, but I noticed some of the test case names were mistyped, and the way Jest shows failures with snapshots (which have numbers) makes the queries a little confusing.

Fix the typos and put the queries in quotes in the test names.