### PR TITLE
reduce Linux artifact size in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,10 @@ jobs:
           npx electron-builder --linux
       - name: Persist Linux packages
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: linux-release
-          path: ./dist/installers
+          path: dist/installers/Brim-*
 
   integration_test_centos:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
The linux-release artifact in .github/workflows/ci.yml is about 1 GB,
but 653 MB of that is the linux-unpacked directory, which is ignored.
Reduce the artifact's size by including only installer package files.