### PR TITLE
PROD-1518 Use Window Manager to Dispatch Global Actions

### DIFF
--- a/src/js/electron/ipc/globalStore/mainHandler.js
+++ b/src/js/electron/ipc/globalStore/mainHandler.js
@@ -1,25 +1,26 @@
 /* @flow */
 import {ipcMain} from "electron"
 
+import type {$WindowManager, WindowState} from "../../tron/windowManager"
 import ipc from ".."
 import sendTo from "../sendTo"
 
-export default function(store: *) {
-  let windows = new Map()
-  // XXX We need to clean up these windows when they close
-
-  ipcMain.handle("globalStore:init", (e) => {
-    windows.set(e.sender.id, e.sender)
+export default function(store: *, winMan: $WindowManager) {
+  ipcMain.handle("globalStore:init", () => {
     return {
-      id: e.sender.id,
       initialState: store.getState()
     }
   })
 
   ipcMain.handle("globalStore:dispatch", (e, {action}) => {
     store.dispatch(action)
-    for (let [_id, web] of windows) {
-      sendTo(web, ipc.globalStore.dispatch(action))
+    for (let win of getWindows(winMan)) {
+      sendTo(win.ref.webContents, ipc.globalStore.dispatch(action))
     }
   })
+}
+
+function getWindows(winMan): WindowState[] {
+  // $FlowFixMe
+  return Object.values(winMan.getWindows())
 }

--- a/src/js/electron/main.js
+++ b/src/js/electron/main.js
@@ -36,7 +36,7 @@ async function main() {
 
   zqdMainHandler()
   windowsMainHandler(winMan)
-  globalStoreMainHandler(store)
+  globalStoreMainHandler(store, winMan)
 
   app.on("ready", () => {
     installExtensions()

--- a/src/js/electron/tron/windowManager.js
+++ b/src/js/electron/tron/windowManager.js
@@ -41,7 +41,7 @@ export default function windowManager() {
       isQuitting = true
     },
 
-    getWindows() {
+    getWindows(): WindowsState {
       return windows
     },
 


### PR DESCRIPTION
Rather than keeping a separate map of windows and needing to clean it up, use the windowManagers' "getWindows()" method which is guaranteed to have only the open windows registered.

