### PR TITLE
PROD-695 Fix badly formatted bytes

### DIFF
--- a/src/css/_conn-versation.scss
+++ b/src/css/_conn-versation.scss
@@ -11,16 +11,11 @@
   .host {
     border: 1px solid $white-5;
     border-radius: 3px;
-    min-width: 135px;
   }
 
   .fieldset {
     text-align: center;
     padding: 6px 3px;
-  }
-
-  table {
-    width: 100%;
   }
 
   .ip,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3460638/63614340-9f9b4f00-c597-11e9-949d-d5c65529fc2e.png)

If the detail pane is not wide enough, the graphics will fall off to the right rather than mess up formatting of the text.