### PR TITLE
PROD-884 Allow data urls to work in the app

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src https: file: http: ws: 'unsafe-inline'"
+      content="default-src https: file: http: ws: data: 'unsafe-inline'"
     />
   </head>
   <body>


### PR DESCRIPTION
The content security policy did not allow images with data urls to work within the app. The Two calendar picker symbols are data images and did not appear. Adding :data to the content security policy allows those to come back.

![image](https://user-images.githubusercontent.com/3460638/64635022-85dd7280-d3b3-11e9-9723-ba6ce27b0518.png)
