### PR TITLE
PROD-1536 point dev data path to same as release path

### DIFF
--- a/src/js/electron/main.js
+++ b/src/js/electron/main.js
@@ -16,15 +16,6 @@ import {installExtensions} from "./extensions"
 import tron from "./tron"
 import path from "path"
 import {ZQD} from "../zqd/zqd"
-import electronIsDev from "./isDev"
-
-function appRoot() {
-  if (electronIsDev) {
-    return app.getAppPath()
-  } else {
-    return app.getPath("userData")
-  }
-}
 
 async function main() {
   // Disable Warnings in the Console
@@ -40,7 +31,7 @@ async function main() {
     sessionState ? sessionState.globalState : undefined
   )
 
-  const spaceDir = path.join(appRoot(), "data", "spaces")
+  const spaceDir = path.join(app.getPath("userData"), "data", "spaces")
   const zqd = new ZQD(spaceDir)
 
   zqdMainHandler(zqd)


### PR DESCRIPTION
Note that this will effectively remove the use of `<source code path>/data/spaces` as a source in favor of keeping everything ( also including appState.json, windowState.json, etc) in the same place since app.getPath("userData") always points to  ~/Library/Application Support/Brim/... 

Signed-off-by: Mason Fish <mason@looky.cloud>