### PR TITLE
Interact with the editor correctly

### DIFF
--- a/apps/zui/src/app/query-home/search-area/zed-editor.tsx
+++ b/apps/zui/src/app/query-home/search-area/zed-editor.tsx
@@ -34,6 +34,9 @@ export function ZedEditor(props: {
       onMount={(editor) => {
         ref.current = editor
       }}
+      wrapperProps={{
+        "aria-label": "main-editor",
+      }}
       path={props.path}
     />
   )

--- a/packages/e2e-tests/helpers/test-app.ts
+++ b/packages/e2e-tests/helpers/test-app.ts
@@ -82,9 +82,15 @@ export default class TestApp {
   }
 
   async query(zed: string): Promise<void> {
-    await this.mainWin.locator('div[role="textbox"]').fill(zed);
+    await this.setEditor(zed);
     await this.mainWin.locator('[aria-label="run-query"]').click();
     await this.mainWin.locator('span[aria-label="fetching"]').isHidden();
+  }
+
+  async setEditor(zed: string) {
+    await this.mainWin.locator('[aria-label=main-editor]').click();
+    await this.mainWin.keyboard.press('Meta+KeyA');
+    await this.mainWin.keyboard.type(zed);
   }
 
   async getViewerResults(includeHeaders = true): Promise<string[]> {

--- a/packages/e2e-tests/tests/queries.spec.ts
+++ b/packages/e2e-tests/tests/queries.spec.ts
@@ -75,16 +75,15 @@ test.describe('Query tests', () => {
     await titleBar
       .locator('[placeholder="Query name\\.\\.\\."]')
       .fill('Another Test Query');
-    await app.mainWin
-      .locator('div[role="textbox"]')
-      .fill('another test query zed value');
+
+    await app.setEditor('another test query zed value');
     await titleBar.getByRole('button', { name: 'Create' }).click();
     await expect(
       await app.mainWin.locator('button :text-is("Another Test Query")')
     ).toBeVisible();
     await expect(
       await app.mainWin.locator(
-        'div[role="textbox"]:has-text("another test query zed value")'
+        '[aria-label=main-editor]:has-text("another test query zed value")'
       )
     ).toBeVisible();
   });


### PR DESCRIPTION
We just needed to target and fill in the new editor slightly differently.