### PR TITLE
test fix: update integration tests affected by removing duplicate tuples (PROD-938)

### DIFF
--- a/itest/tests/__snapshots__/query.test.js.snap
+++ b/itest/tests/__snapshots__/query.test.js.snap
@@ -10,7 +10,7 @@ Array [
 exports[`Query tests query "* | count()"; switch to whole space 2`] = `
 Array [
   "count",
-  "1,031,683",
+  "1,031,672",
 ]
 `;
 

--- a/itest/tests/__snapshots__/space.test.js.snap
+++ b/itest/tests/__snapshots__/space.test.js.snap
@@ -10,6 +10,6 @@ Array [
 exports[`Spaces tests change space to hq_integration 2`] = `
 Array [
   "count",
-  "41,108,632",
+  "41,088,058",
 ]
 `;


### PR DESCRIPTION
These are the desktop.git-side changes for https://github.com/looky-cloud/boom/pull/849 . The tests pass locally against looky-cloud/boom@f0c8a76 , the current HEAD for looky-cloud/boom#849