### PR TITLE
Don't require Community ID on all pcap-eligible conn records

### DIFF
--- a/apps/zui/src/plugins/brimcap/zeek/queries.ts
+++ b/apps/zui/src/plugins/brimcap/zeek/queries.ts
@@ -26,7 +26,6 @@ export function findConnLog(pool: string, uid: string) {
     uidFilter(uid) +
     `)
   | is(ts, <time>) 
-  | is(community_id, <string>) 
   | is(duration, <duration>) 
   | is(uid, <string>)
   | head 1


### PR DESCRIPTION
Fixes #2827, which has all the background.

The attached video shows the fix having the desired effect: Now when I have a `conn` log that lacks a `community_id` field that meets all the other requirements, the Packets button still lights up.

https://github.com/brimdata/zui/assets/5934157/163d9dfd-98b3-4a21-b323-dfc24253f62b
