### PR TITLE
Only use Meta+KeyA combo to Select All on macOS

### DIFF
--- a/packages/e2e-tests/helpers/test-app.ts
+++ b/packages/e2e-tests/helpers/test-app.ts
@@ -89,7 +89,7 @@ export default class TestApp {
 
   async setEditor(zed: string) {
     await this.mainWin.locator('[aria-label=main-editor]').click();
-    await this.mainWin.keyboard.press('Meta+KeyA');
+    await this.mainWin.keyboard.press(isMac() ? 'Meta+KeyA' : 'Control+KeyA');
     await this.mainWin.keyboard.type(zed);
   }
 


### PR DESCRIPTION
The e2e tests recently started showing consistent failures in Actions with this symptom:

```
  3) queries.spec.ts:18:3 › Query tests › session queries are the default and ordered properly in history 

    Error: expect(received).toEqual(expected) // deep equality

    - Expected  - 2
    + Received  + 2

      Array [
    -   "from 'sample.tsv' | 3 now",
    -   "from 'sample.tsv' | 2 now",
    +   "from 'sample.tsv' | 123 now",
    +   "from 'sample.tsv' | 12 now",
        "from 'sample.tsv' | 1 now",
      ]

      31 |       "from 'sample.tsv' | 1 now",
      32 |     ];
    > 33 |     expect(entries).toEqual(expected);
         |                     ^
      34 |   });
      35 |
      36 |   test("named queries' creation, modification, update/save, proper outdated status display", async () => {

        at /home/runner/work/zui/zui/packages/e2e-tests/tests/queries.spec.ts:33:21
        at runMicrotasks (<anonymous>)
```

However, they ran fine when I ran them locally on my Macbook. After reproducing it locally on Linux I could see that the problem was because the test was hard-wired to do a "select all" key combination in the editor that would only work on macOS. Since that combo wasn't working on Linux where the CI runs in Actions, the tests kept appending to whatever was already in the editor.

https://github.com/brimdata/zui/actions/runs/5914897601/job/16040645301 shows the e2e tests now finishing successfully in Actions.