### PR TITLE
PROD-949 Do not use the word close in a web browser

### DIFF
--- a/src/js/components/CurlModal.js
+++ b/src/js/components/CurlModal.js
@@ -39,7 +39,7 @@ export default function CurlModalBox() {
     },
     {
       label: "Done",
-      click: (close) => close()
+      click: (closeModal) => closeModal()
     }
   ]
 

--- a/src/js/components/ModalBox/Buttons.js
+++ b/src/js/components/ModalBox/Buttons.js
@@ -8,14 +8,14 @@ import ButtonRow from "../ButtonRow"
 
 type Props = {
   template: void | string | ModalButton[],
-  close: Function
+  closeModal: Function
 }
 
-export default function Buttons({template, close}: Props) {
+export default function Buttons({template, closeModal}: Props) {
   let buttons = []
 
   if (isString(template)) {
-    buttons = [{label: template, click: close}]
+    buttons = [{label: template, click: closeModal}]
   }
 
   if (isArray(template)) {
@@ -23,7 +23,7 @@ export default function Buttons({template, close}: Props) {
   }
 
   function onClick(button: ModalButton, e: PointerEvent) {
-    button.click(close, e)
+    button.click(closeModal, e)
   }
 
   return (

--- a/src/js/components/ModalBox/ModalContents.js
+++ b/src/js/components/ModalBox/ModalContents.js
@@ -19,16 +19,16 @@ export default function ModalContents({
   willUnmount,
   ...rest
 }: ModalContentsProps) {
-  let {close} = useModalController()
+  let {closeModal} = useModalController()
   useModalAnimation(duration, willUnmount)
 
   return ReactDOM.createPortal(
     <div className="modal-overlay">
       <div className={classNames("modal-contents", className)} {...rest}>
-        <CloseButton light onClick={close} />
+        <CloseButton light onClick={closeModal} />
         <h2 className="modal-header">{title}</h2>
         <div className="modal-body">{children}</div>
-        <Buttons template={buttons} close={close} />
+        <Buttons template={buttons} closeModal={closeModal} />
       </div>
     </div>,
     lib.doc.id("modal-root")

--- a/src/js/components/ModalBox/useModalController.js
+++ b/src/js/components/ModalBox/useModalController.js
@@ -8,17 +8,19 @@ import useListener from "../../hooks/useListener"
 export default function useModalController() {
   let dispatch = useDispatch()
 
+  function closeModal() {
+    dispatch(modal.hide())
+  }
+
   useListener(document, "keydown", (e: KeyboardEvent) => {
     if (e.key === "Enter" || e.key === "Escape") {
       e.stopPropagation()
       e.preventDefault()
-      close()
+      closeModal()
     }
   })
 
   return {
-    close() {
-      dispatch(modal.hide())
-    }
+    closeModal
   }
 }


### PR DESCRIPTION
Clicking enter or escape would close the Brim app window because I used a method called close somewhere that is a global method in a web browser. I changed it to closeModal and fixed the bad reference.