### PR TITLE
Clone array before storing in redux

### DIFF
--- a/src/core/query/run.ts
+++ b/src/core/query/run.ts
@@ -39,8 +39,10 @@ function run(id: string): Thunk<Promise<ResultStream | null>> {
         tabId,
       })
       res.collect(({rows, shapesMap}) => {
-        const values = isFirstPage ? rows : [...prevVals, ...rows]
-        const shapes = isFirstPage ? shapesMap : {...prevShapes, ...shapesMap}
+        const values = isFirstPage ? [...rows] : [...prevVals, ...rows]
+        const shapes = isFirstPage
+          ? {...shapesMap}
+          : {...prevShapes, ...shapesMap}
         dispatch(Results.setValues({id, tabId, values}))
         dispatch(Results.setShapes({id, tabId, shapes}))
       }, {})


### PR DESCRIPTION
When we put things in our Redux store, it "for our convenience" makes objects and arrays non-extensible. The problem here was that while that object was frozen, the zealot lib tried to add to it. If we make a copy before putting it in the store, our problems get solved.

This appeared with the s3 backed lake because of the latency. Also, this does not happen in production I don't think.

Error "Cannot add property" when accessing pool on S3-backed Zed service

Fixes #2798