### PR TITLE
zealot: use query for pools.get & pools.list

### DIFF
--- a/test/api/tests/pools.test.ts
+++ b/test/api/tests/pools.test.ts
@@ -1,6 +1,6 @@
 import {withLake} from "../helpers/with-lake"
 
-test("listing the pool", () => {
+test("list pools", () => {
   return withLake(async (zealot: any) => {
     await zealot.pools.create({name: "pool1"})
     const pools = await zealot.pools.list()
@@ -8,9 +8,25 @@ test("listing the pool", () => {
   })
 })
 
-test("creating a pool", () => {
+test("create a pool", () => {
   return withLake(async (zealot: any) => {
     const {pool} = await zealot.pools.create({name: "pool1"})
     expect(pool.name).toBe("pool1")
+  })
+})
+
+test("get pool", () => {
+  return withLake(async (zealot: any) => {
+    const meta = await zealot.pools.create({name: "pool1"})
+    let pool = await zealot.pools.get(meta.pool.id)
+    expect(pool.name).toBe("pool1")
+    pool = await zealot.pools.get("pool1")
+    expect(pool.name).toBe("pool1")
+  })
+})
+
+test("get non-existant pool", () => {
+  return withLake(async (zealot: any) => {
+    await expect(zealot.pools.get("pool1")).rejects.toEqual(new Error("pool not found"))
   })
 })

--- a/zealot/api/pools.ts
+++ b/zealot/api/pools.ts
@@ -2,20 +2,6 @@ import newHeaders from "./headers"
 import {PoolArgs, PoolLoadArgs} from "../types"
 
 export default {
-  list() {
-    return {
-      headers: newHeaders(),
-      path: "/pool",
-      method: "GET"
-    }
-  },
-  get(poolId: string) {
-    return {
-      headers: newHeaders(),
-      path: `/pool/${poolId}`,
-      method: "GET"
-    }
-  },
   stats(poolId: string) {
     return {
       headers: newHeaders({Accept: "application/x-zjson"}),

--- a/zealot/api/query.ts
+++ b/zealot/api/query.ts
@@ -2,11 +2,11 @@ import newHeaders from "./headers"
 import {QueryArgs} from "../types"
 import {FetchArgs} from "../fetcher/fetcher"
 
-export default function queryApi(zql: string, args: QueryArgs): FetchArgs {
+export default function queryApi(zed: string, args: QueryArgs): FetchArgs {
   return {
     method: "POST",
     path: `/query?${getQueryParams(args)}`,
-    body: JSON.stringify({query: zql}),
+    body: JSON.stringify({query: zed}),
     headers: getHeaders(args),
     signal: args.signal
   }
@@ -15,7 +15,7 @@ export default function queryApi(zql: string, args: QueryArgs): FetchArgs {
 function getHeaders(args: QueryArgs) {
   let h = newHeaders()
 
-  let format
+  let format: string
   switch (args.format) {
     case "zng":
       format = "application/x-zng"
@@ -25,6 +25,9 @@ function getHeaders(args: QueryArgs) {
       break
     case "csv":
       format = "text/csv"
+      break
+    case "json":
+      format = "application/json"
       break
     default:
       format = "application/x-zjson"

--- a/zealot/types.ts
+++ b/zealot/types.ts
@@ -18,7 +18,7 @@ export interface ZealotArgs {
   fetcher: (host: string) => ZFetcher
 }
 
-export type QueryFormat = "zjson" | "zng" | "ndjson" | "csv"
+export type QueryFormat = "zjson" | "zng" | "ndjson" | "csv" | "json"
 
 export type Order = "desc" | "asc"
 
@@ -31,8 +31,8 @@ export interface Response<T> {
 
 export interface QueryArgs {
   format: QueryFormat
-  controlMessages: boolean
-  enhancers: Enhancer[]
+  controlMessages?: boolean
+  enhancers?: Enhancer[]
   signal?: AbortSignal
 }
 

--- a/zealot/zealot.ts
+++ b/zealot/zealot.ts
@@ -51,13 +51,20 @@ export function createZealot(
     },
     pools: {
       list: async (): Promise<PoolConfig[]> => {
-        let values: Response<PoolConfig>[] = await promise(pools.list())
+        let values: Response<PoolConfig>[] = await promise(
+          query("from :pools", {format: "json"})
+        )
         if (!values) return []
         return values.map((res) => res.value)
       },
       get: async (id: string): Promise<PoolConfig> => {
-        let res = await promise(pools.get(id))
-        return res.value
+        let values: Response<PoolConfig>[] = await promise(
+          query(`from :pools | id == ${id} or name == "${id}"`, {
+            format: "json"
+          })
+        )
+        if (!values || values.length == 0) throw new Error("pool not found")
+        return values[0].value
       },
       stats: async (id: string): Promise<PoolStats> => {
         const res = await promise(pools.stats(id))


### PR DESCRIPTION
The GET /pools and /pools/:pool endpoints are now deprecated. Instead
use the query endpoint with the pool meta query to access pool info.