### PR TITLE
Error/timeout on network failures during link checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@types/tmp": "^0.2.0",
     "@typescript-eslint/eslint-plugin": "^5.16.0",
     "@typescript-eslint/parser": "^5.16.0",
+    "abort-controller": "^3.0.0",
     "acorn": "^7.4.1",
     "ajv": "^6.9.1",
     "animejs": "^3.2.0",

--- a/src/app/core/links.test.ts
+++ b/src/app/core/links.test.ts
@@ -1,9 +1,21 @@
 import links from "./links"
-import nodeFetch from "node-fetch"
+import fetch from "node-fetch"
+import AbortController from "abort-controller"
 
 const fetchStatusCode = async (link: string): Promise<[string, number]> => {
-  const resp = await nodeFetch(link)
-  return [link, resp.status]
+  const controller = new AbortController()
+  const timeout = setTimeout(() => {
+    controller.abort()
+  }, 1000)
+
+  try {
+    const resp = await fetch(link, {signal: controller.signal})
+    return [link, resp.status]
+  } catch (err) {
+    throw `fetch failed when trying to test link => ${link} (${err})`
+  } finally {
+    clearTimeout(timeout)
+  }
 }
 
 test("no broken links", async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3581,6 +3581,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"abort-controller@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "abort-controller@npm:3.0.0"
+  dependencies:
+    event-target-shim: ^5.0.0
+  checksum: 170bdba9b47b7e65906a28c8ce4f38a7a369d78e2271706f020849c1bfe0ee2067d4261df8bbb66eb84f79208fd5b710df759d64191db58cfba7ce8ef9c54b75
+  languageName: node
+  linkType: hard
+
 "acorn-globals@npm:^6.0.0":
   version: 6.0.0
   resolution: "acorn-globals@npm:6.0.0"
@@ -6728,6 +6737,13 @@ __metadata:
     stream-combiner: ^0.2.2
     through: ^2.3.8
   checksum: 515cdff30c8dd74d5869cf53133b8851deba012605d2a15a1bc77b777b9d237ebf06d99ec62be2c6fc8adb2c89bf392771e2809239b278e5e70ba2f88cd1955c
+  languageName: node
+  linkType: hard
+
+"event-target-shim@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "event-target-shim@npm:5.0.1"
+  checksum: 1ffe3bb22a6d51bdeb6bf6f7cf97d2ff4a74b017ad12284cc9e6a279e727dc30a5de6bb613e5596ff4dc3e517841339ad09a7eec44266eccb1aa201a30448166
   languageName: node
   linkType: hard
 
@@ -14112,6 +14128,7 @@ __metadata:
     "@types/tmp": ^0.2.0
     "@typescript-eslint/eslint-plugin": ^5.16.0
     "@typescript-eslint/parser": ^5.16.0
+    abort-controller: ^3.0.0
     acorn: ^7.4.1
     ajv: ^6.9.1
     animejs: ^3.2.0


### PR DESCRIPTION
For most of yesterday the Zui CI consistently failed in Actions but was running ok locally. The failures were all with the following test:

```
FAIL src/app/core/links.test.ts (5.231 s)
  ● no broken links

    thrown: "Exceeded timeout of 5000 ms for a test.
    Use jest.setTimeout(newTimeout) to increase the timeout value, if this is a long-running test."

       7 | }
       8 |
    >  9 | test("no broken links", async () => {
         | ^
      10 |   const statusCodes = await Promise.all<[string, number]>(
      11 |     Object.values(links).map(fetchStatusCode)
      12 |   )

      at Object.test (src/app/core/links.test.ts:9:1)
```

One shortcoming of this test as it has existed to date is that it's only been wired to catch HTTP-level failures, e.g., if the web site hosting one of the links is responsive but starts returning a 404. However if the site is offline entirely or super slow to respond, we'll only see the error shown above when the test engine gives up after 5 seconds on the overall test.

This PR adds some catching & reporting of errors during link checking that might happen at the network level. To test it, I created this simple Python-based HTTP server that waits 10 seconds before sending an HTTP 200 response.

```
#!/usr/bin/env python3

from http.server import BaseHTTPRequestHandler, HTTPServer
import time

hostName = "0.0.0.0"
serverPort = 9090

class MyServer(BaseHTTPRequestHandler):
    def do_GET(self):
        time.sleep(10)
        self.send_response(200)
        self.send_header("Content-type", "text/html")
        self.end_headers()
        self.wfile.write(bytes("<html><head><title>https://pythonbasics.org</title></head>", "utf-8"))
        self.wfile.write(bytes("<p>Request: %s</p>" % self.path, "utf-8"))
        self.wfile.write(bytes("<body>", "utf-8"))
        self.wfile.write(bytes("<p>This is an example web server.</p>", "utf-8"))
        self.wfile.write(bytes("</body></html>", "utf-8"))

if __name__ == "__main__":        
    webServer = HTTPServer((hostName, serverPort), MyServer)
    print("Server started http://%s:%s" % (hostName, serverPort))

    try:
        webServer.serve_forever()
    except KeyboardInterrupt:
        pass

    webServer.server_close()
    print("Server stopped.")
```

Running this on a scratch AWS VM and adding a link to it in `links.ts`, here's how it the enhanced code looks when catching this failure:

```
FAIL  src/app/core/links.test.ts
  ● no broken links

    thrown: "fetch failed when trying to test link => http://ec2-18-218-75-108.us-east-2.compute.amazonaws.com:9090 (AbortError: The user aborted a request.)"

      19 | }
      20 |
    > 21 | test("no broken links", async () => {
         | ^
      22 |   const statusCodes = await Promise.all<[string, number]>(
      23 |     Object.values(links).map(fetchStatusCode)
      24 |   )

      at Object.test (src/app/core/links.test.ts:21:1)
```

And if I stop the server entirely such that port 9090 is open in the AWS Security Group but nothing's listening to accept the connection, we see:

```
 FAIL  src/app/core/links.test.ts
  ● no broken links

    thrown: "fetch failed when trying to test link => http://ec2-18-218-75-108.us-east-2.compute.amazonaws.com:9090 (FetchError: request to http://ec2-18-218-75-108.us-east-2.compute.amazonaws.com:9090/ failed, reason: connect ECONNREFUSED 18.218.75.108:9090)"

      19 | }
      20 |
    > 21 | test("no broken links", async () => {
         | ^
      22 |   const statusCodes = await Promise.all<[string, number]>(
      23 |     Object.values(links).map(fetchStatusCode)
      24 |   )

      at Object.test (src/app/core/links.test.ts:21:1)
```

Finally, if I tweak the server to respond right away but with a 404, the test still catches & reports the error it always did:

```
 FAIL  src/app/core/links.test.ts
  ● no broken links

    thrown: "Broken link => http://ec2-18-218-75-108.us-east-2.compute.amazonaws.com:9090: 404"

      19 | }
      20 |
    > 21 | test("no broken links", async () => {
         | ^
      22 |   const statusCodes = await Promise.all<[string, number]>(
      23 |     Object.values(links).map(fetchStatusCode)
      24 |   )

      at Object.test (src/app/core/links.test.ts:21:1)
```

The choice of setting the timeout to 1000 ms was somewhat arbitrary, but here's my thinking. The overall Jest timeout is 5 seconds, and all the link tests need to complete within that amount of time for the test to succeed (correct?). A healthy web site that's even on the other side of the country should probably respond in less than 100 ms, so I figured setting it to 1000 ms means a site that's having some kind of temporary outage could time out such that the test would catch/report it and still move on and test the remainder of the links in the remaining 4 seconds. Like all other timeouts, we could surely adjust this going forward if we find it's too sensitive or forgiving.

In terms of what we can do with this new info, like the link failure reports we get from our website/docs deployment CI, knowing which precise link(s) are failing could help us to narrow down if we're seeing consistent failures with one particular site, if they're only failing from Actions or from everywhere, etc. In addition to letting us ignore benign/temporary failures with more confidence, it may help us to sniff out if the sites we rely on start to become unreliable.