### PR TITLE
test fix: update some searches to use determinstic sort

### DIFF
--- a/itest/tests/__snapshots__/query.test.js.snap
+++ b/itest/tests/__snapshots__/query.test.js.snap
@@ -14,7 +14,7 @@ Array [
 ]
 `;
 
-exports[`Query tests query "_path=http | count() by id.resp_p | sort" 1`] = `
+exports[`Query tests query "_path=http | count() by id.resp_p | sort count" 1`] = `
 Array [
   "id.resp_p",
   "count",
@@ -47,7 +47,7 @@ Array [
 ]
 `;
 
-exports[`Query tests query "_path=weird | sort" 1`] = `
+exports[`Query tests query "_path=weird | sort ts" 1`] = `
 Array [
   "ts",
   "_path",

--- a/itest/tests/query.test.js
+++ b/itest/tests/query.test.js
@@ -32,9 +32,9 @@ describe("Query tests", () => {
     }
   })
 
-  stdTest('query "_path=weird | sort"', (done) => {
+  stdTest('query "_path=weird | sort ts"', (done) => {
     logIn(app)
-      .then(() => writeSearch(app, "_path=weird | sort"))
+      .then(() => writeSearch(app, "_path=weird | sort ts"))
       .then(() => startSearch(app))
       .then(() => waitForSearch(app))
       .then(() => searchDisplay(app))
@@ -82,9 +82,11 @@ describe("Query tests", () => {
       })
   })
 
-  stdTest('query "_path=http | count() by id.resp_p | sort"', (done) => {
+  stdTest('query "_path=http | count() by id.resp_p | sort count"', (done) => {
     logIn(app)
-      .then(() => writeSearch(app, "_path=http | count() by id.resp_p | sort"))
+      .then(() =>
+        writeSearch(app, "_path=http | count() by id.resp_p | sort count")
+      )
       .then(() => startSearch(app))
       .then(() => waitForSearch(app))
       .then(() => searchDisplay(app))


### PR DESCRIPTION
`sort` without any arguments isn't guaranteed to sort on `ts`, or I suppose anything else. Update all bare `sort` instances to be explicit. Note that against boom master, the results haven't changed.