### PR TITLE
PROD-1594 Show search warnings under the search bar.

### DIFF
--- a/src/js/brim/search.js
+++ b/src/js/brim/search.js
@@ -5,7 +5,14 @@ import type {RecordData} from "../types/records"
 import type {SearchStats, SearchStatus} from "../types/searches"
 import randomHash from "./randomHash"
 
-type EventNames = "stats" | "status" | "end" | "start" | "error" | number
+type EventNames =
+  | "stats"
+  | "status"
+  | "end"
+  | "start"
+  | "error"
+  | "warnings"
+  | number
 
 export default function search(
   program: string,
@@ -48,6 +55,10 @@ export default function search(
     },
     error(func: (string) => void) {
       callbacks.set("error", func)
+      return this
+    },
+    warnings(func: (string[]) => void) {
+      callbacks.set("warnings", func)
       return this
     },
     emit(event: EventNames, ...data: *) {

--- a/src/js/flows/executeSearch.js
+++ b/src/js/flows/executeSearch.js
@@ -60,6 +60,10 @@ export default function executeSearch(search: $Search): Thunk {
       dispatch(Handlers.remove(search.getId()))
     }
 
+    function warnings(payload) {
+      search.emit("warnings", payload.warnings)
+    }
+
     function streamed(payload) {
       switch (payload.type) {
         case "TaskStart":
@@ -70,6 +74,8 @@ export default function executeSearch(search: $Search): Thunk {
           return stats(payload)
         case "TaskEnd":
           return ended(payload)
+        case "SearchWarnings":
+          return warnings(payload)
       }
     }
 

--- a/src/js/flows/executeTableSearch.js
+++ b/src/js/flows/executeTableSearch.js
@@ -5,6 +5,7 @@ import type {SearchArgs} from "../state/Search/types"
 import type {Thunk} from "../state/types"
 import ErrorFactory from "../models/ErrorFactory"
 import Notice from "../state/Notice"
+import SearchBar from "../state/SearchBar"
 import Viewer from "../state/Viewer"
 import brim from "../brim"
 import executeSearch from "./executeSearch"
@@ -22,6 +23,9 @@ export default function executeTableSearch(
         dispatch(Viewer.appendRecords(tabId, records))
         dispatch(Viewer.updateColumns(tabId, types))
       })
+      .warnings((warnings) =>
+        dispatch(SearchBar.errorSearchBarParse(warnings[0]))
+      )
       .stats((stats) => dispatch(Viewer.setStats(tabId, stats)))
       .error((error) => dispatch(Notice.set(ErrorFactory.create(error))))
       .end((_id, count) =>


### PR DESCRIPTION
If they exist, present them under the search bar in the same place
that we put parse errors.

<img width="481" alt="image" src="https://user-images.githubusercontent.com/3460638/77098389-85abd880-69cf-11ea-8e49-6782596893a6.png">
