### PR TITLE
update brimsec/zq to v0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15437,8 +15437,8 @@
       }
     },
     "zq": {
-      "version": "github:brimsec/zq#5089912087f76e15de268811e4e5aa67746d2cb3",
-      "from": "github:brimsec/zq#5089912087f76e15de268811e4e5aa67746d2cb3"
+      "version": "github:brimsec/zq#501472372c6970f2ae05619d9754de4f666adcce",
+      "from": "github:brimsec/zq#v0.3.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -135,6 +135,6 @@
     "rimraf": "^3.0.2",
     "source-map-support": "^0.5.16",
     "valid-url": "^1.0.9",
-    "zq": "brimsec/zq#5089912087f76e15de268811e4e5aa67746d2cb3"
+    "zq": "brimsec/zq#v0.3.0"
   }
 }


### PR DESCRIPTION
This brings us up to date with recent changes to type names at the AST
level.