### PR TITLE
Zealot load method needs node fetch

### DIFF
--- a/packages/zealot/src/client/client.ts
+++ b/packages/zealot/src/client/client.ts
@@ -58,7 +58,8 @@ export class Client {
       method: "POST",
       body: data,
       headers,
-      signal: opts.signal
+      signal: opts.signal,
+      fetch: nodeFetch
     })
     return toJS(res)
   }


### PR DESCRIPTION
So for now, it only works in the node environment.