### PR TITLE
CI: use brimsec/ci:0.0.1-zeek-mergecap

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,0 +1,22 @@
+# Builds brimsec/ci:<version>-zeek-mergecap.
+# Justification: Golang 1.13, Node 12, browser libs, and XVFB for free.
+# Adding Zeek and mergecap.
+# References.
+#   https://www.zeek.org/download/packages.html
+#   https://software.opensuse.org//download.html?project=security%3Azeek&package=zeek
+# Instructions:
+# docker build -f Dockerfile .
+# docker tag <image> brimsec/ci:<version>-zeek-mergecap
+# docker push brimsec/ci:<version>-zeek-mergecap
+FROM circleci/golang:1.13-buster-node-browsers
+
+RUN sudo bash -c "echo 'deb http://download.opensuse.org/repositories/security:/zeek/Debian_10/ /' > /etc/apt/sources.list.d/security:zeek.list" \
+    && curl https://download.opensuse.org/repositories/security:/zeek/Debian_10/Release.key | sudo apt-key add - \
+    && sudo apt-get update \
+    && sudo apt-get -y install \
+        wireshark-common \
+        zeek \
+    && sudo apt-get -y clean \
+    && sudo apt-get -y autoremove
+
+ENV PATH "/opt/zeek/bin:$PATH"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.0
 jobs:
   build:
     docker:
-      - image: circleci/node:10.11.0-jessie-browsers
+      - image: brimsec/ci:0.0.1-zeek-mergecap
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Brim has prereqs for Node, Zeek, mergecap, and ZQD. Brim integration testing requires browser libs and XVFB. ZQD requires Go 1.13. Build a Docker container based off `circleci/golang:1.13-buster-node-browsers` and install Zeek and mergecap on top. This satisfies all prereqs except ZQD (next PR).

After Brim contains Zeek, mergecap, and ZQD in its distribution, this image could be backed out, probably to `circleci/node:12-buster-browsers`.

This updates the CI node version from Node 10 to Node 12.