### PR TITLE
Adjust server unreachable message

### DIFF
--- a/src/js/models/Errors.js
+++ b/src/js/models/Errors.js
@@ -35,7 +35,7 @@ export class NetworkError extends AppError {
   }
 
   message() {
-    return "The server could not be reached."
+    return "The local server process could not be reached."
   }
 }
 


### PR DESCRIPTION
Change it to reflect that the server is running locally on the same
host as Brim, and avoid giving the impression that Brim is connecting
to some server over the network.