### PR TITLE
Fix link for guidance on opening an issue

### DIFF
--- a/src/js/electron/windows/search/app-menu.ts
+++ b/src/js/electron/windows/search/app-menu.ts
@@ -259,7 +259,7 @@ export function compileTemplate(
         label: "Submit Issue...",
         click() {
           shell.openExternal(
-            "https://github.com/brimdata/zui/wiki/Troubleshooting#opening-an-issue"
+            "https://zui.brimdata.io/docs/support/Troubleshooting#opening-an-issue"
           )
         },
       },


### PR DESCRIPTION
This link was still pointing an an article in the old Brim wiki that I missed when fixing all the others.