### PR TITLE
add gsutil capabilities to integration tests image (PROD-802)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
   integration_tests:
     docker:
       # Built from https://github.com/looky-cloud/rug/blob/master/.circleci/Dockerfile.
-      - image: gcr.io/quixotic-strand-159502/rug@sha256:349ab7134e0dc210ec511452b922f6d7e0173c38d0cca52822f6aaa7b85e41d7
+      - image: gcr.io/quixotic-strand-159502/rug@sha256:1e481d07f11a7363b7b38bea3c0fd0aea642c90e88cb46c596b7749408bfb0f7
         auth:
           username: _json_key
           password: $GCLOUD_SERVICE_KEY


### PR DESCRIPTION
In order to load meaningfully larger data sets for the integration
tests, change the integration test CI's image. Use the image that the
correctness tests have been using for a couple months. That image is the
existing integration test image already in use with gsutil installed on
top. The effective diff is here:

https://github.com/looky-cloud/rug/commit/e53cb3f30a31272b6e4866a2a98234ece724183f#diff-bebe822d715123ec31b03d977212fe2a