### PR TITLE
PROD-869 Only create a window if one doesn't exist

### DIFF
--- a/src/js/electron/brimWindow.js
+++ b/src/js/electron/brimWindow.js
@@ -12,7 +12,7 @@ export default function brimWindow() {
 
   return {
     exists() {
-      win != null
+      return win != null
     },
 
     destroy() {

--- a/src/js/electron/brimWindow.test.js
+++ b/src/js/electron/brimWindow.test.js
@@ -1,0 +1,14 @@
+/* @flow */
+import brimWindow from "./brimWindow"
+
+test("brim window exists", () => {
+  let win = brimWindow()
+
+  expect(win.exists()).toBe(false)
+})
+
+test("brim window does not exists", () => {
+  let win = brimWindow()
+  win.create()
+  expect(win.exists()).toBe(true)
+})

--- a/src/js/test/setup.js
+++ b/src/js/test/setup.js
@@ -3,6 +3,13 @@ const Adapter = require("enzyme-adapter-react-16")
 const enzyme = require("enzyme")
 
 jest.mock("electron", function() {
+  class FakeBrowserWindow {
+    center() {}
+    setMenu() {}
+    on() {}
+    loadFile() {}
+  }
+
   let electron = {
     app: {
       isPackaged: true,
@@ -14,6 +21,10 @@ jest.mock("electron", function() {
     Menu: {
       buildFromTemplate: jest.fn(),
       setApplicationMenu: jest.fn()
+    },
+    BrowserWindow: FakeBrowserWindow,
+    ipcMain: {
+      on: jest.fn()
     }
   }
 


### PR DESCRIPTION
Don't keep making windows whenever Brim app is activated.
