### PR TITLE
fix failure in date.test.ts

### DIFF
--- a/src/js/lib/date.test.ts
+++ b/src/js/lib/date.test.ts
@@ -26,14 +26,17 @@ describe("parseInZone", () => {
       // This is very odd, it does 4 minutes and 30 sec instead of 5
       if (zone === "Africa/Monrovia") return
 
-      const ref = new Date(0)
+      // Use "1970-01-02T00:00:00.000Z" instead of 0 because
+      // chrono.strict.parseDate("5 minutes ago", new Date(0)) started returning
+      // 1970-01-01T00:55:00.000Z when daylight saving time began.
+      const ref = new Date("1970-01-02T00:00:00.000Z")
       const date = lib.date.parseInZone(referenceDate, zone, ref)
       const str = lib
         .date(time(date || new Date()).toDate())
         .zone(zone)
         .format(fmt)
 
-      expect(str).toBe("1969 12 31 15 55 00 000")
+      expect(str).toBe("1970 01 01 15 55 00 000")
     })
   })
 


### PR DESCRIPTION
This fixes the following test:unit failure, which first appeared when daylight saving time began.

    $ yarn test:unit date.test.ts --noStackTrace
     FAIL  src/js/lib/date.test.ts
      parseInZone
	✓ strict date in all zones (219 ms)
	✕ reference date in all zones (4 ms)
	✓ casual date in all zones (157 ms)
	✓ relative expression remains (1 ms)
	✓ relative with subtraction
	✓ invalid relative expression

      ● parseInZone › reference date in all zones

	expect(received).toBe(expected) // Object.is equality

	Expected: "1969 12 31 15 55 00 000"
	Received: "1969 12 31 16 55 00 000"

    Test Suites: 1 failed, 1 total
    Tests:       1 failed, 5 passed, 6 total
    Snapshots:   0 total
    Time:        0.797 s, estimated 1 s
    Ran all test suites matching /date.test.ts/i.

Fixes #2724