### PR TITLE
create a zqd config file with logging enabled

### DIFF
--- a/src/js/zqd/zqd.js
+++ b/src/js/zqd/zqd.js
@@ -26,7 +26,7 @@ const platformDefs = {
 }
 
 function writeZqdConfigFile(): string {
-  const logDir = join(app.getAppPath(), "logs")
+  const logDir = app.getPath("logs")
   mkdirSync(logDir, {recursive: true, mode: 0o755})
 
   const zqdLogFile = join(logDir, "zqd-core.log")
@@ -44,7 +44,7 @@ loggers:
     mode: rotate
 `
 
-  const confFile = join(app.getAppPath(), "zdeps", "zqd-config.yaml")
+  const confFile = join(app.getPath("temp"), "zqd-config.yaml")
   outputFileSync(confFile, data)
   return confFile
 }


### PR DESCRIPTION
When we launch zqd, create a configuration file that causes it to write a core and access logs, using the logging facilities added in https://github.com/brimsec/zq/pull/418 .