### PR TITLE
Advance Brimcap dependency to tag v1.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8174,8 +8174,8 @@
       }
     },
     "brimcap": {
-      "version": "github:brimdata/brimcap#047366c798f679efe55ec45b3020d0466bc39c1c",
-      "from": "github:brimdata/brimcap#v1.1.1",
+      "version": "github:brimdata/brimcap#3ec2bc8001a58a4fc9c28a2c55ecaeae9914b620",
+      "from": "github:brimdata/brimcap#v1.1.2",
       "dev": true
     },
     "browser-process-hrtime": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "babel-plugin-inline-react-svg": "^1.1.1",
     "babel-plugin-module-resolver": "^4.0.0",
     "babel-plugin-source-map-support": "^2.1.2",
-    "brimcap": "brimdata/brimcap#v1.1.1",
+    "brimcap": "brimdata/brimcap#v1.1.2",
     "chalk": "^4.1.0",
     "commander": "^2.20.3",
     "cpx": "^1.5.0",


### PR DESCRIPTION
To take advantage of JSON reader enhancements that were made in Zed and then into Brimcap.