### PR TITLE
PROD-1117 NaN in search stats.

### DIFF
--- a/src/js/brim/time.test.js
+++ b/src/js/brim/time.test.js
@@ -11,3 +11,27 @@ test("date to ts", () => {
 
   expect(brim.time(ts).toDate()).toEqual(new Date(1))
 })
+
+test("add", () => {
+  let ts = brim
+    .time(new Date(1))
+    .add(1, "ms")
+    .toTs()
+
+  expect(ts).toEqual({
+    ns: 2000000,
+    sec: 0
+  })
+})
+
+test("subtract", () => {
+  let ts = brim
+    .time(new Date(1))
+    .subtract(1, "second")
+    .toTs()
+
+  expect(ts).toEqual({
+    ns: 1000000,
+    sec: -1
+  })
+})


### PR DESCRIPTION
I was previously converting ts objects into dates and loosing 6 digits of precision. This caused some NaNs to appear on the page when subtracting two close dates resulted in 0.

The fix as to keep the ns for as long as possible.