### PR TITLE
Have Shift+Enter run queries when "Run Query on Enter" is unchecked

### DIFF
--- a/src/app/query-home/search-area/editor/query-editor.tsx
+++ b/src/app/query-home/search-area/editor/query-editor.tsx
@@ -28,8 +28,11 @@ const QueryEditor = ({value, disabled}: Props) => {
   const dispatch = useDispatch()
   const onChange = useCallback((s: string) => dispatch(Editor.setValue(s)), [])
   const onKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter" && !e.shiftKey) {
-      if ((runOnEnter && !e.shiftKey) || (!runOnEnter && cmdOrCtrl(e))) {
+    if (e.key === "Enter") {
+      if (
+        (runOnEnter && !e.shiftKey) ||
+        (!runOnEnter && (e.shiftKey || cmdOrCtrl(e)))
+      ) {
         e.preventDefault()
         dispatch(submitSearch())
       }


### PR DESCRIPTION
Fixes #2763

I tested this out on macOS, Linux, and Windows using the dev artifacts from https://github.com/brimdata/zui/actions/runs/4889204739.
