### PR TITLE
Skip link check on VirusTotal URL due to HTTP 403

### DIFF
--- a/docs/Troubleshooting-(v0.25.0+).md
+++ b/docs/Troubleshooting-(v0.25.0+).md
@@ -205,8 +205,8 @@ having been blocked.
 ## My antivirus software has flagged Brim as potentially malicious
 
 We've been made aware that the Windows binary `suricata-update.exe` has been
-flagged by several antivirus engines, as summarized in
-<!-- markdown-link-check-disable -->[this VirusTotal entry](https://www.virustotal.com/gui/file/b184511d689d547fa5fd524c7ca120586fcffc60f338f932d41800c63961d723/detection). <!-- markdown-link-check-enable-->
+flagged by several antivirus engines, as summarized in<!-- markdown-link-check-disable -->
+[this VirusTotal entry](https://www.virustotal.com/gui/file/b184511d689d547fa5fd524c7ca120586fcffc60f338f932d41800c63961d723/detection).<!-- markdown-link-check-enable-->
 If your antivirus software should flag a different Brim-related binary as
 potentially malicious, please [open an issue](#opening-an-issue), as we'd
 want to investigate that as well.


### PR DESCRIPTION
For the past several days the nightly Markdown link checker has failed due to an HTTP 403 on this link. Indeed, I get the same when doing it manually via `curl`, so I suspect this is some intentional attempt on their part to discourage people from crawling their stuff in bulk via automation. Or something. Anyway, I get the hint, so, skipping it.

```
$ curl -I "https://support.virustotal.com/hc/en-us/articles/115002146769-Comments"
HTTP/2 403 
date: Sat, 09 Oct 2021 16:07:24 GMT
content-type: text/html; charset=UTF-8
...
```