### PR TITLE
Add newlines to histogram queries

### DIFF
--- a/src/panes/histogram-pane/run-query.ts
+++ b/src/panes/histogram-pane/run-query.ts
@@ -59,8 +59,8 @@ export async function runHistogramQuery(api: ZuiApi) {
   }
 
   async function getNullTimeCount() {
-    const query = `${baseQuery}
-    | ${timeField} == null | count()`
+    // Newline after baseQuery in case it ends with a comment.
+    const query = `${baseQuery}\n | ${timeField} == null | count()`
     const id = "null-time-count"
     const resp = await api.query(query, {id, tabId})
     const [count] = await resp.js()
@@ -68,8 +68,8 @@ export async function runHistogramQuery(api: ZuiApi) {
   }
 
   async function getMissingTimeCount() {
-    const query = `${baseQuery}
-    | !has(${timeField}) | count()`
+    // Newline after baseQuery in case it ends with a comment.
+    const query = `${baseQuery}\n | !has(${timeField}) | count()`
     const id = "missing-time-count"
     const resp = await api.query(query, {id, tabId})
     const [count] = await resp.js()
@@ -83,8 +83,8 @@ export async function runHistogramQuery(api: ZuiApi) {
 
     const {unit, number, fn} = getInterval(range)
     const interval = `${number}${timeUnits[unit]}`
-    const query = `${baseQuery}
-    | ${timeField} != null | count() by time := bucket(${timeField}, ${interval}), group := ${colorField} | sort time`
+    // Newline after baseQuery in case it ends with a comment.
+    const query = `${baseQuery}\n | ${timeField} != null | count() by time := bucket(${timeField}, ${interval}), group := ${colorField} | sort time`
     const resp = await api.query(query, {id, tabId})
     api.dispatch(Histogram.setInterval({unit, number, fn}))
     api.dispatch(Histogram.setRange(range))

--- a/src/panes/histogram-pane/run-query.ts
+++ b/src/panes/histogram-pane/run-query.ts
@@ -59,7 +59,8 @@ export async function runHistogramQuery(api: ZuiApi) {
   }
 
   async function getNullTimeCount() {
-    const query = `${baseQuery} | ${timeField} == null | count()`
+    const query = `${baseQuery}
+    | ${timeField} == null | count()`
     const id = "null-time-count"
     const resp = await api.query(query, {id, tabId})
     const [count] = await resp.js()
@@ -67,7 +68,8 @@ export async function runHistogramQuery(api: ZuiApi) {
   }
 
   async function getMissingTimeCount() {
-    const query = `${baseQuery} | !has(${timeField}) | count()`
+    const query = `${baseQuery}
+    | !has(${timeField}) | count()`
     const id = "missing-time-count"
     const resp = await api.query(query, {id, tabId})
     const [count] = await resp.js()
@@ -81,7 +83,8 @@ export async function runHistogramQuery(api: ZuiApi) {
 
     const {unit, number, fn} = getInterval(range)
     const interval = `${number}${timeUnits[unit]}`
-    const query = `${baseQuery} | ${timeField} != null | count() by time := bucket(${timeField}, ${interval}), group := ${colorField} | sort time`
+    const query = `${baseQuery}
+    | ${timeField} != null | count() by time := bucket(${timeField}, ${interval}), group := ${colorField} | sort time`
     const resp = await api.query(query, {id, tabId})
     api.dispatch(Histogram.setInterval({unit, number, fn}))
     api.dispatch(Histogram.setRange(range))


### PR DESCRIPTION
The issue in #2819 looks to be a revisit of what we first saw in #2452. Like that issue, it seems the fix is as simple as adding a newline after the user's base query so that way the additional Zed that app tacks on will still be active even if the user's program ended with a comment.

Regarding coding style, I wasn't sure if indents were necessary to make it obvious that these string literals spanned multiple lines. However, the prior fix in #2519 didn't have indents and what I've got in this branch seems to pass the linter.

I've put down @nwt as an additional reviewer just to double check that there's no negative side effects we can think of from these newlines being added.

Here's the video evidence on this branch of the fix working for the three variations laid out in #2819

https://github.com/brimdata/zui/assets/5934157/0dced062-47d7-4f34-a244-1e43f716d085

Note that I've not tried to dig into the "TypeError: Cannot add property 2000, object is not extensible" error I showed in #2819 since that's a bit beyond my expertise. As I expected, my fixes here seem to prevent that error from being triggered anymore, but maybe there's still something to look closer at there.

Fixes #2819