### PR TITLE
disable Playwright logging in .github/workflows/advance-zed.yml

### DIFF
--- a/.github/workflows/advance-zed.yml
+++ b/.github/workflows/advance-zed.yml
@@ -83,8 +83,6 @@ jobs:
         with:
           options: -screen 0 1280x1024x24
           run: yarn e2e
-        env:
-          DEBUG: pw:api
       - uses: actions/upload-artifact@v2
         if: failure() && steps.playwright.outcome == 'failure'
         with:


### PR DESCRIPTION
The pw:api logs from Playwright are voluminous, and I've never found them to be useful in CI.