### PR TITLE
PROD-710: Fix "limitted" typos, and change ref to "logs" to "events"

### DIFF
--- a/src/js/components/UidTimeline.js
+++ b/src/js/components/UidTimeline.js
@@ -96,7 +96,7 @@ function captionText(logs: Log[], queryForAll) {
   if (limit)
     return (
       <>
-        Limitted to 100 logs. <a onClick={queryForAll}>Query for all.</a>
+        Limited to 100 events. <a onClick={queryForAll}>Query for all.</a>
       </>
     )
   else if (conn) {

--- a/src/js/state/viewer/test.js
+++ b/src/js/state/viewer/test.js
@@ -55,7 +55,7 @@ test("results incomplete", () => {
   expect(getViewerStatus(state)).toBe("INCOMPLETE")
 })
 
-test("results limitted", () => {
+test("results limited", () => {
   let state = store.dispatchAll([setViewerStatus("LIMIT")])
 
   expect(getViewerStatus(state)).toBe("LIMIT")


### PR DESCRIPTION
While verifying PROD-710, I noticed a typo that said "Limitted". This seems like a rare occasion when I could trust myself to propose a code change, hence this PR. :)  While I was searching in GitHub to find the right file, I found a spot in the tests where the same typo was made, so I fixed that one while I was at it.

Also while I was in there, I got to thinking about the reference to "logs". They'd more accurately be described as "log lines", but even then, within the Zeek universe, it seems more common to refer to them as "events". As I write the customer-facing docs I'm going out of my way to say "events" a lot, so I made that change here. I know there's other places in the app where we continue to say "logs" (e.g. "Pivot to Logs") but we can always circle back to those later.