### PR TITLE
Upgrade to Go 1.20

### DIFF
--- a/.github/actions/setup-zui/action.yml
+++ b/.github/actions/setup-zui/action.yml
@@ -6,7 +6,7 @@ runs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: "1.19"
+        go-version: "1.20"
 
     - name: Install Node
       uses: actions/setup-node@v3


### PR DESCRIPTION
This parallels brimdata/zed#4690, which upgrades Zed to Go 1.20.