### PR TITLE
ci: add node --version as node_modules cache key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,13 +5,16 @@ jobs:
       - image: circleci/node:10.11.0-jessie-browsers
     steps:
       - checkout
+      - run:
+          name: Set Node Version File
+          command: node --version > nodeversion
       - restore_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
+          key: dependency-cache-node-{{ checksum "nodeversion" }}-{{ checksum "package.json" }}
       - run:
           name: Install Dependencies
           command: npm install --no-audit
       - save_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
+          key: dependency-cache-node-{{ checksum "nodeversion" }}-{{ checksum "package.json" }}
           paths:
             - ./node_modules
       - run:


### PR DESCRIPTION
Brim can be built with Node 10, Node 12, and probably others. The build will fail if a Node 12 build attempts to use a node_modules CircleCI cache saved from Node 10.

```
    Error: Missing binding /home/circleci/project/node_modules/node-sass/vendor/linux-x64-72/binding.node
    Node Sass could not find a binding for your current environment: Linux 64-bit with Node.js 12.x

    Found bindings for the following environments:
      - Linux 64-bit with Node.js 10.x

    This usually happens because your environment has changed since running `npm install`.
```
Add `node --version` as a `node_modules` cache key.

[CircleCI has limited capability for dynamically-generated cache keys.](https://circleci.com/docs/2.0/configuration-reference/#save_cache) Using `{{.Environment.variablename}}` only works if the variable is hard-coded in something called a context, or provided by CircleCI. Using `BASH_ENV` ([link](https://circleci.com/docs/2.0/env-vars/#using-bash_env-to-set-environment-variables)) does not work. It does work to write the node version to a file and use `{{checksum}}`.