### PR TITLE
upgrade electron 7.1.8 -> 7.1.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4512,9 +4512,9 @@
       "dev": true
     },
     "electron": {
-      "version": "7.1.8",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-7.1.8.tgz",
-      "integrity": "sha512-1cWT7toVcSTKu3HdnhDQpbTmI5QCSKtIbg+wHUkSZCdAqjPcuH+dpm+j21g38LbE2DoIzdryaN0RTZOqTPebMA==",
+      "version": "7.1.9",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-7.1.9.tgz",
+      "integrity": "sha512-gkzDr08XxRaNZhwPLRXYNXDaPuiAeCrRPcClowlDVfCLKi+kRNhzekZpfYUBq8DdZCD29D3rCtgc9IHjD/xuHw==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",
@@ -4523,9 +4523,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.24",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.24.tgz",
-          "integrity": "sha512-1Ciqv9pqwVtW6FsIUKSZNB82E5Cu1I2bBTj1xuIHXLe/1zYLl3956Nbhg2MzSYHVfl9/rmanjbQIb7LibfCnug==",
+          "version": "12.12.29",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.29.tgz",
+          "integrity": "sha512-yo8Qz0ygADGFptISDj3pOC9wXfln/5pQaN/ysDIzOaAWXt73cNHmtEC8zSO2Y+kse/txmwIAJzkYZ5fooaS5DQ==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "commander": "^2.20.3",
     "cpx": "^1.5.0",
     "cross-unzip": "^0.2.1",
-    "electron": "^7.1.8",
+    "electron": "^7.1.9",
     "electron-devtools-installer": "^2.2.4",
     "electron-installer-dmg": "^3.0.0",
     "electron-notarize": "^0.2.1",


### PR DESCRIPTION
I discovered that the height of the draggable element which I increased in https://github.com/brimsec/brim/pull/431 was only one of two culprits to the no-drag problem. This issue ALSO occurs if you resize the height of the app and then try to drag it again (which fails). Turns out this is an issue that exists in electron and was at least partially fixed in the next patch version up from where we are currently at as noted in https://github.com/electron/electron/pull/21723. From my own testing, this does seem to fix the issue for us as well.

Signed-off-by: Mason Fish <mason@looky.cloud>