### PR TITLE
PROD-1507 Show loading message after selecting pcaps

### DIFF
--- a/src/css/_ingest-progress.scss
+++ b/src/css/_ingest-progress.scss
@@ -1,36 +1,26 @@
-.ingest-progress {
-  position: fixed;
-  background: $chrome-gradient;
-  box-shadow: inset 0 0 0px 0.5px rgba(0, 0, 0, 0.2),
-    0px 1px 5px 0px rgba(0, 0, 0, 0.1);
+.ingest-progress-wrapper {
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  animation: fadein 300ms;
+  margin-top: 20%;
+}
 
-  border-radius: 5px;
-  bottom: 8px;
-  right: 8px;
+.ingest-progress {
   padding: 8px;
   user-select: none;
-
   display: flex;
   align-items: center;
-
-  .icon {
-    margin-right: 8px;
-    height: 24px;
-    width: 20px;
-    svg {
-      height: 100%;
-      width: 100%;
-
-      path {
-        stroke: $white-9 !important;
-      }
-    }
-  }
 
   p {
     margin: 0;
     margin-right: 8px;
-    @include label-small;
+    @include label-normal;
+  }
+
+  .mac-spinner {
+    transform: scale(0.6);
   }
 
   .progress-indicator {

--- a/src/css/_new-tab-content.scss
+++ b/src/css/_new-tab-content.scss
@@ -39,7 +39,7 @@
 
   label {
     display: block;
-    @include label-section;
+    @include heading-section;
     margin-bottom: 24px;
   }
 }

--- a/src/css/shared/_typography.scss
+++ b/src/css/shared/_typography.scss
@@ -1,4 +1,4 @@
-@mixin label-section {
+@mixin heading-section {
   font-family: system-ui;
   font-weight: 500;
   font-size: 13px;

--- a/src/js/components/IngestProgress.js
+++ b/src/js/components/IngestProgress.js
@@ -1,22 +1,15 @@
 /* @flow */
-import {useSelector} from "react-redux"
 import React from "react"
 
 import MacSpinner from "./MacSpinner"
-import PcapFileSvg from "../icons/pcap-file.svg"
-import View from "../state/View"
 
 export default function IngestProgress() {
-  let show = useSelector(View.getIsIngesting)
-  if (!show) return null
-
   return (
-    <div className="ingest-progress">
-      <div className="icon">
-        <PcapFileSvg />
+    <div className="ingest-progress-wrapper">
+      <div className="ingest-progress">
+        <p>Processing PCAPs...</p>
+        <MacSpinner />
       </div>
-      <p>Processing PCAPs...</p>
-      <MacSpinner />
     </div>
   )
 }

--- a/src/js/components/NewTabContent.js
+++ b/src/js/components/NewTabContent.js
@@ -1,13 +1,16 @@
 /* @flow */
-import React from "react"
-import fsExtra from "fs-extra"
 import {useDispatch} from "react-redux"
+import React, {useState} from "react"
+import fsExtra from "fs-extra"
 
+import {initSpace} from "../flows/initSpace"
 import {useGlobalSelector} from "../state/GlobalContext"
+import ErrorFactory from "../models/ErrorFactory"
+import IngestProgress from "./IngestProgress"
 import LogoType from "../icons/LogoType"
+import Notice from "../state/Notice"
 import PcapFileInput from "./PcapFileInput"
 import RecentFiles from "../state/RecentFiles"
-import {initSpace} from "../flows/initSpace"
 import SavedSpacesList from "./SavedSpacesList"
 import zealot from "../services/zealot"
 
@@ -15,61 +18,53 @@ export default function NewTabContent() {
   let dispatch = useDispatch()
   let files = useGlobalSelector(RecentFiles.getPaths)
   let filesPresent = files.length !== 0
+  let [loading, setLoading] = useState(false)
 
   function onChange(_e, [file]) {
     if (!file) return
     let dir = file + ".brim"
     let client = zealot.client("localhost:9867")
     let space
+    setLoading(true)
     fsExtra
       .ensureDir(dir)
       .then(() => client.spaces.create({data_dir: dir}))
-      .catch((e) => {
-        console.error(
-          `POST /space with {dir: '${dir}'} is not ready yet. Response was:`,
-          e
-        )
-        return {name: "Not-Implemented"}
-      })
       .then(({name}) => {
         space = name
         return client.pcaps.post({space, path: file})
       })
-      .catch((e) => {
-        console.error(
-          `POST /space/<name>/pcaps with {path: '${file}'} is not ready yet. Response was:`,
-          e
-        )
-        throw "Not Implemented"
-      })
+      .finally(() => setLoading(false))
       .then(() => dispatch(initSpace(space)))
-      .catch(() => {
-        alert("NEW FEATURE IN PROGRESS")
-      })
+      .catch((e) => dispatch(Notice.set(ErrorFactory.create(e))))
   }
 
   return (
     <div className="new-tab-content">
-      <section>
-        <div className="logo">
-          <LogoType />
-        </div>
-      </section>
-      <div className="input-methods">
-        {filesPresent && (
-          <>
+      {loading && <IngestProgress />}
+      {!loading && (
+        <>
+          <section>
+            <div className="logo">
+              <LogoType />
+            </div>
+          </section>
+          <div className="input-methods">
+            {filesPresent && (
+              <>
+                <section>
+                  <label>Recent Files</label>
+                  <SavedSpacesList />
+                </section>
+                <div className="separator" />
+              </>
+            )}
             <section>
-              <label>Recent Files</label>
-              <SavedSpacesList />
+              <label>Open File</label>
+              <PcapFileInput onChange={onChange} />
             </section>
-            <div className="separator" />
-          </>
-        )}
-        <section>
-          <label>Open File</label>
-          <PcapFileInput onChange={onChange} />
-        </section>
-      </div>
+          </div>
+        </>
+      )}
     </div>
   )
 }

--- a/src/js/components/SearchPage.js
+++ b/src/js/components/SearchPage.js
@@ -14,7 +14,6 @@ import CurlModal from "./CurlModal"
 import EmptySpaceModal from "./EmptySpaceModal"
 import ErrorNotice from "./ErrorNotice"
 import Handlers from "../state/Handlers"
-import IngestProgress from "./IngestProgress"
 import NewTabContent from "./NewTabContent"
 import SearchHeaderChart from "./SearchHeaderChart"
 import SearchResults from "./SearchResults/SearchResults"
@@ -52,7 +51,6 @@ export default function SearchPage() {
         </div>
         <XRightPane />
       </div>
-      <IngestProgress />
       <ErrorNotice />
       <XDownloadProgress />
       <WhoisModal />


### PR DESCRIPTION
I removed the modal version of the progress indicator for a simple
spinner on the page. It will be displayed until the pcap has been
processed and is entirely ready to search.

Soon zqd will provide streaming updates, in which case we will add
an indicator somewhere else on the page with the progress.

**The successful case:**
![loading](https://user-images.githubusercontent.com/3460638/75713904-90503900-5c7f-11ea-8206-83c677fc04f3.gif)

**The error case:**
![error](https://user-images.githubusercontent.com/3460638/75713933-9c3bfb00-5c7f-11ea-970f-edc2d210b968.gif)
