### PR TITLE
PROD-701 Replace 'Other' with 'New connection'

### DIFF
--- a/src/js/components/ClusterPicker.js
+++ b/src/js/components/ClusterPicker.js
@@ -24,7 +24,7 @@ export default function CluterPicker() {
 
   template.push({type: "divider"})
   template.push({
-    label: "Other...",
+    label: "New connection...",
     click: () => {
       dispatch(disconnectCluster())
     }


### PR DESCRIPTION
I chose the word new connection since that is what we are using on the login page. 
<img width="350" alt="Screen Shot 2019-11-26 at 2 55 12 PM" src="https://user-images.githubusercontent.com/3460638/69679435-f748cb00-105c-11ea-833e-82eeecfc0a1e.png">

<img width="346" alt="Screen Shot 2019-11-26 at 2 55 05 PM" src="https://user-images.githubusercontent.com/3460638/69679431-f4e67100-105c-11ea-9ccd-c85655a1e163.png">

<img width="408" alt="Screen Shot 2019-11-26 at 2 55 00 PM" src="https://user-images.githubusercontent.com/3460638/69679427-f2841700-105c-11ea-8f55-b8825f670021.png">
