### PR TITLE
Check array is non-empty before referencing 0th element

### DIFF
--- a/apps/zui/src/js/lib/date.ts
+++ b/apps/zui/src/js/lib/date.ts
@@ -46,7 +46,7 @@ date.parseInZone = (string, zone, ref?) => {
   } else {
     if (/^\s*now.*/i.test(string)) return null
     const d = chrono.casual.parse(string, ref)
-    if (d && d[0].text == string) {
+    if (d && d.length > 0 && d[0].text == string) {
       return time(d[0].date()).toTs()
     } else {
       return null


### PR DESCRIPTION
A console debug message indicated that when the crash in #2853 was occurring, the `d` value returned from `chrono.casual.parse()` was the empty array `[]`. As shown in the attached video based on this branch, it therefore looks like just checking that this array is non-empty is enough to avoid the crash.

https://github.com/brimdata/zui/assets/5934157/e11d24aa-1c22-43f7-9a1d-7bdfb41ae321

Fixes #2853