### PR TITLE
Filter out Suricata rules when assembling zdeps on Windows

### DIFF
--- a/apps/zui/scripts/download-zdeps/index.js
+++ b/apps/zui/scripts/download-zdeps/index.js
@@ -111,11 +111,24 @@ async function zedDevBuild(destPath) {
   }
 }
 
+// Suricata rules are dropped from the Windows build to fix a false positive
+// malware flagging. See https://github.com/brimdata/zui/issues/2857.
+const filterBrimcapZdeps = (src, dest) => {
+  if (process.platform == "win32" &&
+      (/suricata\.rules$/.test(src) || /emerging\.rules\.tar\.gz$/.test(src)) &&
+      fs.statSync(src).isFile()) {
+    return false
+  } else {
+    return true
+  }
+}
+
 async function main() {
   try {
     fs.copySync(
       path.resolve("..", "..", "node_modules", "brimcap", "build", "dist"),
-      zdepsPath
+      zdepsPath,
+      { filter: filterBrimcapZdeps }
     )
     const brimcapVersion = child_process
       .execSync(path.join(zdepsPath, "brimcap") + " -version")


### PR DESCRIPTION
When investigating the reports linked from #2857, one of the high-level patterns observed was reference to the Suricata rules that ship with Zui as part of Brimcap. Thinking these might be a root cause of the many evidence-of-malware flaggings found in the reports, one of our community members that works in the cybercrime team at Mandiant/Google confirmed our suspicion that this might be a root cause of some/all of the problems.

> the sandbox detections on the rulesets makes sense to me, ive seen that problem with other rulesets in the past where AV sigs are too loose and hit on detections for malware instead of the malware itself. 

The shipped fallback rule sets have always been "nice to have" because they'd potentially allow some initial alerts even when installing Zui in an airgapped environment. However, these rules are arguably out-of-date by the time the user installs Zui since they're frozen at the time Zui is built & shipped. Meanwhile, almost all users are surely Internet connected and will hence get up-to-date rules the first time they launch Zui. So as much as we'd prefer it if all the vendors saw the rules as harmless, the approach in this PR takes the shortcut of just dropping the rules files from the Windows build.

With a Dev Build based on this branch, [this VirusTotal report](https://www.virustotal.com/gui/file/3cd9267713f5b8b11e211e5284c30f6783eb71a79ea6c6599897aca862f31b23) shows zero out of 66 vendors flagging it for evidence of malware, compared with the 16/69 shown with the GA Zui v1.3.0 build in #2857.

![image](https://github.com/brimdata/zui/assets/5934157/d9659578-e939-4f20-8c51-b2268c5c1f8f)

Likewise [this Recorded Future Triage report](https://tria.ge/231016-v7hyxach23) shows a score of 4/10 (which is not shown in "red"), compared with the 10/10 shown with the GA Zui v1.3.0 build in #2857.

![image](https://github.com/brimdata/zui/assets/5934157/9e7a1189-ee94-492a-b530-becb0d38d1ef)

Tests I've run with the Dev Build:

1. Confirmed on Windows that the `suricata.rules` and `70d9eddbf429eafe2b741e615a00a74a-emerging.rules.tar.gz` files are the only files dropped from the installed Dev build when compared to a GA v1.3.0 install
2. Confirmed on Windows when running the Dev Build that the updated-over-the-Internet Suricata rules end up being the same as the when running the GA v1.3.0 install
3. Confirmed that the shipped rules files are still present on a macOS install of the Dev Build

Fixes #2857