### PR TITLE
integration tests: do not clobber chromedriver logs

### DIFF
--- a/itest/lib/app.js
+++ b/itest/lib/app.js
@@ -15,15 +15,17 @@ const appStep = async (stepMessage, f) => {
   return result
 }
 
-export const newAppInstance = () =>
+export const newAppInstance = (name: string, idx: number) =>
   // https://github.com/electron-userland/spectron#new-applicationoptions
   new Application({
     path: electronPath,
     args: [path.join(__dirname, "..", "..")],
     startTimeout: 60000,
     waitTimeout: 60000,
-    chromeDriverLogPath: workspaceLogfile("chromedriver.log"),
-    webdriverLogPath: workspaceLogfile("webdriverLogFiles"),
+    chromeDriverLogPath: workspaceLogfile(
+      name + idx.toString() + "-chromedriver.log"
+    ),
+    webdriverLogPath: workspaceLogfile(name + "-webdriverLogFiles"),
     // PROD-831: Latest compatible spectron and webdriverio lead to the
     // following:
     //  console.warn node_modules/webdriverio/build/lib/helpers/deprecationWarning.js:12

--- a/itest/tests/histogram.test.js
+++ b/itest/tests/histogram.test.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+import {basename} from "path"
+
 import {
   logIn,
   newAppInstance,
@@ -45,8 +47,9 @@ const verifyPathClassRect = (app, pathClass) =>
 
 describe("Histogram tests", () => {
   let app
+  let testIdx = 0
   beforeEach(() => {
-    app = newAppInstance()
+    app = newAppInstance(basename(__filename), ++testIdx)
     return startApp(app)
   })
 

--- a/itest/tests/query.test.js
+++ b/itest/tests/query.test.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+import {basename} from "path"
+
 import {
   getSearchSpeed,
   getSearchTime,
@@ -17,8 +19,9 @@ import {handleError, stdTest} from "../lib/jest.js"
 
 describe("Query tests", () => {
   let app
+  let testIdx = 0
   beforeEach(() => {
-    app = newAppInstance()
+    app = newAppInstance(basename(__filename), ++testIdx)
     return startApp(app)
   })
 

--- a/itest/tests/reset.test.js
+++ b/itest/tests/reset.test.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+import {basename} from "path"
+
 import {
   startApp,
   logIn,
@@ -16,8 +18,9 @@ import {selectors} from "../../src/js/test/integration"
 
 describe("Reset state tests", () => {
   let app
+  let testIdx = 0
   beforeEach(() => {
-    app = newAppInstance()
+    app = newAppInstance(basename(__filename), ++testIdx)
     return startApp(app)
   })
 

--- a/itest/tests/rightClickSearch.test.js
+++ b/itest/tests/rightClickSearch.test.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+import {basename} from "path"
+
 import {
   click,
   getSearchText,
@@ -19,8 +21,9 @@ import {dataSets, selectors} from "../../src/js/test/integration"
 
 describe("Test search mods via right-clicks", () => {
   let app
+  let testIdx = 0
   beforeEach(() => {
-    app = newAppInstance()
+    app = newAppInstance(basename(__filename), ++testIdx)
     return startApp(app)
   })
 

--- a/itest/tests/smoke.test.js
+++ b/itest/tests/smoke.test.js
@@ -1,19 +1,15 @@
 /* @flow */
 
-// The purpose of this file is to demonstrate that basic Spectron interaction
-// can work in a CI environment. The tests don't claim to be meaningful other
-// than showing Spectron works in a headless environment.
-//
-// The setup/teardown was taken from
-// https://github.com/electron/spectron/#usage
+import {basename} from "path"
 
 import {logIn, newAppInstance, resetState, startApp} from "../lib/app.js"
 import {handleError, stdTest} from "../lib/jest.js"
 
 describe("Smoke test", () => {
   let app
+  let testIdx = 0
   beforeEach(() => {
-    app = newAppInstance()
+    app = newAppInstance(basename(__filename), ++testIdx)
     return startApp(app)
   })
 

--- a/itest/tests/space.test.js
+++ b/itest/tests/space.test.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+import {basename} from "path"
+
 import {
   getCurrentSpace,
   logIn,
@@ -11,8 +13,9 @@ import {handleError, stdTest} from "../lib/jest.js"
 
 describe("Spaces tests", () => {
   let app
+  let testIdx = 0
   beforeEach(() => {
-    app = newAppInstance()
+    app = newAppInstance(basename(__filename), ++testIdx)
     return startApp(app)
   })
 


### PR DESCRIPTION
To get more insight into PROD-853 we must stop clobbering chromedriver
logs. (My local testing with tail -f assumed we wouldn't clobber, but
it's clear we do.) The fastest way not to clobber is to tell
newAppInstance() a way to set a unique path for each test's log. Do that
using the __filename under test and a test ID number.

This is a hack that takes on some tech debt but the idea is to get the
logs asap. I can refactor test sections and other things later.