### PR TITLE
If insiders release workflow finds same SHA, exit early with success

### DIFF
--- a/.github/workflows/release-insiders.yml
+++ b/.github/workflows/release-insiders.yml
@@ -17,17 +17,19 @@ jobs:
           owner: brimdata
           repo: zui-insiders
       - name: Download last build_sha
-        run: curl -L https://github.com/brimdata/zui-insiders/releases/download/${{ steps.latest_release.outputs.release }}/build_sha.txt > build_sha.txt
-      - name: Compare last build_sha to current sha
+        id: latest_sha
         run: |
-          [[ $(cat build_sha.txt) != ${{ github.sha }} ]]
+          curl -L https://github.com/brimdata/zui-insiders/releases/download/${{ steps.latest_release.outputs.release }}/build_sha.txt > build_sha.txt
+          echo "sha=$(cat build_sha.txt)" >> $GITHUB_OUTPUT
 
     outputs:
       version: ${{ steps.latest_release.outputs.release }}
+      latest_sha: ${{ steps.latest_sha.outputs.sha }}
 
   release:
     name: Publish Release
     needs: check_latest
+    if: ${{ needs.check_latest.outputs.latest_sha != github.sha }}
     strategy:
       matrix:
         platform: [windows-2019, macos-12, ubuntu-20.04]


### PR DESCRIPTION
Currently when the Zui Insiders release workflow finds the SHA has not changed since the last release, it exits as a red failure. Since PRs merge to `main` on Zui infrequently, this is likely to happen often, so I'm concerned this would get us out of the habit of checking the outputs when they "fail" and hence be at risk of missing legit failures. The changes in this PR make it so that the workflow will instead exit early as successful when the SHA hasn't changed.

FWIW, I first tested out the logic in a personal repo's workflow https://github.com/philrz/build-sha-test/blob/main/.github/workflows/foo.yml.