### PR TITLE
PROD-840 Include span and space in the copy for curl link

### DIFF
--- a/src/js/backend/thunks.js
+++ b/src/js/backend/thunks.js
@@ -3,6 +3,8 @@ import type {Cluster} from "../state/clusters/types"
 import type {Span} from "../BoomClient/types"
 import type {Thunk} from "../state/types"
 import {createError} from "../state/errors"
+import {getCurrentSpaceName} from "../state/reducers/spaces"
+import {getTimeWindow} from "../state/reducers/timeWindow"
 import {setBackendError} from "./"
 import ErrorFactory from "../models/ErrorFactory"
 
@@ -40,9 +42,11 @@ export function testConnection(cluster: Cluster): Thunk {
 }
 
 export function inspectSearch(lookytalk: string): Thunk {
-  return function(_, __, boom) {
+  return function(_, getState, boom) {
+    let searchSpan = getTimeWindow(getState())
+    let searchSpace = getCurrentSpaceName(getState())
     try {
-      return boom.inspectSearch(lookytalk)
+      return boom.inspectSearch(lookytalk, {searchSpan, searchSpace})
     } catch {
       return null
     }


### PR DESCRIPTION
The span and space was not properly included in the copy for curl utility. They now are.