### PR TITLE
Wait for Load Successful to disappear first in pool-loads e2e test

### DIFF
--- a/packages/e2e-tests/tests/pool-loads.spec.ts
+++ b/packages/e2e-tests/tests/pool-loads.spec.ts
@@ -18,9 +18,9 @@ test.describe("Pool Loads", () => {
     await app.createPool([getPath("prs.json")])
     await app.mainWin.getByRole("button", {name: "Query Pool"}).click()
     await app.query("count()")
+    await app.mainWin.getByText("Load Successful").waitFor({state: "hidden"})
     const results = await app.getViewerResults()
     expect(results).toEqual(["this", "1"])
-    await app.mainWin.getByText("Load Successful").waitFor({state: "hidden"})
   })
 
   test("load more data into the pool", async () => {
@@ -32,9 +32,9 @@ test.describe("Pool Loads", () => {
     await app.mainWin.getByText("Load Successful").waitFor()
     await app.mainWin.getByRole("button", {name: "Query Pool"}).click()
     await app.query("count()")
+    await app.mainWin.getByText("Load Successful").waitFor({state: "hidden"})
     const results = await app.getViewerResults()
     expect(results).toEqual(["this", "2"])
-    await app.mainWin.getByText("Load Successful").waitFor({state: "hidden"})
   })
 
   test("create with bad data deletes pool", async () => {


### PR DESCRIPTION
In a recent group discussion about some of the approaches proposed to address #2843, @jameskerr expressed a preference for the 2nd proposal that "tagged" queries and their results. However, since implementing that would require @jameskerr to interrupt his other priorities, I went ahead and tested the changes in this PR that are what's described in the 3rd proposal. I tested it out using my Linux VM with the config/script described in https://github.com/brimdata/zui/issues/2843#issuecomment-1694016932. The tests confirmed that these changes do indeed greatly improve reliability of the test, as a baseline run of the `cycle.sh` at Zui commit 3d3b66d saw 18 failures out of 200 runs, whereas f9fc137 running the `cycle.sh` at Zui commit f9fc137 from this branch saw 0 failures out of 200 runs.

I still feel that we'll ultimately want to go ahead with the 2nd proposal from #2843 since that would potentially help all tests that issue queries and check results whereas the changes in this PR just improve one particular test. However, since these changes should greatly reduce the number of e2e failures in the meantime, I'm game to see them merged.
