### PR TITLE
Create Suricata Alert View

### DIFF
--- a/src/app/query-home/results/alert-view.ts
+++ b/src/app/query-home/results/alert-view.ts
@@ -7,13 +7,14 @@ export class AlertView extends View {
     return (
       args.type === zed.TypeString &&
       args.field?.name === "event_type" &&
-      args.value.toString() == "alert"
+      args.value.toString() == "alert" &&
+      args.field.rootRecord?.has(["alert", "severity"])
     )
   }
 
   get severity() {
     try {
-      return this.args.field.parent.get(["alert", "severity"]).toString()
+      return this.args.field.rootRecord.get(["alert", "severity"]).toString()
     } catch (_) {
       return "?"
     }

--- a/src/app/query-home/results/alert-view.ts
+++ b/src/app/query-home/results/alert-view.ts
@@ -1,0 +1,30 @@
+import {zed} from "@brimdata/zealot"
+import {InspectArgs} from "src/app/features/inspector/types"
+import {View} from "src/app/features/inspector/views/view"
+
+export class AlertView extends View {
+  static when(args: InspectArgs) {
+    return (
+      args.type === zed.TypeString &&
+      args.field?.name === "event_type" &&
+      args.value.toString() == "alert"
+    )
+  }
+
+  get severity() {
+    try {
+      return this.args.field.parent.get(["alert", "severity"]).toString()
+    } catch (_) {
+      return "?"
+    }
+  }
+
+  get className() {
+    const type = `alert-${this.severity}`
+    return `zeek-path-tag ${type}-bg-color`
+  }
+
+  render() {
+    return `alert (${this.severity})`
+  }
+}

--- a/src/panes/results-pane/inspector.tsx
+++ b/src/panes/results-pane/inspector.tsx
@@ -10,6 +10,7 @@ import {valueContextMenu} from "src/app/menus/value-context-menu"
 import useSelect from "src/app/core/hooks/use-select"
 import {ListViewApi} from "src/zui-kit"
 import {PathView} from "src/app/query-home/results/path-view"
+import {AlertView} from "src/app/query-home/results/alert-view"
 
 export function Inspector(props: {height?: number}) {
   const {values, shapes, width, height, loadMore} = useResultsPaneContext()
@@ -36,7 +37,7 @@ export function Inspector(props: {height?: number}) {
       onScroll={onScroll}
       initialScrollPosition={initialScrollPosition}
       viewConfig={{
-        customViews: [PathView],
+        customViews: [PathView, AlertView],
       }}
       valueExpandedState={{
         value: useSelector(Slice.getExpanded),

--- a/src/panes/results-pane/table.tsx
+++ b/src/panes/results-pane/table.tsx
@@ -14,6 +14,7 @@ import {PathView} from "src/app/query-home/results/path-view"
 import {openLogDetailsWindow} from "src/js/flows/openLogDetailsWindow"
 import {viewLogDetail} from "src/js/flows/viewLogDetail"
 import {zed} from "@brimdata/zealot"
+import {AlertView} from "src/app/query-home/results/alert-view"
 
 export function Table() {
   const {table, setTable} = useResultsContext()
@@ -84,7 +85,7 @@ export function Table() {
         lineLimit: 2,
         rowLimit: 300,
         rowsPerPage: 50,
-        customViews: [PathView, BareStringView],
+        customViews: [AlertView, PathView, BareStringView],
         hideDecorators: true,
       }}
     />


### PR DESCRIPTION
I don't have sample data where we have alert-2 and alert-1s, but the colors should change from yellow to orange to red based on the severity.

I didn't re-order the columns like we used to. It's not clear how to do it in a clean way. Maybe we can revisit if the need comes up again.

fixes: #2738 

<img width="551" alt="Screenshot 2023-03-30 at 11 32 40 AM" src="https://user-images.githubusercontent.com/3460638/228931749-57746d83-5324-463b-ad6c-ca1b9dfcd6f8.png">
<img width="589" alt="Screenshot 2023-03-30 at 11 32 43 AM" src="https://user-images.githubusercontent.com/3460638/228931771-92534bde-85d2-4cf3-98e6-5d80ef2c107f.png">
<img width="633" alt="Screenshot 2023-03-30 at 11 32 47 AM" src="https://user-images.githubusercontent.com/3460638/228931787-4b4791a9-e9ba-498e-90fb-7f1cc1aab4bb.png">
