### PR TITLE
bump version to 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "Brim",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Brim Desktop App",
   "repository": "https://github.com/brimsec/brim",
   "license": "ISC",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "main": "dist/js/electron/main.js",
   "author": "Brim Security, Inc.",
   "bin": {


### PR DESCRIPTION
Remove the non-functional win32 release option, and bump the package.json version to 0.3.0, in anticipation of creating a new release.
