### PR TITLE
PROD-828 Handle Task End events with errors

### DIFF
--- a/src/css/_notice.scss
+++ b/src/css/_notice.scss
@@ -8,6 +8,7 @@
   left: 50%;
   transform: translateX(-50%);
   font-size: 14px;
+  white-space: nowrap;
 
   a {
     padding-left: $space-s;

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -68,7 +68,7 @@
 @import "portal";
 @import "menu-list";
 @import "message-box";
-@import "notifications";
+@import "notice";
 @import "circle-chevron";
 @import "pane-toggle-buttons";
 @import "animations";

--- a/src/js/BoomClient/types.js
+++ b/src/js/BoomClient/types.js
@@ -83,8 +83,17 @@ type SearchStatsPayload = {
   }
 }
 
+type TaskEndPayload = {
+  type: "TaskEnd",
+  error?: {
+    type: string,
+    error: string
+  }
+}
+
 export type BoomPayload =
   | SearchDescriptorsPayload
   | SearchTuplesPayload
   | SearchStatsPayload
   | SearchEndPayload
+  | TaskEndPayload

--- a/src/js/searches/baseHandler.js
+++ b/src/js/searches/baseHandler.js
@@ -11,6 +11,8 @@ import {
   setSearchStatus
 } from "../state/searches/actions"
 import {boomTime} from "../lib/Time"
+import {setBackendError} from "../backend"
+import ErrorFactory from "../models/ErrorFactory"
 
 export default function(
   dispatch: Dispatch,
@@ -54,6 +56,14 @@ export default function(
         dispatchResults()
         dispatch(setSearchStatus(name, "SUCCESS"))
         break
+      case "TaskEnd":
+        if (payload.error) {
+          dispatch(setSearchStatus(name, "ERROR"))
+          dispatch(setBackendError(ErrorFactory.create(payload.error)))
+          dispatchResultsSteady.cancel()
+          dispatchResults()
+          break
+        }
     }
   }
 


### PR DESCRIPTION
If a task end if received with an error object nested within, quit the search and display a backend error.

![image](https://user-images.githubusercontent.com/3460638/63884244-aad0ef00-c98a-11e9-8297-061de5f60046.png)
