### PR TITLE
Ensure all initializers export a function called initialize.

### DIFF
--- a/CODE.md
+++ b/CODE.md
@@ -65,4 +65,4 @@ The plugin api runs in the Node main process and is given to plugin authors to e
 
 _Main Process Initializers_
 
-Code that needs to be run one time before the app starts up can be put in an initializer. An initializer is a file that lives in the folder `src/electron/initializers/`. It must export a function named _initialize(main)_ that takes the Main Object as it's only argument. See the FAQ for an example of creating a new initializer.
+Code that needs to be run one time before the app starts up can be put in an initializer. An initializer is a file that lives in the folder `src/electron/initializers/`. It must export a function named _initialize(main)_ that takes the Main Object as its only argument. See the FAQ for an example of creating a new initializer.

--- a/CODE.md
+++ b/CODE.md
@@ -2,6 +2,19 @@
 
 This is here to document the design patterns chosen by the developers. It documents structures, abstractions, and philosophy in this repo.
 
+## FAQs
+
+How do I add a main process initializer?
+
+1. Create a new file in `src/electron/initializers/`.
+2. Add the following line to `src/electron/initializers/index.ts`.
+
+```
+export * as myNewInitializer from "./my-new-initializer"
+```
+
+Export all symbols as a camel cased alias of the file name. This will now run automatically when the app starts.
+
 ## Folders
 
 Documentation for where code should go.
@@ -49,3 +62,7 @@ A message is a TypeScript type defining a name and a set of arguments. Messages 
 _Plugin Api_
 
 The plugin api runs in the Node main process and is given to plugin authors to extend the app. It should not have privileged access to everything. Only what is useful for plugin authors. This means it should not contain references to the full store or the main process. Instead, it exposes methods that in turn call operations. Operations are not exposed to plugins and therefore have the main object and store in scope. The pattern should be: plugin-api exposes a simple method which then runs an operation.
+
+_Main Process Initializers_
+
+Code that needs to be run one time before the app starts up can be put in an initializer. An initializer is a file that lives in the folder `src/electron/initializers/`. It must export a function named _initialize(main)_ that takes the Main Object as it's only argument. See the FAQ for an example of creating a new initializer.

--- a/src/electron/initializers/commands.ts
+++ b/src/electron/initializers/commands.ts
@@ -1,3 +1,7 @@
 // Import all the commands so that they get registered in the command center
 
 import "src/domain/commands"
+
+export function initialize() {
+  // No op
+}

--- a/src/electron/initializers/index.ts
+++ b/src/electron/initializers/index.ts
@@ -1,4 +1,4 @@
-export * from "./auto-update"
+export * as autoUpdate from "./auto-update"
 export * as commands from "./commands"
 export * as customProtocol from "./custom-protocol"
 export * as logFilters from "./log-filters"

--- a/src/electron/initializers/menus.ts
+++ b/src/electron/initializers/menus.ts
@@ -1,3 +1,7 @@
 // Import all menus here to register them
 
 import "src/domain/menus"
+
+export function initialize() {
+  // No op
+}

--- a/src/electron/run-main/run-initializers.ts
+++ b/src/electron/run-main/run-initializers.ts
@@ -4,9 +4,14 @@ import * as initializers from "../initializers"
 
 export async function runInitializers(main: ZuiMain) {
   for (const name in initializers) {
+    console.log("name", name)
     const mod = initializers[name]
     if ("initialize" in mod) {
       mod.initialize(main)
+    } else {
+      throw new Error(
+        `Expected file "${name}" to export a function named "initialize" but none was found.`
+      )
     }
   }
   log.info(`initializers loaded`)

--- a/src/electron/run-main/run-initializers.ts
+++ b/src/electron/run-main/run-initializers.ts
@@ -4,7 +4,6 @@ import * as initializers from "../initializers"
 
 export async function runInitializers(main: ZuiMain) {
   for (const name in initializers) {
-    console.log("name", name)
     const mod = initializers[name]
     if ("initialize" in mod) {
       mod.initialize(main)


### PR DESCRIPTION
The auto update initializer was not running because it did not alias itself when exporting its symbols in the src/electron/initializers/index.ts file. When initializers are run, they check if the name has a function called "initialize". Since the auto update export had no name, its name was "initialize". Then when the code checked if "initialize" had an "initialize" function, it was false.

The changes here are:
1. Now if that check returns false, we will throw an error.
2. The auto-update.ts initializer is now exported with an alias so that it works when called by src/electron/run-main/run-initializers.ts.
3. I added documentation of all this in CODE.md for my future self.

Fixes #2778 