### PR TITLE
test fix: increase test timeout

### DIFF
--- a/itest/lib/jest.js
+++ b/itest/lib/jest.js
@@ -4,7 +4,7 @@ import {Application} from "spectron"
 
 import {selectors} from "../../src/js/test/integration"
 
-export const TestTimeout = 60000
+export const TestTimeout = 300000
 // https://jestjs.io/docs/en/troubleshooting#unresolved-promises
 // https://jestjs.io/docs/en/jest-object#jestsettimeouttimeout
 jest.setTimeout(TestTimeout)


### PR DESCRIPTION
Browser tests on a loaded system are an incredible pain. The timings can
really screw up and tests fail in annoying ways. Let's increase this
timeout to see if that reduces flakiness.