### PR TITLE
PROD-665 Add drop down menus to the detail pane

### DIFF
--- a/src/js/components/ConnVersation.js
+++ b/src/js/components/ConnVersation.js
@@ -4,7 +4,7 @@ import {every} from "lodash"
 import React from "react"
 
 import {Fieldset} from "./Typography"
-import {detailMenu} from "../rightclick/detailMenu"
+import {useDetailMenu} from "../rightclick/detailMenu"
 import Log from "../models/Log"
 import VerticalTable from "./Tables/VerticalTable"
 import connHistoryView from "../lib/connHistoryView"
@@ -53,6 +53,7 @@ const ConnHistory = ({history = ""}) => (
 )
 
 const Host = ({className, title = "", ip = "", port = "", log}) => {
+  let detailMenu = useDetailMenu()
   return (
     <div className={`host ${className}`}>
       <Fieldset>{title}</Fieldset>

--- a/src/js/components/LogDetails/FieldsPanel.js
+++ b/src/js/components/LogDetails/FieldsPanel.js
@@ -3,12 +3,13 @@
 import React from "react"
 
 import type {PanelProps} from "./"
-import {detailMenu} from "../../rightclick/detailMenu"
+import {useDetailMenu} from "../../rightclick/detailMenu"
 import PanelHeading from "./PanelHeading"
 import VerticalTable from "../Tables/VerticalTable"
 
 export default function FieldsPanel({log}: PanelProps) {
   log = log.exclude("_td")
+  let detailMenu = useDetailMenu()
 
   return (
     <div className="fields-table-panel detail-panel">

--- a/src/js/rightclick/detailMenu.js
+++ b/src/js/rightclick/detailMenu.js
@@ -1,24 +1,46 @@
 /* @flow */
 
-import {freshInclude, fromTime, toTime, whoisRightclick} from "./actions"
+import {useSelector} from "react-redux"
+
+import {
+  countBy,
+  exclude,
+  freshInclude,
+  fromTime,
+  include,
+  toTime,
+  whoisRightclick
+} from "./actions"
+import {getPrevSearchProgram} from "../state/selectors/searchBar"
+import {hasGroupByProc} from "../lib/Program"
 import Field, {TimeField} from "../models/Field"
 import menuBuilder from "./menuBuilder"
 
-export function detailMenu(field: Field) {
-  const menu = menuBuilder()
+export function useDetailMenu() {
+  let program = useSelector(getPrevSearchProgram)
 
-  if (!(field instanceof TimeField)) {
-    menu.queryAction(freshInclude(field))
+  return function(field: Field) {
+    const menu = menuBuilder()
+
+    if (field instanceof TimeField) {
+      menu.queryAction(fromTime(field), toTime(field))
+    } else {
+      menu.queryAction(exclude(field), include(field), freshInclude(field))
+
+      if (!hasGroupByProc(program)) {
+        menu.queryAction(countBy(field))
+      }
+    }
+
+    if (field instanceof TimeField) {
+      menu.queryAction(fromTime(field))
+      menu.queryAction(toTime(field))
+    }
+
+    if (["addr", "set[addr]"].includes(field.type)) {
+      menu.fieldAction(whoisRightclick(field))
+    }
+
+    return menu.build()
   }
-
-  if (field instanceof TimeField) {
-    menu.queryAction(fromTime(field))
-    menu.queryAction(toTime(field))
-  }
-
-  if (["addr", "set[addr]"].includes(field.type)) {
-    menu.fieldAction(whoisRightclick(field))
-  }
-
-  return menu.build()
 }


### PR DESCRIPTION
Add the right click menu options to fields in the detail view. This happens in the table of fields, as well as in the small tables in each of the "Originator" "Responder" tiles.

If the last search had a group by clause in it, the "Count by" options will not appear. The "exclude", "include", and "new search" options always appear. 

![image](https://user-images.githubusercontent.com/3460638/63538986-e7ee3a80-c4cd-11e9-939b-486d71e54822.png)
