### PR TITLE
Upgrade deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3997,9 +3997,9 @@
       "dev": true
     },
     "electron": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-4.2.4.tgz",
-      "integrity": "sha512-d4wEwJluMsRyRgbukLmFVTb6l1J+mc3RLB1ctbpMlSWDFvs+zknPWa+cHBzTWwrdgwINLddr69qsAW1ku6FqYw==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-4.2.12.tgz",
+      "integrity": "sha512-EES8eMztoW8gEP5E4GQLP8slrfS2jqTYtHbu36mlu3k1xYAaNPyQQr6mCILkYxqj4l3la4CT2Vcs89CUG62vcQ==",
       "dev": true,
       "requires": {
         "@types/node": "^10.12.18",
@@ -4008,9 +4008,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.14.9",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.9.tgz",
-          "integrity": "sha512-NelG/dSahlXYtSoVPErrp06tYFrvzj8XLWmKA+X8x0W//4MqbUyZu++giUG/v0bjAT6/Qxa8IjodrfdACyb0Fg==",
+          "version": "10.17.2",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.2.tgz",
+          "integrity": "sha512-sAh60KDol+MpwOr1RTK0+HgBEYejKsxdpmrOS1Wts5bI03dLzq8F7T0sRXDKeaEK8iWDlGfdzxrzg6vx/c5pNA==",
           "dev": true
         }
       }
@@ -11145,7 +11145,7 @@
         },
         "os-locale": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "dev": true,
           "requires": {
@@ -11165,7 +11165,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -11238,7 +11238,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "babel-plugin-source-map-support": "^2.0.1",
     "commander": "^2.19.0",
     "cpx": "^1.5.0",
-    "electron": "^4.2.4",
+    "electron": "^4.2.12",
     "electron-devtools-installer": "^2.2.4",
     "electron-installer-dmg": "^2.0.0",
     "electron-packager": "^13.1.1",


### PR DESCRIPTION
Noah and Andrew ran into some issues with our deps on Node 12. This PR incorporates their fixes.

Electron has been upgraded to `4.2.12`
Node-sass-chkdir has been updated which in turn updated the node-sass version to `4.12.0`