### PR TITLE
Show notarytool instead of altool in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,7 +194,7 @@ Where `APPLE_ID` is the Apple ID user name (typically an email address), `APPLE_
 Notarization can take some time to complete ("typically less than an hour"). If you want to check on the status of the notarization request, run:
 
 ```bash
-xcrun altool --notarization-history 0 -u <user> -p <app-specific-password>
+xcrun notarytool history --apple-id <apple-user-id> --password <app-specific-password> --team-id <apple-team-id>
 ```
 
 ### Windows Code Signing


### PR DESCRIPTION
Since working on #2779 confirmed that we've already been using `notarytool` for some time and will be using it exclusively going forward due to the deprecation of `altool` for notarization, here I'm switching over the "check notarization status" command line we show in the CONTRIBUTING doc.