### PR TITLE
PROD-1561 edit curl and zq modal text

### DIFF
--- a/src/css/_curl-modal.scss
+++ b/src/css/_curl-modal.scss
@@ -11,6 +11,6 @@
   }
 }
 
-.zq-get-modal {
+.zq-modal {
   min-height: 200px;
 }

--- a/src/js/components/CurlModal.js
+++ b/src/js/components/CurlModal.js
@@ -1,15 +1,12 @@
 /* @flow */
 
 import {useDispatch, useSelector} from "react-redux"
-import React, {useState} from "react"
+import React from "react"
 
-import {InputCheckbox} from "./form/Inputs"
 import {inspectSearch} from "../services/boom"
 import {reactElementProps} from "../test/integration"
-import Form from "./form/Form"
 import ModalBox from "./ModalBox/ModalBox"
 import SearchBar from "../state/SearchBar"
-import Tab from "../state/Tab"
 import TextContent from "./TextContent"
 import clickFeedback from "./clickFeedback"
 import lib from "../lib"
@@ -38,7 +35,7 @@ export default function CurlModalBox() {
       buttons={buttons}
       name="curl"
       className="curl-modal"
-      title="Curl Command"
+      title="curl command"
       {...reactElementProps("curlModal")}
     >
       <CurlModalContents />
@@ -48,20 +45,14 @@ export default function CurlModalBox() {
 
 function CurlModalContents() {
   let dispatch = useDispatch()
-  let [includeCreds, setIncludeCreds] = useState(false)
   let program = useSelector(SearchBar.getSearchProgram)
-  let {username, password} = useSelector(Tab.cluster)
   let info = dispatch(inspectSearch(program))
 
-  function getCreds() {
-    if (includeCreds) return `-u ${username}:${password}`
-    else return ""
-  }
   return (
     <TextContent>
       {info && (
         <pre id="copy-to-curl-code" {...reactElementProps("curlCommand")}>
-          curl -X {info.method} {getCreds()} -d &apos;
+          curl -X {info.method} -d &apos;
           {JSON.stringify(info.body, null, 2)}
           &apos; {info.url}
         </pre>
@@ -71,13 +62,6 @@ function CurlModalContents() {
           Invalid ZQL: &apos;{program}&apos;
         </pre>
       )}
-      <Form>
-        <InputCheckbox
-          label="Include Credentials:"
-          checked={includeCreds}
-          onChange={(e) => setIncludeCreds(e.target.checked)}
-        />
-      </Form>
     </TextContent>
   )
 }

--- a/src/js/components/SearchInput.js
+++ b/src/js/components/SearchInput.js
@@ -75,7 +75,7 @@ function Menu() {
   let menu = [
     {label: "Debug query", click: () => dispatch(Modal.show("debug"))},
     {label: "Copy for curl", click: () => dispatch(Modal.show("curl"))},
-    {label: "Copy for zq", click: () => dispatch(Modal.show("zq-get"))},
+    {label: "Copy for zq", click: () => dispatch(Modal.show("zq"))},
     {
       label: "Kill search",
       click: () => dispatch(Handlers.abortAll()),

--- a/src/js/components/SearchPage.js
+++ b/src/js/components/SearchPage.js
@@ -22,7 +22,7 @@ import Tab from "../state/Tab"
 import TabBar from "./TabBar/TabBar"
 import Tabs from "../state/Tabs"
 import WhoisModal from "./WhoisModal"
-import ZQGetModal from "./ZQGetModal"
+import ZQModal from "./ZQModal"
 import submitSearch from "../flows/submitSearch"
 import useSearchShortcuts from "./useSearchShortcuts"
 
@@ -72,7 +72,7 @@ export default function SearchPage() {
       <CurlModal />
       <SettingsModal />
       <EmptySpaceModal />
-      <ZQGetModal />
+      <ZQModal />
     </div>
   )
 }

--- a/src/js/components/ZQModal.js
+++ b/src/js/components/ZQModal.js
@@ -12,10 +12,10 @@ import TextContent from "./TextContent"
 import clickFeedback from "./clickFeedback"
 import lib from "../lib"
 
-export default function ZQGetModal() {
+export default function ZQModal() {
   function copyToClip(_, e) {
     clickFeedback(e.target, "Copied")
-    var node = document.getElementById("zq-get-code")
+    var node = document.getElementById("zq-code")
     if (node) lib.doc.copyToClipboard(node.textContent)
   }
 
@@ -25,17 +25,17 @@ export default function ZQGetModal() {
         {label: "Copy", click: copyToClip},
         {label: "Done", click: (closeModal) => closeModal()}
       ]}
-      name="zq-get"
-      className="zq-get-modal"
-      title="ZQ Get Command"
-      {...reactElementProps("zqGetModal")}
+      name="zq"
+      className="zq-modal"
+      title="zq command"
+      {...reactElementProps("zqModal")}
     >
-      <ZQDGetModalContents />
+      <ZQModalContents />
     </ModalBox>
   )
 }
 
-function ZQDGetModalContents() {
+function ZQModalContents() {
   let program = useSelector(SearchBar.getSearchProgram)
   const bzng = join(useSelector(Tab.spaceName), "all.bzng")
 
@@ -43,7 +43,7 @@ function ZQDGetModalContents() {
 
   return (
     <TextContent>
-      <pre id="zq-get-code">{cmd}</pre>
+      <pre id="zq-code">{cmd}</pre>
     </TextContent>
   )
 }

--- a/src/js/components/ZQModal.test.js
+++ b/src/js/components/ZQModal.test.js
@@ -1,7 +1,7 @@
 /* @flow */
 import React from "react"
 
-import ZQGetModal from "./ZQGetModal"
+import ZQModal from "./ZQModal"
 import Modal from "../state/Modal"
 import SearchBar from "../state/SearchBar"
 import logInto from "../test/helpers/loginTo"
@@ -14,10 +14,10 @@ test("renders with zq get command", async () => {
   store.dispatchAll([
     SearchBar.changeSearchBarInput("hi"),
     submitSearch(),
-    Modal.show("zq-get")
+    Modal.show("zq")
   ])
 
-  let wrapper = provide(store, <ZQGetModal />)
+  let wrapper = provide(store, <ZQModal />)
   wrapper.find("input[value='Copy']").simulate("click")
   wrapper.find("input[value='Done']").simulate("click")
 

--- a/src/js/state/Modal/types.js
+++ b/src/js/state/Modal/types.js
@@ -18,4 +18,4 @@ export type ModalName =
   | "whois"
   | "curl"
   | "nodata"
-  | "zq-get"
+  | "zq"


### PR DESCRIPTION
Edits text and removes the credentials check box and behavior from the curl modal

![cpcmds](https://user-images.githubusercontent.com/14865533/76440174-b316d780-637a-11ea-8699-0bdae3927df9.gif)


Signed-off-by: Mason Fish <mason@looky.cloud>