### PR TITLE
ci: use circleci/node:12-buster-browsers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ commands:
 jobs:
   build:
     docker:
-      - image: brimsec/ci:0.0.1-zeek-mergecap
+      - image: circleci/node:12-buster-browsers
     steps:
       - checkout
       - npm_install


### PR DESCRIPTION
This further walks back from customized stuff for CI. In this change, we
switch images to a vanilla circleci image. We ought not need golang,
Zeek, and mergecap.

Note that brimsec/ci:0.0.1-zeek-mergecap was based off
circleci/golang:1.13-buster-node-browsers which also had Node 12, so
there's no change to the Node major version here.

Note that in the future we may want to use a customized image again. But
we should at least remove dependencies provided by the image that ought
now be provided by the product directly.