### PR TITLE
PROD-1636 Query side effects in other windows

### DIFF
--- a/src/js/components/SearchHeaderChart.js
+++ b/src/js/components/SearchHeaderChart.js
@@ -12,7 +12,6 @@ export default function SearchHeaderChart() {
 
   if (searchRecord) {
     let {program, pins} = searchRecord
-    console.log(brim.program(program, pins).string())
     chartable = !brim.program(program, pins).hasAnalytics()
   }
 


### PR DESCRIPTION
When issuing an analytics search from one window, the histogram would disappear on the other windows.


This was because all the windows were looking at the last entry in the global history to see if they should render the histogram (we don't render the histogram for analytic searches).

The fix is to look at the window level history and not the global history when deciding to render the histogram.

As you can see, now you have two windows, one with analytics and one without:

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/3460638/77259254-86e23d00-6c3d-11ea-9887-c550dfff6789.png">
