### PR TITLE
Make the Export Completed check more strict

### DIFF
--- a/packages/e2e-tests/tests/export.spec.ts
+++ b/packages/e2e-tests/tests/export.spec.ts
@@ -49,7 +49,7 @@ test.describe("Export tests", () => {
       await dialog.getByRole("radio", {name: `${label}`}).click()
       await dialog.getByRole("button").filter({hasText: "Export"}).click()
       await app.mainWin
-        .getByText(new RegExp("Export Completed: .*results." + label))
+        .getByText(new RegExp("Export Completed: .*results\\." + label))
         .waitFor()
 
       expect(fsExtra.statSync(file).size).toBe(expectedSize)

--- a/packages/e2e-tests/tests/export.spec.ts
+++ b/packages/e2e-tests/tests/export.spec.ts
@@ -48,10 +48,9 @@ test.describe("Export tests", () => {
       const dialog = app.mainWin.getByRole("dialog")
       await dialog.getByRole("radio", {name: `${label}`}).click()
       await dialog.getByRole("button").filter({hasText: "Export"}).click()
-
-      await expect(
-        await app.mainWin.locator("text=Export Complete").first()
-      ).toBeVisible()
+      await app.mainWin
+        .getByText(new RegExp("Export Completed: .*results." + label))
+        .waitFor()
 
       expect(fsExtra.statSync(file).size).toBe(expectedSize)
     })


### PR DESCRIPTION
The intermittent failure in #2734 is a pattern that's been seen before, such as described in #2605. The stacking of the "Export Completed" pop-ups make it such that every export after the first is prone to seeing the pop-up from a prior successful export and thinking the one it just initiated has already finished. I believe this can explain why the check for the expected file size can be attempted on a file that's only been partially been written and hence fail the test.

![image](https://user-images.githubusercontent.com/5934157/226710365-9da73092-8e32-41a5-a263-ddd957b6c5b6.png)

Unlike in #2605, in this case the pop-up has enough specific text (the file extension) that we can uniquely wait on the pop-up that references each format.

Fixes #2734