### PR TITLE
Create settings with defaults when a pool is created

### DIFF
--- a/src/domain/pools/messages.ts
+++ b/src/domain/pools/messages.ts
@@ -12,6 +12,7 @@ export type PoolsOperations = {
 
   "pools.update": (lakeId: string, update: PoolUpdate | PoolUpdate[]) => void
   "pools.load": (poolId: string, data: string, opts: Partial<LoadOpts>) => void
+  "pools.createSettings": (id: string) => void
   "pools.updateSettings": (update: Update<PoolSetting>) => void
   "pools.getSettings": (id: string) => PoolSetting | null
 }

--- a/src/domain/pools/operations.ts
+++ b/src/domain/pools/operations.ts
@@ -50,8 +50,7 @@ export const createSettings = createOperation(
 export const updateSettings = createOperation(
   "pools.updateSettings",
   async ({main}, update) => {
-    const {dispatch} = main.store
-    dispatch(PoolSettings.update(update))
+    main.store.dispatch(PoolSettings.update(update))
   }
 )
 

--- a/src/domain/pools/operations.ts
+++ b/src/domain/pools/operations.ts
@@ -3,6 +3,7 @@ import {createOperation} from "src/core/operations"
 import {CreatePoolOpts, LoadOpts} from "@brimdata/zed-js"
 import {lake, pools} from "src/zui"
 import PoolSettings from "src/js/state/PoolSettings"
+import {getDefaults} from "src/js/state/PoolSettings/selectors"
 
 export const create = createOperation(
   "pools.create",
@@ -39,11 +40,17 @@ export const load = createOperation(
   }
 )
 
+export const createSettings = createOperation(
+  "pools.createSettings",
+  async ({main}, id: string) => {
+    main.store.dispatch(PoolSettings.create({id, ...getDefaults()}))
+  }
+)
+
 export const updateSettings = createOperation(
   "pools.updateSettings",
   async ({main}, update) => {
-    const dispatch = main.store.dispatch
-    dispatch(PoolSettings.create({id: update.id as string}))
+    const {dispatch} = main.store
     dispatch(PoolSettings.update(update))
   }
 )

--- a/src/plugins/core-pool/index.ts
+++ b/src/plugins/core-pool/index.ts
@@ -1,10 +1,13 @@
 import {FieldPath} from "src/core/field-path"
+import {createSettings} from "src/domain/pools/operations"
 import {pools, PluginContext} from "src/zui"
 
 export function activate(_ctx: PluginContext) {
   pools.on("create", ({pool}) => {
-    const poolKeyAccessor = new FieldPath(pool.layout.keys[0]).toString()
+    createSettings.run(pool.id)
 
-    pools.configure(pool.id).set("timeField", poolKeyAccessor)
+    pools
+      .configure(pool.id)
+      .set("timeField", new FieldPath(pool.layout.keys[0]).toString())
   })
 }


### PR DESCRIPTION
Fixes #2792

Before "updating" settings, we need to "create" the settings with the default values. The problem here was we were creating things without the defaults.