### PR TITLE
More Brim/Zui renames

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Create a report to help us fix a problem in Brim
+about: Create a report to help us fix a problem in Zui
 title: ''
 labels: bug
 assignees: ''
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 Before opening a new issue, please make sure you've reviewed the troubleshooting guide:
-https://github.com/brimdata/brim/wiki/Troubleshooting
+https://zui.brimdata.io/docs/support/Troubleshooting
 
 **Describe the bug**
 [A description of what the bug is]
@@ -25,4 +25,4 @@ https://github.com/brimdata/brim/wiki/Troubleshooting
 **Desktop Info**
 [Please complete the following information]
  - OS: [e.g. Windows, Linux, macOS]
- - Brim Version: [copy from **Help > About Brim** on Windows and Linux, or **Brim > About Brim** on macOS]
+ - Zui Version: [copy from **Help > About Zui** on Windows and Linux, or **Zui > About Zui** on macOS]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Suggest an idea to improve Brim
+about: Suggest an idea to improve Zui
 title: ''
 labels: ''
 assignees: ''
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 Before opening a new issue, please make sure you've reviewed the troubleshooting guide:
-https://github.com/brimdata/brim/wiki/Troubleshooting#opening-an-issue
+https://zui.brimdata.io/docs/support/Troubleshooting
 
 **Is your feature request related to a problem? Please describe.**
 [For example: "I'm always frustrated when..."]

--- a/.github/workflows/advance-zed.yml
+++ b/.github/workflows/advance-zed.yml
@@ -41,7 +41,7 @@ jobs:
         # body can be multiline and must be escaped as described here:
         # https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/m-p/37870
         #
-        # Rewrite bare PR numbers as Zed PRs (https://github.com/brimdata/brim/issues/797)
+        # Rewrite bare PR numbers as Zed PRs (https://github.com/brimdata/zui/issues/797)
         run: |
           sha="$(jq -r '.client_payload.merge_commit_sha' "${GITHUB_EVENT_PATH}")"
           echo "sha=$sha" >> $GITHUB_OUTPUT
@@ -97,7 +97,7 @@ jobs:
 
       # If this push fails because a PR was merged while this job was
       # running, you can re-run the failed job via
-      # https://github.com/brimdata/brim/actions.  Or, if you expect
+      # https://github.com/brimdata/zui/actions.  Or, if you expect
       # this workflow to be dispatched again soon, you can simply ignore
       # the failure.
       - run: git push

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Brim CI
+name: Zui CI
 
 on:
   pull_request:

--- a/.github/workflows/notify-main-failure.yml
+++ b/.github/workflows/notify-main-failure.yml
@@ -22,5 +22,5 @@ jobs:
           slack_json: |
             {
               "username": "github-actions",
-              "text": "brimdata/brim workflow \"${{ github.event.workflow_run.name }}\" failed on main.\n${{ github.event.workflow_run.html_url }}"
+              "text": "brimdata/zui workflow \"${{ github.event.workflow_run.name }}\" failed on main.\n${{ github.event.workflow_run.html_url }}"
             }  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,23 +1,23 @@
-# Brim Development
+# Zui Development
 
-Thank you for contributing to Brim!
+Thank you for contributing to Zui!
 
-Per common practice, please [open an issue](https://github.com/brimdata/brim/wiki/Troubleshooting#opening-an-issue) before sending a pull request. If you think your ideas might benefit from some refinement via Q&A, come talk to us on [Slack](https://www.brimdata.io/join-slack/) as well.
+Per common practice, please [open an issue](https://zui.brimdata.io/docs/support/Troubleshooting#opening-an-issue) before sending a pull request. If you think your ideas might benefit from some refinement via Q&A, come talk to us on [Slack](https://www.brimdata.io/join-slack/) as well.
 
 ## Setup
 
 Install these dependencies:
 
 1. [Node](https://nodejs.org/en/download/package-manager/) - the version specified in the `.node-version` file at the root folder.
-2. [Yarn](https://yarnpkg.com/) - a package manager for installing dependencies and starting Brim in dev mode.
+2. [Yarn](https://yarnpkg.com/) - a package manager for installing dependencies and starting Zui in dev mode.
 3. [Go](https://go.dev/doc/install) - to compile some [Zed](https://zed.brimdata.io/) dependencies.
 4. Typical command line tools, such as `make`, `unzip`, and `curl`
 
 Then clone the repo, install the node modules, and start the app.
 
 ```bash
-git clone https://github.com/brimdata/brim
-cd brim
+git clone https://github.com/brimdata/zui
+cd zui
 yarn
 yarn start
 ```
@@ -28,7 +28,7 @@ On subsequent updates, `git pull` and `yarn`.
 
 ## Libraries
 
-Brim is a TypeScript, React, Electron app.
+Zui is a TypeScript, React, Electron app.
 
 - [Electron](https://www.electronjs.org/docs/latest) - it's helpful to understand the [main vs renderer processes](https://www.electronjs.org/docs/latest/tutorial/quick-start#main-and-renderer-processes)
 - [TypeScript](https://www.typescriptlang.org/)
@@ -115,7 +115,7 @@ test("click the button", async () => {
 
 All backend requests are made with Node and hit the local Zed lake. Any browser APIs that are not in JSDOM are mocked or polyfilled. The electron APIs are mocked as well. You can find them in `test/shared/__mocks__/electron`.
 
-The `SystemTest` class comes with a few helper methods for commonly performed actions in the Brim app like _.runQuery(q)_, _.ingestFile_(name), _.navTo(path)_, and _.render(jsx)_. It also re-exports some of the common [userEvent](https://testing-library.com/docs/ecosystem-user-event/) methods like _.click()_ and _.rightClick()_
+The `SystemTest` class comes with a few helper methods for commonly performed actions in the Zui app like _.runQuery(q)_, _.ingestFile_(name), _.navTo(path)_, and _.render(jsx)_. It also re-exports some of the common [userEvent](https://testing-library.com/docs/ecosystem-user-event/) methods like _.click()_ and _.rightClick()_
 
 They can be run like so:
 
@@ -132,7 +132,7 @@ Use the Styled Components library to style new components. Previously, we used s
 
 ## Migrations
 
-Because we persist state on a user's computer, if they upgrade Brim and we've changed the expected state, we need to migrate the old state. If any of the reducers in `src/js/state` are changed, we need to write a migration. There is a tool we built to help with this. You can run, for example:
+Because we persist state on a user's computer, if they upgrade Zui and we've changed the expected state, we need to migrate the old state. If any of the reducers in `src/js/state` are changed, we need to write a migration. There is a tool we built to help with this. You can run, for example:
 
 ```bash
 bin/gen migration addScrollPositionToViewer
@@ -140,11 +140,11 @@ bin/gen migration addScrollPositionToViewer
 
 This creates a file in `src/js/state/migrations` with a function that can manipulate the persisted state from the previous version.
 
-See the [Adding Migrations](https://github.com/brimdata/brim/wiki/Adding-Migrations) page for a more detailed guide.
+See the [Adding Migrations](https://zui.brimdata.io/docs/developer/Adding-Migrations) page for a more detailed guide.
 
 ### Zed
 
-The [Zed service](https://zed.brimdata.io/docs/commands/zed#213-serve) is the daemon responsible for data ingestion and query execution. As a postinstall step, the `zed` binary is downloaded and stored in the `./zdeps` directory. Brim will automatically execute and terminate the service when it starts and stops.
+The [Zed service](https://zed.brimdata.io/docs/commands/zed#213-serve) is the daemon responsible for data ingestion and query execution. As a postinstall step, the `zed` binary is downloaded and stored in the `./zdeps` directory. Zui will automatically execute and terminate the service when it starts and stops.
 
 ## Pull Requests
 
@@ -162,7 +162,7 @@ yarn test:playwright  # Integration tests with jest & playwright
 
 ## Installation Packaging
 
-[Releases](https://github.com/brimdata/brim/releases) with installable artifacts are created automatically by an [Actions Workflow](.github/workflows/release.yml) when a GA release is tagged.
+[Releases](https://github.com/brimdata/zui/releases) with installable artifacts are created automatically by an [Actions Workflow](.github/workflows/release.yml) when a GA release is tagged.
 
 You can installable artifacts based on your own checkout via:
 
@@ -226,8 +226,8 @@ your contribution under those license terms.
 We want to prevent technology giants from using the Polyform Perimeter license
 covered code to create replacement offerings of our projects.
 
-The overwhelming majority of Brim or Zed users and developers will not be
-restricted by this license, including those using Brim or Zed in commercial
+The overwhelming majority of Zui or Zed users and developers will not be
+restricted by this license, including those using Zui or Zed in commercial
 settings.
 
 The use of the source-available Polyform Perimeter license prevents use
@@ -236,7 +236,7 @@ cases like:
 - Marketing a work as a “as-a-service” style offering for server
   components like Zed, while using material covered under the Polyform
   Perimeter license
-- Marketing a work as a replacement for the Brim desktop application,
+- Marketing a work as a replacement for the Zui desktop application,
   while using material covered under the Polyform Perimeter license
 
 We believe users and developers should have access to the source code for our
@@ -246,4 +246,4 @@ of the source code lets us realize both.
 
 ## Questions?
 
-We appreciate your interest in improving Brim. If you've got questions that aren't answered here, please join our [public Slack](https://www.brimdata.io/join-slack/) workspace and ask!
+We appreciate your interest in improving Zui. If you've got questions that aren't answered here, please join our [public Slack](https://www.brimdata.io/join-slack/) workspace and ask!

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2019-2021, Brim Security, Inc.
+Copyright (c) 2019-2023, Brim Data, Inc.
 All rights reserved.
 
 Source code in this repository is licensed under either the BSD-3-Clause license
@@ -83,7 +83,7 @@ URL for them above, as well as copies of any plain-text lines
 beginning with `Required Notice:` that the licensor provided
 with the software.  For example:
 
-> Required Notice: Copyright Brim Security, Inc. (http://www.brimdata.io)
+> Required Notice: Copyright Brim Data, Inc. (http://www.brimdata.io)
 
 ## Changes and New Works License
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Highlights:
 
 **[Download Zui](https://www.brimdata.io/download/)** for your operating system.
 
-Refer to the [installation guide](https://github.com/brimdata/brim/wiki/Installation) and
-[release notes](https://github.com/brimdata/brim/releases) for more information.
+Refer to the [installation guide](https://zui.brimdata.io/docs/Installation) and
+[release notes](https://github.com/brimdata/zui/releases) for more information.
 
 ## Powered By Zed
 
@@ -47,7 +47,7 @@ Zui retains the security-specific features that made Brim popular while expandin
 
 ## Need Help?
 
-Please browse the [wiki](https://github.com/brimdata/brim/wiki) to review common problems and helpful tips before [opening an issue](https://github.com/brimdata/brim/wiki/Troubleshooting#opening-an-issue).
+Please browse the [support resources](https://zui.brimdata.io/docs/support) to review common problems and helpful tips before [opening an issue](https://zui.brimdata.io/docs/support/Troubleshooting#opening-an-issue).
 
 ## Contributing
 

--- a/docs/advanced/Remote-Zed-Lakes.md
+++ b/docs/advanced/Remote-Zed-Lakes.md
@@ -97,7 +97,7 @@ ubuntu# sudo apt install -y ./Zui-1.0.0.deb
 ```
 
 The following additional steps are also currently necessary to work around
-issue [zui/1701](https://github.com/brimdata/brim/issues/1701).
+issue [zui/1701](https://github.com/brimdata/zui/issues/1701).
 
 ```
 ubuntu# sudo find /opt/Zui/resources/app.asar.unpacked/zdeps/suricata -exec chmod go+w {} \;

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -5,6 +5,6 @@ sidebar_position: 5
 # Developer Resources
 
 Developers that wish to extend or customize the Zui application code should
-read the [contributing](https://github.com/brimdata/brim/blob/main/CONTRIBUTING.md)
+read the [contributing](https://github.com/brimdata/zui/blob/main/CONTRIBUTING.md)
 guide and also understand how to [add state migrations](Adding-Migrations.md)
 between app versions.

--- a/docs/support/Brim-Zui-Transition.md
+++ b/docs/support/Brim-Zui-Transition.md
@@ -36,7 +36,7 @@ regarding the transition on your operating system.
 
 Those interested in the technical details of the testing that led to this
 guidance can read more
-[here](https://github.com/brimdata/brim/issues/2459#issuecomment-1442316859).
+[here](https://github.com/brimdata/zui/issues/2459#issuecomment-1442316859).
 
 ### Windows
 

--- a/docs/support/Supported-Platforms.md
+++ b/docs/support/Supported-Platforms.md
@@ -52,7 +52,7 @@ and regularly perform ad hoc testing with it to reproduce reported issues.
 
 Basic [smoke testing](#smoke-testing) has also validated that Zui appears to
 work on macOS Big Sur 11.7.2 as well. We do _not_ recommend attempting to run
-Brim on macOS releases older than macOS Big Sur 11.7.2.
+Zui on macOS releases older than macOS Big Sur 11.7.2.
 
 #### Hardware
 
@@ -75,7 +75,7 @@ will become more popular in the future, please
 for problems you experience with Zui on M1-based Macs as you would any other.
 If we should begin to accumulate bugs that are specific to M1-based hardware,
 this will help guide the prioritization of our goal to deliver M1-specific
-builds ([zui/1266](https://github.com/brimdata/brim/issues/1266)).
+builds ([zui/1266](https://github.com/brimdata/zui/issues/1266)).
 
 ### Linux
 
@@ -129,8 +129,8 @@ The most extensive testing of Zui is provided via automation that is run on
 [GitHub Actions](https://github.com/features/actions). Specific platform
 versions of
 hosted [runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners) are referenced in the automation for Zui's
-[continuous integration tests](https://github.com/brimdata/brim/blob/main/.github/workflows/ci.yml)
-and [release workflow](https://github.com/brimdata/brim/blob/main/.github/workflows/release.yml).
+[continuous integration tests](https://github.com/brimdata/zui/blob/main/.github/workflows/ci.yml)
+and [release workflow](https://github.com/brimdata/brim/zui/main/.github/workflows/release.yml).
 
 ### Smoke Testing
 
@@ -147,8 +147,8 @@ confirm basic functionality. Such a smoke test consists of the following:
 
 This exercise was most recently performed in August, 2022 in preparation for
 Zui release v1.0.0. For more details on
-previously-performed smoke testing exercises, review [zui/1263](https://github.com/brimdata/brim/issues/1263),
-[zui/2481](https://github.com/brimdata/brim/pull/2481), and [zui/2482](https://github.com/brimdata/brim/issues/2482).
+previously-performed smoke testing exercises, review [zui/1263](https://github.com/brimdata/zui/issues/1263),
+[zui/2481](https://github.com/brimdata/zui/pull/2481), and [zui/2482](https://github.com/brimdata/zui/issues/2482).
 
 ### Non-Recommended Platforms
 

--- a/docs/support/Supported-Platforms.md
+++ b/docs/support/Supported-Platforms.md
@@ -130,7 +130,7 @@ The most extensive testing of Zui is provided via automation that is run on
 versions of
 hosted [runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners) are referenced in the automation for Zui's
 [continuous integration tests](https://github.com/brimdata/zui/blob/main/.github/workflows/ci.yml)
-and [release workflow](https://github.com/brimdata/brim/zui/main/.github/workflows/release.yml).
+and [release workflow](https://github.com/brimdata/zui/blob/main/.github/workflows/release.yml).
 
 ### Smoke Testing
 

--- a/docs/support/Troubleshooting.md
+++ b/docs/support/Troubleshooting.md
@@ -10,7 +10,7 @@ before you [open an issue](#opening-an-issue).
 ## Common Problems
 
 The following are some of the more commonly-reported Zui problems. You may
-also want to review the [current open issues](https://github.com/brimdata/brim/issues).
+also want to review the [current open issues](https://github.com/brimdata/zui/issues).
 
 * [I've clicked to open a packet capture in Zui, but it failed to open](#ive-clicked-to-open-a-packet-capture-in-zui-but-it-failed-to-open)
 * [I've clicked in Zui to extract a flow from my pcap into Wireshark, but the flow looks different than when I isolate it in the original pcap file in Wireshark](#ive-clicked-in-zui-to-extract-a-flow-from-my-pcap-into-wireshark-but-the-flow-looks-different-than-when-i-isolate-it-in-the-original-pcap-file-in-wireshark)
@@ -21,15 +21,15 @@ also want to review the [current open issues](https://github.com/brimdata/brim/i
 #### I've clicked to open a packet capture in Zui, but it failed to open
 
 Functionality related to pcaps is
-provided via [Brimcap](https://github.com/brimdata/brimcap#usage-with-brim-desktop-app).
-This question is covered [here](https://github.com/brimdata/brimcap/wiki/Troubleshooting#ive-clicked-to-open-a-packet-capture-in-brim-but-it-failed-to-open)
+provided via [Brimcap](https://github.com/brimdata/brimcap#usage-with-zui-desktop-app).
+This question is covered [here](https://github.com/brimdata/brimcap/wiki/Troubleshooting#ive-clicked-to-open-a-packet-capture-in-zui-but-it-failed-to-open)
 in the Brimcap wiki.
 
 #### I've clicked in Zui to extract a flow from my pcap into Wireshark, but the flow looks different than when I isolate it in the original pcap file in Wireshark
 
 Functionality related to pcaps is
-provided via [Brimcap](https://github.com/brimdata/brimcap#usage-with-brim-desktop-app).
-This question is covered [here](https://github.com/brimdata/brimcap/wiki/Troubleshooting#ive-clicked-in-brim-to-extract-a-flow-from-my-pcap-into-wireshark-but-the-flow-looks-different-than-when-i-isolate-it-in-the-original-pcap-file-in-wireshark)
+provided via [Brimcap](https://github.com/brimdata/brimcap#usage-with-zui-desktop-app).
+This question is covered [here](https://github.com/brimdata/brimcap/wiki/Troubleshooting#ive-clicked-in-zui-to-extract-a-flow-from-my-pcap-into-wireshark-but-the-flow-looks-different-than-when-i-isolate-it-in-the-original-pcap-file-in-wireshark)
 in the Brimcap wiki.
 
 #### Zui seems unable to restart normally, such as after a bad crash
@@ -38,7 +38,7 @@ Though we attempt to fix bad bugs in Zui soon after they're identified,
 occasionally you may encounter a new bug that crashes the app in a way that
 leaves it in a bad state. In these situations Zui will seem "stuck" each time
 it starts, either at a blank white screen (such as in previously-fixed issue
-[zui/1099](https://github.com/brimdata/brim/issues/1099)) or showing an error
+[zui/1099](https://github.com/brimdata/zui/issues/1099)) or showing an error
 dump similar to the one below:
 
 ![Example crash from issue #652](media/Crash-652.png)
@@ -77,12 +77,12 @@ symptoms after an upgrade to a newer Zui release. In each case the users
 ultimately resolved the problem via system reboot. We've unfortunately been
 unable to reproduce this problem or study a system "live" that's in this state
 to determine the root cause or why the reboot fixed it. An issue
-[zui/1490](https://github.com/brimdata/brim/issues/1490) is being kept open to
+[zui/1490](https://github.com/brimdata/zui/issues/1490) is being kept open to
 track this specific case. Even though a reboot might be an effective fix for
 you also, your assistance would be much appreciated in still running
 through the troubleshooting steps below and gathering the debug information.
 If you ultimately find a reboot fixes the symptom for you, please add your logs
-and details to [zui/1490](https://github.com/brimdata/brim/issues/1490).
+and details to [zui/1490](https://github.com/brimdata/zui/issues/1490).
 In all other cases, please [open a new issue](#opening-an-issue).
 
 To begin troubleshooting this, it helps to understand the "backend" of Zui.
@@ -276,8 +276,8 @@ its origin.
   which [downloads the Suricata artifact](https://github.com/brimdata/brimcap/blob/03b90badb7ea1f3a97c793b21f97d4f525cdd65f/Makefile#L39) which is bundled
   into [Brimcap releases](https://github.com/brimdata/brimcap/releases).
 
-* Each Zui release points at a [Brimcap release](https://github.com/brimdata/brim/blob/4c74bdcdb38b84ff15c20926a7a05bfb7fe61d92/package.json#L69)
-  that's bundled by Zui's own [release automation](https://github.com/brimdata/brim/blob/main/.github/workflows/release.yml).
+* Each Zui release points at a [Brimcap release](https://github.com/brimdata/zui/blob/4c74bdcdb38b84ff15c20926a7a05bfb7fe61d92/package.json#L69)
+  that's bundled by Zui's own [release automation](https://github.com/brimdata/zui/blob/main/.github/workflows/release.yml).
 
 To summarize, the executable consists of a minimally-enhanced Suricata-Update that's been
 turned into an executable by other open source tools. If your conclusion
@@ -363,11 +363,11 @@ a link to it in your issue.
 
 ## Opening an Issue
 
-Before/when [opening a new issue](https://github.com/brimdata/brim/issues/new/choose),
+Before/when [opening a new issue](https://github.com/brimdata/zui/issues/new/choose),
 you can help us out by doing the following:
 
 * Review the [common problems](#common-problems) above see if you're hitting one of those.
-* Browse the existing [open issues](https://github.com/brimdata/brim/issues?q=is%3Aissue+is%3Aopen). If you confirm you're hitting one of those, please add a comment to it rather than opening a new issue.
+* Browse the existing [open issues](https://github.com/brimdata/zui/issues?q=is%3Aissue+is%3Aopen). If you confirm you're hitting one of those, please add a comment to it rather than opening a new issue.
 * [Gather info](#gathering-info) that may help in reproducing the issue and testing a fix, and attach it to your issue.
 * Feel free to chat with the team on the [public Slack](https://www.brimdata.io/join-slack/) before/after opening an issue.
 * When you open a new issue, its initial text will include a template with standard info that will almost always be needed. Please include detail for all areas of the template.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "Zui",
   "private": true,
   "description": "Zed User Interface",
-  "repository": "https://github.com/brimdata/brim",
+  "repository": "https://github.com/brimdata/zui",
   "license": "BSD-3-Clause",
   "version": "1.0.0",
   "main": "dist/js/electron/main.js",

--- a/scripts/lib/common.bash
+++ b/scripts/lib/common.bash
@@ -28,7 +28,7 @@ function retry_until_success {
 }
 
 function umount_macos_ci_dimg {
-    # https://github.com/brimdata/brim/issues/690
+    # https://github.com/brimdata/zui/issues/690
     # It's possible for hdiutil to fail with an error code, yet
     # subsequently the volume disappears. This is a function so that
     # its logic can be used with retry_until_success.

--- a/src/app/release-notes/test.tsx
+++ b/src/app/release-notes/test.tsx
@@ -12,7 +12,7 @@ const system = new SystemTest("release-notes")
 
 system.network.use(
   rest.get(
-    "https://api.github.com/repos/brimdata/brim/releases/tags/v0.0.0",
+    "https://api.github.com/repos/brimdata/zui/releases/tags/v0.0.0",
     (req, res, ctx) => {
       return res(ctx.status(200), ctx.json({body: "Testing Release Notes"}))
     }

--- a/src/js/components/AboutWindow.tsx
+++ b/src/js/components/AboutWindow.tsx
@@ -43,8 +43,8 @@ export default function AboutWindow() {
           </section>
           <section>
             <label>Source</label>
-            <a onClick={() => open("https://github.com/brimdata/brim")}>
-              github.com/brimdata/brim
+            <a onClick={() => open("https://github.com/brimdata/zui")}>
+              github.com/brimdata/zui
             </a>
           </section>
           <hr />

--- a/src/plugins/brimcap/brimcap-plugin.ts
+++ b/src/plugins/brimcap/brimcap-plugin.ts
@@ -18,7 +18,7 @@ export default class BrimcapPlugin {
   private pluginNamespace = "brimcap"
   private yamlConfigPropName = "yamlConfigPath"
   private cli: BrimcapCLI
-  // currentConn represents the data detail currently seen in the Brim detail
+  // currentConn represents the data detail currently seen in the Zui detail
   // pane/window
   private currentConn = null
   private yamlConfigPath = ""


### PR DESCRIPTION
Now that the repo has been renamed and the [old Brim wiki](https://github.com/brimdata/zui/wiki) has been replaced with a pointer to the new Zui docs site, here's more Brim-to-Zui renames throughout the repo.

@jameskerr: I know you already did a pass through the actual code with lots of renames. I found a few lingering references to "Brim" in variables names and such that I did _not_ change since I assume you left them where they were intentionally. But if you spot more and want to change them in this PR, please feel free to push to the branch. Thanks!