### PR TITLE
upgrade @reduxjs/tookit to 1.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@codemirror/state": "^0.19.9",
     "@electron/remote": "^2.0.1",
     "@js-joda/core": "^3.2.0",
-    "@reduxjs/toolkit": "^1.5.0",
+    "@reduxjs/toolkit": "^1.9.3",
     "@tanstack/react-table": "^8.7.0",
     "acorn": "^7.4.1",
     "ajv": "^6.9.1",

--- a/src/app/core/format.ts
+++ b/src/app/core/format.ts
@@ -3,7 +3,6 @@ import * as d3 from "d3"
 import {useMemo} from "react"
 import {useSelector} from "react-redux"
 import ConfigPropValues from "src/js/state/ConfigPropValues"
-import {State} from "src/js/state/types"
 import {zed} from "@brimdata/zealot"
 import {isString} from "lodash"
 import time from "src/js/models/time"
@@ -18,7 +17,7 @@ export type FormatConfig = {
   decimal: string
 }
 
-export const getFormatConfig = createSelector<State, any, FormatConfig>(
+export const getFormatConfig = createSelector(
   ConfigPropValues.get("display"),
   (values) => ({
     thousands: values.thousandsSeparator,
@@ -28,10 +27,7 @@ export const getFormatConfig = createSelector<State, any, FormatConfig>(
   })
 )
 
-const getTimeZone = createSelector<State, FormatConfig, string>(
-  getFormatConfig,
-  (config) => config.timeZone
-)
+const getTimeZone = createSelector(getFormatConfig, (config) => config.timeZone)
 
 export const useTimeZone = () => useSelector(getTimeZone)
 

--- a/src/app/features/sidebar/pools-section/pool-item.tsx
+++ b/src/app/features/sidebar/pools-section/pool-item.tsx
@@ -10,10 +10,13 @@ import {updateFrom} from "src/app/commands/pins"
 import {useAfterDelayOf} from "src/app/core/hooks/use-after-delay-of"
 import Config from "src/js/state/Config"
 import {PoolName} from "./pool-name"
+import {State} from "src/js/state/types"
 
 const PoolItem = ({node, tree, style, dragHandle}: NodeRendererProps<Pool>) => {
   const pool = node.data
-  const progress = useSelector((state) => Loads.getPoolProgress(state, pool.id))
+  const progress = useSelector((state: State) =>
+    Loads.getPoolProgress(state, pool.id)
+  )
   const afterDelayOf = useAfterDelayOf()
   const delimiter = useSelector(Config.getPoolNameDelimiter)
   const poolName = new PoolName(pool.name, delimiter)

--- a/src/js/components/status-bar/ingest-progress.tsx
+++ b/src/js/components/status-bar/ingest-progress.tsx
@@ -8,12 +8,13 @@ import Loads from "src/js/state/Loads"
 import Modal from "src/js/state/Modal"
 import Pools from "src/js/state/Pools"
 import ProgressIndicator from "../ProgressIndicator"
+import {State} from "src/js/state/types"
 
 export function IngestProgress() {
   const dispatch = useDispatch()
   const lakeId = useSelector(Current.getLakeId)
   const poolId = useSelector(Current.getPoolId)
-  const progress = useSelector((s) => Loads.getPoolProgress(s, poolId))
+  const progress = useSelector((s: State) => Loads.getPoolProgress(s, poolId))
   const warnings = useSelector(Pools.getWarnings(lakeId, poolId))
 
   if (progress === null && !warnings) return null

--- a/src/js/state/Current/selectors.ts
+++ b/src/js/state/Current/selectors.ts
@@ -1,10 +1,8 @@
 import {matchPath} from "react-router"
 import * as Pools from "../Pools/selectors"
-import {PoolsState} from "../Pools/types"
 import Tabs from "../Tabs"
 import {State} from "../types"
 import Lakes from "../Lakes"
-import {LakesState} from "../Lakes/types"
 import {MemoryHistory} from "history"
 import {Pool} from "src/app/core/pools/pool"
 import Queries from "../Queries"
@@ -13,18 +11,12 @@ import QueryVersions from "../QueryVersions"
 import {query, queryVersion} from "src/app/router/routes"
 import SessionHistories from "../SessionHistories"
 import {createSelector} from "@reduxjs/toolkit"
-import {
-  SessionHistoriesState,
-  SessionHistoryEntry,
-} from "../SessionHistories/types"
 import {QueryVersion} from "../QueryVersions/types"
 import {ActiveQuery} from "src/app/core/models/active-query"
 import SessionQueries from "../SessionQueries"
 import memoizeOne from "memoize-one"
 import {entitiesToArray} from "../utils"
-import lake, {LakeModel} from "src/js/models/lake"
-
-type Id = string | null
+import lake from "src/js/models/lake"
 
 export const getHistory = (
   state,
@@ -115,18 +107,14 @@ export const getLakeId = (state: State = undefined) => {
   return match?.params?.lakeId || null
 }
 
-export const mustGetLake = createSelector<State, LakesState, Id, LakeModel>(
-  Lakes.raw,
-  getLakeId,
-  (lakes, id) => {
-    if (!id) throw new Error("Current lake id is unset")
-    if (!lakes[id]) throw new Error(`Missing lake id: ${id}`)
+export const mustGetLake = createSelector(Lakes.raw, getLakeId, (lakes, id) => {
+  if (!id) throw new Error("Current lake id is unset")
+  if (!lakes[id]) throw new Error(`Missing lake id: ${id}`)
 
-    return lake(lakes[id])
-  }
-)
+  return lake(lakes[id])
+})
 
-export const mustGetPool = createSelector<State, PoolsState, Id, Id, Pool>(
+export const mustGetPool = createSelector(
   Pools.raw,
   getLakeId,
   getPoolId,
@@ -171,11 +159,9 @@ export const getTabId = (s: State) => {
   return s.tabs.active
 }
 
-export const getSessionHistory = createSelector<
-  State,
-  string,
-  SessionHistoriesState,
-  SessionHistoryEntry[]
->([getTabId, SessionHistories.raw], (tabId, histories) => histories[tabId])
+export const getSessionHistory = createSelector(
+  [getTabId, SessionHistories.raw],
+  (tabId, histories) => histories[tabId]
+)
 
 export const getSessionId = getTabId

--- a/src/js/state/SessionHistories/reducer.ts
+++ b/src/js/state/SessionHistories/reducer.ts
@@ -33,10 +33,10 @@ const slice = createSlice({
       }
     },
   },
-  extraReducers: {
-    [tabs.remove.toString()]: (s, a: ReturnType<typeof tabs.remove>) => {
+  extraReducers: (builder) => {
+    builder.addCase(tabs.remove, (s, a: ReturnType<typeof tabs.remove>) => {
       delete s[a.payload]
-    },
+    })
   },
 })
 

--- a/src/js/state/SessionQueries/reducer.ts
+++ b/src/js/state/SessionQueries/reducer.ts
@@ -9,10 +9,10 @@ const slice = createSlice({
       s[a.payload.id] = a.payload
     },
   },
-  extraReducers: {
-    [tabs.remove.toString()]: (s, a: ReturnType<typeof tabs.remove>) => {
+  extraReducers: (builder) => {
+    builder.addCase(tabs.remove, (s, a: ReturnType<typeof tabs.remove>) => {
       delete s[a.payload]
-    },
+    })
   },
 })
 

--- a/src/js/state/TabHistories/index.ts
+++ b/src/js/state/TabHistories/index.ts
@@ -11,14 +11,14 @@ const slice = createSlice({
   reducers: {
     save: adapter.setAll,
   },
-  extraReducers: {
-    [tabs.remove.toString()]: (
+  extraReducers: (builder) => {
+    builder.addCase(tabs.remove, (
       state,
       action: ReturnType<typeof tabs.remove>
     ) => {
       global.tabHistories.delete(action.payload)
       return state
-    },
+    })
   },
 })
 

--- a/src/js/state/TabHistories/index.ts
+++ b/src/js/state/TabHistories/index.ts
@@ -12,13 +12,13 @@ const slice = createSlice({
     save: adapter.setAll,
   },
   extraReducers: (builder) => {
-    builder.addCase(tabs.remove, (
-      state,
-      action: ReturnType<typeof tabs.remove>
-    ) => {
-      global.tabHistories.delete(action.payload)
-      return state
-    })
+    builder.addCase(
+      tabs.remove,
+      (state, action: ReturnType<typeof tabs.remove>) => {
+        global.tabHistories.delete(action.payload)
+        return state
+      }
+    )
   },
 })
 

--- a/src/panes/results-pane/errors/missing-pool-error.tsx
+++ b/src/panes/results-pane/errors/missing-pool-error.tsx
@@ -9,6 +9,7 @@ import useLakeId from "src/app/router/hooks/use-lake-id"
 import {Content} from "src/js/components/Content"
 import {VirtualList} from "src/js/components/virtual-list"
 import Pools from "src/js/state/Pools"
+import {State} from "src/js/state/types"
 import styled from "styled-components"
 import {Button} from "../../../app/query-home/title-bar/button"
 
@@ -107,7 +108,7 @@ function SomePoolsMessage(props: {pools: Pool[]}) {
 
 export function MissingPoolError() {
   const lakeId = useLakeId()
-  const pools = useSelector((state) => Pools.all(state, lakeId))
+  const pools = useSelector((state: State) => Pools.all(state, lakeId))
   return (
     <BG>
       <h1>No Pool Specified</h1>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2180,15 +2180,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@reduxjs/toolkit@npm:^1.5.0":
-  version: 1.5.0
-  resolution: "@reduxjs/toolkit@npm:1.5.0"
+"@reduxjs/toolkit@npm:^1.9.3":
+  version: 1.9.3
+  resolution: "@reduxjs/toolkit@npm:1.9.3"
   dependencies:
-    immer: ^8.0.0
-    redux: ^4.0.0
-    redux-thunk: ^2.3.0
-    reselect: ^4.0.0
-  checksum: c2d9b0a43018aa3dadbb3c4dd3cd12d2cbaf8bcb30f2478a1208d735186c1fb8a0523cbacaea7df35d8390d19deddb3b39e6b1490a450222c3021277fa56e213
+    immer: ^9.0.16
+    redux: ^4.2.0
+    redux-thunk: ^2.4.2
+    reselect: ^4.1.7
+  peerDependencies:
+    react: ^16.9.0 || ^17.0.0 || ^18
+    react-redux: ^7.2.1 || ^8.0.2
+  peerDependenciesMeta:
+    react:
+      optional: true
+    react-redux:
+      optional: true
+  checksum: d965fc6197fd420e4b8eb714015aa908d4ea214e6e10889cf4521e64ac4f8e0a7de29ee4e8da63b291acc40ac330dd31682334090d54838add73c746dc590650
   languageName: node
   linkType: hard
 
@@ -9072,10 +9080,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immer@npm:^8.0.0":
-  version: 8.0.1
-  resolution: "immer@npm:8.0.1"
-  checksum: 63d875c04882b862481a0a692816e5982975a47a57619698bc1bb52963ad3b624911991708b2b81a7af6fdac15083d408e43932d83a6a61216e5a4503efd4095
+"immer@npm:^9.0.16":
+  version: 9.0.19
+  resolution: "immer@npm:9.0.19"
+  checksum: f02ee53989989c287cd548a3d817fccf0bfe56db919755ee94a72ea3ae78a00363fba93ee6c010fe54a664380c29c53d44ed4091c6a86cae60957ad2cfabc010
   languageName: node
   linkType: hard
 
@@ -13971,10 +13979,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"redux-thunk@npm:^2.3.0":
-  version: 2.3.0
-  resolution: "redux-thunk@npm:2.3.0"
-  checksum: d13f442ffc91249b534bf14884c33feff582894be2562169637dc9d4d70aec6423bfe6d66f88c46ac027ac1c0cd07d6c2dd4a61cf7695b8e43491de679df9bcf
+"redux-thunk@npm:^2.4.2":
+  version: 2.4.2
+  resolution: "redux-thunk@npm:2.4.2"
+  peerDependencies:
+    redux: ^4
+  checksum: c7f757f6c383b8ec26152c113e20087818d18ed3edf438aaad43539e9a6b77b427ade755c9595c4a163b6ad3063adf3497e5fe6a36c68884eb1f1cfb6f049a5c
   languageName: node
   linkType: hard
 
@@ -13994,6 +14004,15 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.9.2
   checksum: 6a839cee5bd580c5298d968e9e2302150e961318253819bcd97f9d945a5a409559eacddf6026f4118bb68b681c593d90e8a2c5bbf278f014aff9bf0d2d8fa084
+  languageName: node
+  linkType: hard
+
+"redux@npm:^4.2.0":
+  version: 4.2.1
+  resolution: "redux@npm:4.2.1"
+  dependencies:
+    "@babel/runtime": ^7.9.2
+  checksum: f63b9060c3a1d930ae775252bb6e579b42415aee7a23c4114e21a0b4ba7ec12f0ec76936c00f546893f06e139819f0e2855e0d55ebfce34ca9c026241a6950dd
   languageName: node
   linkType: hard
 
@@ -14157,6 +14176,13 @@ __metadata:
   version: 4.0.0
   resolution: "reselect@npm:4.0.0"
   checksum: ac7dfc9ef2cdb42b6fc87a856f3ce904c2e4363a2bc1e6fb7eea5f78902a6f506e4388e6509752984877c6dbfe501100c076671d334799eb5a1bfe9936cb2c12
+  languageName: node
+  linkType: hard
+
+"reselect@npm:^4.1.7":
+  version: 4.1.7
+  resolution: "reselect@npm:4.1.7"
+  checksum: 738d8e2b8f0dca154ad29de6a209c9fbca2d70ae6788fd85df87f2c74b95a65bbf2d16d43a9e2faff39de34d17a29d706ba08a6b2ee5660c09589edbd19af7e1
   languageName: node
   linkType: hard
 
@@ -17074,7 +17100,7 @@ __metadata:
     "@codemirror/state": ^0.19.9
     "@electron/remote": ^2.0.1
     "@js-joda/core": ^3.2.0
-    "@reduxjs/toolkit": ^1.5.0
+    "@reduxjs/toolkit": ^1.9.3
     "@swc/cli": ^0.1.55
     "@swc/core": ^1.2.144
     "@swc/jest": ^0.2.17


### PR DESCRIPTION
This upgrades immer to 9.0.19, which fixes CVE-2021-3757 and CVE-2021-23436.

The changes to extraReducers functions silence the following warning.

    The object notation for `createSlice.extraReducers` is deprecated,
    and will be removed in RTK 2.0. Please use the 'builder callback'
    notation instead: https://redux-toolkit.js.org/api/createSlice

All other changes below src are for "yarn lint".