### PR TITLE
PROD-1501 add set[ip] as ip type

### DIFF
--- a/src/js/electron/menu/fieldContextMenu.js
+++ b/src/js/electron/menu/fieldContextMenu.js
@@ -16,7 +16,7 @@ export default function fieldContextMenu(
     const isTime = field.type === "time"
     const isConn = log.isPath("conn")
     const isGroupBy = hasGroupByProc(program)
-    const isIp = ["ip"].includes(field.type)
+    const isIp = ["ip", "set[ip]"].includes(field.type)
     const hasCol = columns.includes(field.name)
     const sameCols = isEqual(
       log.descriptor.map((d) => d.name).sort(),


### PR DESCRIPTION
allows whois and virusTotal lookup when given a set of ips

![ipsets](https://user-images.githubusercontent.com/14865533/76374193-bcaf2980-62ff-11ea-8d46-e8799e5725ef.gif)

Signed-off-by: Mason Fish <mason@looky.cloud>