### PR TITLE
Patch release v1.3.1

### DIFF
--- a/apps/zui/CHANGELOG.md
+++ b/apps/zui/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v1.3.1
+- Due to malware false positives, Windows releases no longer include a full initial set of Suricata rules (as always, up-to-date rules will be downloaded on first Internet-connected launch of Zui) (#2858)
+
 ## v1.3.0
 - Update Zed to [v1.10.0](https://github.com/brimdata/zed/releases/tag/v1.10.0)
 - Update Brimcap to [v1.5.2](https://github.com/brimdata/brimcap/releases/tag/v1.5.2)

--- a/apps/zui/package.json
+++ b/apps/zui/package.json
@@ -5,7 +5,7 @@
   "description": "Zed User Interface",
   "repository": "https://github.com/brimdata/zui",
   "license": "BSD-3-Clause",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "main": "dist/main.js",
   "author": "Brim Data <support@brimdata.io> (http://www.brimdata.io)",
   "lake": {

--- a/apps/zui/scripts/download-zdeps/index.js
+++ b/apps/zui/scripts/download-zdeps/index.js
@@ -111,11 +111,24 @@ async function zedDevBuild(destPath) {
   }
 }
 
+// Suricata rules are dropped from the Windows build to fix a false positive
+// malware flagging. See https://github.com/brimdata/zui/issues/2857.
+const filterBrimcapZdeps = (src, dest) => {
+  if (process.platform == "win32" &&
+      (/suricata\.rules$/.test(src) || /emerging\.rules\.tar\.gz$/.test(src)) &&
+      fs.statSync(src).isFile()) {
+    return false
+  } else {
+    return true
+  }
+}
+
 async function main() {
   try {
     fs.copySync(
       path.resolve("..", "..", "node_modules", "brimcap", "build", "dist"),
-      zdepsPath
+      zdepsPath,
+      { filter: filterBrimcapZdeps }
     )
     const brimcapVersion = child_process
       .execSync(path.join(zdepsPath, "brimcap") + " -version")


### PR DESCRIPTION
Ordinarily I'd make changes like the CHANGELOG updates and advancing the `version` string in a  "prep" branch that's merged to `main`, then base the `release/` branch on `main` after that merges. However, since my goal here is to create a true patch release that only contains the fix in #2858, I'm approaching things in reverse.

In this branch I've cherry-picked the changes from #2858 and then made the necessary CHANGELOG and `version` changes. The draft release artifacts are at https://github.com/brimdata/zui/releases/tag/untagged-edbac20bc65f91d4104d, which I've smoke tested and confirmed run [clean on VirusTotal](https://www.virustotal.com/gui/file/9c5d3c3510eb1ac1bc5f9cbf1f4fe113c1b9d0c117861ed08f0385ca11c64c7b) and also [clean on Record Future Triage](https://tria.ge/231016-1vadwshe27).

One this PR is approved, I'll click **Publish Release** so those artifacts go live, then I'll merge this PR so `main` will have the updated CHANGELOG and `version` string going forward.