### PR TITLE
Remove NaN-related errors when rendering historgram

### DIFF
--- a/src/pages/pools/show.tsx
+++ b/src/pages/pools/show.tsx
@@ -63,7 +63,6 @@ export function InitPool({children}) {
   const dispatch = useDispatch<AppDispatch>()
   const poolId = usePoolId()
   const pool = useSelector(Current.getPool)
-  console.log(poolId, pool)
 
   useEffect(() => {
     if (poolId) dispatch(syncPool(poolId))

--- a/src/panes/histogram-pane/d3-stacked-histogram.tsx
+++ b/src/panes/histogram-pane/d3-stacked-histogram.tsx
@@ -21,8 +21,8 @@ export const D3StackedHistogram = memo(function D3StackedHistogram(props: {
 }) {
   // Dimensions
   const {width, height, margin} = props
-  const innerWidth = width - margin.left - margin.right
-  const innerHeight = height - margin.top - margin.bottom
+  const innerWidth = Math.max(1, width - margin.left - margin.right)
+  const innerHeight = Math.max(1, height - margin.top - margin.bottom)
 
   // Scales
   const {xScale, yScale, colorScale, interval} = props

--- a/src/panes/histogram-pane/pane.tsx
+++ b/src/panes/histogram-pane/pane.tsx
@@ -8,7 +8,7 @@ import {Toolbar} from "src/components/toolbar"
 import {Title} from "./title"
 
 export function HistogramPane() {
-  const {Parent, width, height} = useParentSize()
+  const {Parent, width = 0, height = 0} = useParentSize()
   const show = useSelector(Layout.getShowHistogram)
 
   if (!show) return null


### PR DESCRIPTION
Initialize the width and height variables when they are undefined.

Fixes #2800