### PR TITLE
update CI integration test image to use Go 1.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
   integration_tests:
     docker:
       # Built from https://github.com/looky-cloud/rug/blob/master/.circleci/Dockerfile.
-      - image: gcr.io/quixotic-strand-159502/rug@sha256:1e481d07f11a7363b7b38bea3c0fd0aea642c90e88cb46c596b7749408bfb0f7
+      - image: gcr.io/quixotic-strand-159502/rug@sha256:17e41daf787aaee9cc7ab2e08b87dac6d904f7112b24245a631f90a8d1991160
         auth:
           username: _json_key
           password: $GCLOUD_SERVICE_KEY


### PR DESCRIPTION
Central PR is looky-cloud/rug#100 . This image passed green on all CI jobs: https://circleci.com/gh/looky-cloud/rug/tree/gogo13