### PR TITLE
PROD-1407 Modal overflow

### DIFF
--- a/src/css/_curl-modal.scss
+++ b/src/css/_curl-modal.scss
@@ -2,10 +2,15 @@
   .text-content {
     display: flex;
     flex-direction: column;
+    min-height: 0;
     pre {
       flex: 1;
       overflow: auto;
       user-select: all;
     }
   }
+}
+
+.boom-get-modal {
+  min-height: 200px;
 }

--- a/src/css/_debug-modal.scss
+++ b/src/css/_debug-modal.scss
@@ -2,6 +2,8 @@
   .text-content {
     display: flex;
     flex-direction: column;
+    min-height: 0;
+
     pre {
       flex: 1;
       overflow: auto;

--- a/src/css/_modal.scss
+++ b/src/css/_modal.scss
@@ -35,10 +35,13 @@
   .modal-header {
     font-size: $font-size-4;
     margin-bottom: 20px;
+    flex: 0 0 auto;
+    min-height: 0;
   }
 
   .modal-body {
     display: flex;
+    min-height: 0;
     flex-direction: column;
   }
 

--- a/src/css/_whois-modal.scss
+++ b/src/css/_whois-modal.scss
@@ -2,12 +2,14 @@
   .text-content {
     display: flex;
     flex-direction: column;
+    min-height: 0;
 
     & > * {
       flex-shrink: 0;
     }
 
     pre.output {
+      min-height: 0;
       flex: 1;
       overflow: auto;
     }


### PR DESCRIPTION
The text no longer overflows in the modal windows. It scrolls nicely in the middle of the modal. Here are some screenshots with each of the three long modals.

<img width="698" alt="Screen Shot 2020-02-06 at 5 37 39 PM" src="https://user-images.githubusercontent.com/3460638/73993678-c8c25880-4907-11ea-9aa3-39b6fdce5df6.png">
<img width="737" alt="Screen Shot 2020-02-06 at 5 37 15 PM" src="https://user-images.githubusercontent.com/3460638/73993685-cbbd4900-4907-11ea-9b2b-b1b91b2b93a4.png">
<img width="737" alt="Screen Shot 2020-02-06 at 5 37 10 PM" src="https://user-images.githubusercontent.com/3460638/73993686-ccee7600-4907-11ea-9ea6-2e6b7bf8da84.png">


