### PR TITLE
Fix links and paths

### DIFF
--- a/docs/advanced/Remote-Zed-Lakes.md
+++ b/docs/advanced/Remote-Zed-Lakes.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Remote Zed Lakes
 
-By default, the Zui application connects to a [Zed lake](https://zed.brimdata.io/docs/commands/zed/#1-the-lake-model)
+By default, the Zui application connects to a [Zed lake](https://zed.brimdata.io/docs/commands/zed#the-lake-model)
 on the system on which it is launched. However, Zui is capable of accessing
 data stored in a Zed lake on a remote system. This article describes the
 available options and current limitations.
@@ -32,7 +32,7 @@ However, the overall app experience is powered by a distributed "backend"
 architecture that includes multiple components.
 
 One essential component is the Zed lake which is accessed via a
-[`zed serve`](https://zed.brimdata.io/docs/commands/zed/#213-serve)
+[`zed serve`](https://zed.brimdata.io/docs/commands/zed#serve)
 process that manages the storage and querying of imported data. Operations on
 the Zed lake are invoked via a [REST API](https://zed.brimdata.io/docs/lake/api/)
 that's utilized by a "client", such as the Zui app. The
@@ -83,7 +83,7 @@ For our example remote host, we'll use a Linux Ubuntu 22.04 VM running in
 Amazon AWS. Because Zui interacts with `zed serve` over a REST API that
 is still evolving, care should be taken to ensure the Zui version being
 installed on the remote side matches the version being run locally. In this
-article we'll use Zui v1.0.0, which includes Zed v1.6.0.
+article we'll use Zui v1.2.0, which includes Zed v1.9.0.
 
 Even though our VM on AWS has no graphical interface, we'll install the full
 Zui package because it includes the compatible Zed binaries as well as a
@@ -91,9 +91,9 @@ bundled [Brimcap](https://github.com/brimdata/brimcap) that will prove useful
 if we want to import packet capture data.
 
 ```
-ubuntu# wget --quiet https://github.com/brimdata/zui/releases/download/v1.0.0/Zui-1.0.0.deb
+ubuntu# wget --quiet https://github.com/brimdata/zui/releases/download/v1.2.0/zui_1.2.0_amd64.deb
 ubuntu# sudo apt update
-ubuntu# sudo apt install -y ./Zui-1.0.0.deb
+ubuntu# sudo apt install -y ./zui_1.2.0_amd64.deb
 ```
 
 The following additional steps are also currently necessary to work around
@@ -121,7 +121,7 @@ see. Therefore we'll start `zed serve` manually from the
 platform as follows:
 
 ```
-ubuntu# mkdir -p ~/.config/Zui/lake ~/.config/Zui/data/brimcap-root ~/.config/Zui/logs
+ubuntu# mkdir -p ~/.config/Zui/lake ~/.config/Zui/plugins/brimcap/storage/root ~/.config/Zui/logs
 ubuntu# /opt/Zui/resources/app.asar.unpacked/zdeps/zed serve \
           -l :9867 \
           -lake $HOME/.config/Zui/lake \
@@ -192,7 +192,7 @@ shown above. See [brimcap/105](https://github.com/brimdata/brimcap/issues/105) f
 Another_User_macOS# wget --quiet https://archive.wrccdc.org/pcaps/2018/wrccdc.2018-03-23.010014000000000.pcap.gz
 Another_User_macOS# gunzip wrccdc.2018-03-23.010014000000000.pcap.gz
 Another_User_macOS# export PATH="/Applications/Zui.app/Contents/Resources/app.asar.unpacked/zdeps:$PATH"
-Another_User_macOS# brimcap index -root "$HOME/Library/Application Support/Zui/data/brimcap-root" -r wrccdc.2018-03-23.010014000000000.pcap
+Another_User_macOS# brimcap index -root "$HOME/Library/Application Support/Zui/plugins/brimcap/storage/root" -r wrccdc.2018-03-23.010014000000000.pcap
 ```
 
 A connection to a remote lake can be removed by selecting the **Get Info**

--- a/docs/support/Filesystem-Paths.md
+++ b/docs/support/Filesystem-Paths.md
@@ -60,7 +60,7 @@ each supported platform is:
 Particular categories of saved data are held under this path. Specific
 categories of interest include:
 
-   * `data` (subdirectory) - Storage used by tools bundled with Zui, such as
+   * `plugins` (subdirectory) - Storage used by tools bundled with Zui, such as
      [Brimcap](https://github.com/brimdata/brimcap).
 
    * `lake` (subdirectory) - Storage for the local Zed lake that holds data imported into Zui.

--- a/docs/support/Troubleshooting.md
+++ b/docs/support/Troubleshooting.md
@@ -92,7 +92,7 @@ and details to [zui/1490](https://github.com/brimdata/zui/issues/1490).
 In all other cases, please [open a new issue](#opening-an-issue).
 
 To begin troubleshooting this, it helps to understand the "backend" of Zui.
-One essential component is a [Zed lake](https://zed.brimdata.io/docs/commands/zed/#1-the-lake-model),
+One essential component is a [Zed lake](https://zed.brimdata.io/docs/commands/zed#the-lake-model),
 a server-style process that manages the storage and querying of imported data.
 Operations in the pools of a Zed lake are invoked via a [REST
 API](https://zed.brimdata.io/docs/lake/api/) that's


### PR DESCRIPTION
Recent changes to the organization of the Zed docs and the move of some filesystem paths in #2759 made a couple things go stale in the Zui docs as of when I put out the new releases yesterday. I'm fixing all that here. I've seen a build of this run clean in a broken link checker on a personal staging deploy based on this branch. I also ran through the updated Remote Lakes article on a scratch AWS VM to make sure it's all correct with the new GA releases.