### PR TITLE
Highlight zed error values

### DIFF
--- a/app/viewer/cell.tsx
+++ b/app/viewer/cell.tsx
@@ -5,6 +5,9 @@ import styled from "styled-components"
 
 const BG = styled.div`
   overflow: hidden;
+  height: 100%;
+  display: flex;
+  align-items: center;
 `
 
 const getTooltipStyle = (el: Element) => {

--- a/app/viewer/value.tsx
+++ b/app/viewer/value.tsx
@@ -16,7 +16,9 @@ const transHavelock = transparentize(0.75, havelock as string)
 
 const BG = styled.span`
   cursor: default;
-  display: inline-block;
+  display: flex;
+  height: 100%;
+  align-items: center;
   min-width: 7px;
   &:hover {
     background: ${transHavelock};
@@ -79,17 +81,19 @@ export function PrimitiveValue(props: ValueProps) {
   )
 }
 
-const StyledErrorField = styled.span`
+const StyledErrorField = styled.div`
   display: inline-flex;
   background-color: var(--alert-1);
   border-radius: 3px;
   color: white;
-  height: 18px;
+  height: 17px;
+  justify-content: center;
   align-items: center;
-  padding: 0 6px;
+  padding: 0 9px;
 
   svg {
     margin-right: 8px;
+    margin-top: 1px;
     fill: white;
     opacity: 0.6;
     width: 11px;


### PR DESCRIPTION
fixes #1824 

Checks if field value type is a `zed.Error` and highlights the field as shown below.

<img width="1440" alt="Screen Shot 2021-10-27 at 10 22 59 AM" src="https://user-images.githubusercontent.com/14865533/139116153-6a4160da-2616-4e2e-b57e-418c69942e8f.png">

on :hover state
<img width="517" alt="image" src="https://user-images.githubusercontent.com/14865533/139116524-d8171baf-f2e7-4c9e-947c-6785b6052107.png">

...latest commit nudges the cell contents a bit:
<img width="910" alt="image" src="https://user-images.githubusercontent.com/14865533/139160563-2c97ea99-40ab-45a2-a5e5-b6e93ee738de.png">




Signed-off-by: Mason Fish <mason@brimsecurity.com>