### PR TITLE
clear callbacks on abort

### DIFF
--- a/app/core/hooks/useSearch.ts
+++ b/app/core/hooks/useSearch.ts
@@ -15,8 +15,10 @@ export default function useSearch(query: string, deps?: any[]): R {
     setIsFetching(true)
     const {response, abort} = dispatch(search({query}))
     response.chan(0, ({rows}) => setRecords(rows))
-    response.status((status) => setIsFetching(status === "FETCHING"))
-    response.abort(() => response.clearCallbacks())
+    response.status((status) => {
+      if (status === "ABORTED") return
+      setIsFetching(status === "FETCHING")
+    })
     return abort
   }, deps)
 

--- a/src/js/components/LogDetails/Md5Panel.tsx
+++ b/src/js/components/LogDetails/Md5Panel.tsx
@@ -24,12 +24,14 @@ export const Md5Panel = ({record}: Props) => {
   useEffect(() => {
     const {response, abort} = dispatch(md5Search(logMd5))
     response
-      .status(setStatus)
+      .status((status) => {
+        if (status === "ABORTED") return
+        setStatus(status)
+      })
       .chan(0, ({rows}) => setFilenames(rows))
       .chan(1, ({rows}) => setMd5(rows))
       .chan(2, ({rows}) => setRx(rows))
       .chan(3, ({rows}) => setTx(rows))
-      .abort(() => response.clearCallbacks())
 
     return abort
   }, [logMd5])

--- a/src/js/flows/search/handler.ts
+++ b/src/js/flows/search/handler.ts
@@ -28,8 +28,10 @@ export function handle(request: Promise<ZResponse>) {
     function errored(e) {
       flushBufferLazy.cancel()
       if (abortError(e)) {
-        response.emit("abort")
         response.emit("status", "ABORTED")
+        // NOTE: by clearing callbacks here, consumers of search should expect
+        // the aborted status event to be the last actionable emission
+        response.clearCallbacks()
         resolve()
       } else {
         isErrSet = true

--- a/src/js/flows/search/response.ts
+++ b/src/js/flows/search/response.ts
@@ -50,10 +50,6 @@ export class SearchResponse {
     this.callbacks.set("error", func)
     return this
   }
-  abort(func: () => void) {
-    this.callbacks.set("abort", func)
-    return this
-  }
   warning(func: (arg0: string) => void) {
     this.callbacks.set("warning", func)
     return this

--- a/src/js/types/searches.ts
+++ b/src/js/types/searches.ts
@@ -1,4 +1,4 @@
-export type SearchStatus = "FETCHING" | "SUCCESS" | "ERROR" | "INIT"
+export type SearchStatus = "FETCHING" | "SUCCESS" | "ERROR" | "INIT" | "ABORTED"
 
 export type SearchStats = {
   updateTime: number


### PR DESCRIPTION
fixes #1870 

The callback handlers we assign to the `SearchResponse` can continue to persist and finish execution after a component is unmounted. If the component assigns any state setters in these callbacks and they get called post-unmounting then we encounter this memory leak.

Solution proposed here is to expose a `response.clearCallbacks()` method which consumers may choose to use as needed. In this case both the md5 and relatedConns components will now call this as part of an abort handler for the response.

It's a bit difficult to add a test to this but I managed to find a very consistent manual method of reproducing the error and this did the trick.

Signed-off-by: Mason Fish <mason@brimsecurity.com>