### PR TITLE
PROD-1539 adjust time picker, use space-relative options

### DIFF
--- a/src/js/components/useSpanPickerMenu.js
+++ b/src/js/components/useSpanPickerMenu.js
@@ -17,15 +17,17 @@ export default function useSpanPickerMenu() {
     dispatch(submitSearch())
   }
 
-  let menu = [
-    {click: () => setSpan(spanOfLast(30, "minutes")), label: "Last 30 minutes"},
-    {click: () => setSpan(spanOfLast(24, "hours")), label: "Last 24 hours"},
-    {click: () => setSpan(spanOfLast(7, "days")), label: "Last 7 days"},
-    {click: () => setSpan(spanOfLast(30, "days")), label: "Last 30 days"},
-    {click: () => setSpan(spanOfLast(90, "days")), label: "Last 90 days"}
-  ]
+  if (!space)
+    return [
+      {
+        click: () => setSpan(spanOfLast(30, "minutes")),
+        label: "Last 30 minutes"
+      },
+      {click: () => setSpan(spanOfLast(24, "hours")), label: "Last 24 hours"},
+      {click: () => setSpan(spanOfLast(7, "days")), label: "Last 7 days"},
+      {click: () => setSpan(spanOfLast(30, "days")), label: "Last 30 days"}
+    ]
 
-  if (!space) return menu
   let {min_time, max_time} = space
 
   let from = brim.time(min_time).toDate()
@@ -35,6 +37,23 @@ export default function useSpanPickerMenu() {
     .toDate()
   let spaceSpan = [from, to]
 
-  menu.unshift({click: () => setSpan(spaceSpan), label: "Whole Space"})
-  return menu
+  return [
+    {click: () => setSpan(spaceSpan), label: "Whole Space"},
+    {
+      click: () => setSpan(spanOfLast(30, "minutes", to)),
+      label: "Last 30 minutes of space"
+    },
+    {
+      click: () => setSpan(spanOfLast(24, "hours", to)),
+      label: "Last 24 hours of space"
+    },
+    {
+      click: () => setSpan(spanOfLast(7, "days", to)),
+      label: "Last 7 days of space"
+    },
+    {
+      click: () => setSpan(spanOfLast(30, "days", to)),
+      label: "Last 30 days of space"
+    }
+  ]
 }

--- a/src/js/lib/TimeWindow.js
+++ b/src/js/lib/TimeWindow.js
@@ -53,8 +53,11 @@ export const shift = (
   ]
 }
 
-export const spanOfLast = (number: number, unit: TimeUnit) => {
-  const now = new Date()
+export const spanOfLast = (
+  number: number,
+  unit: TimeUnit,
+  now: Date = new Date()
+) => {
   return [
     brim
       .time(now)


### PR DESCRIPTION
Adjusts timespan options to be more relative to the current s

![relative-space](https://user-images.githubusercontent.com/14865533/76652531-ff514b80-6523-11ea-98ac-34e1260a703e.gif)
pace.

Signed-off-by: Mason Fish <mason@looky.cloud>