### PR TITLE
remove async from onbeforeunload

### DIFF
--- a/src/js/detail.tsx
+++ b/src/js/detail.tsx
@@ -15,8 +15,8 @@ import theme from "./style-theme"
 
 initDetail()
   .then(({store, pluginManager}) => {
-    window.onbeforeunload = async () => {
-      await pluginManager.deactivate()
+    window.onbeforeunload = () => {
+      pluginManager.deactivate()
     }
     ReactDOM.render(
       <Router history={global.windowHistory}>

--- a/src/js/search.tsx
+++ b/src/js/search.tsx
@@ -16,11 +16,11 @@ import TabHistories from "./state/TabHistories"
 
 initialize()
   .then(({store, pluginManager}) => {
-    window.onbeforeunload = async () => {
+    window.onbeforeunload = () => {
       // This runs during reload
       // Visit initIpcListeners.ts#prepareClose for closing window
-      await pluginManager.deactivate()
-      await store.dispatch(deletePartialPools())
+      pluginManager.deactivate()
+      store.dispatch(deletePartialPools())
       store.dispatch(TabHistories.save(global.tabHistories.serialize()))
     }
     ReactDOM.render(


### PR DESCRIPTION
`window.onbeforeunload` expects a synchronous return, so we will still fire off these async functions but immediately return instead of awaiting their completion.

Signed-off-by: Mason Fish <mason@looky.cloud>

Fixes #1631