### PR TITLE
Fix Zui Insiders dev builds

### DIFF
--- a/.github/workflows/build-insiders.yml
+++ b/.github/workflows/build-insiders.yml
@@ -26,6 +26,7 @@ jobs:
 
   release:
     name: Build
+    needs: check_latest
     strategy:
       matrix:
         platform: [windows-2019, macos-12, ubuntu-20.04]

--- a/.github/workflows/build-insiders.yml
+++ b/.github/workflows/build-insiders.yml
@@ -12,6 +12,18 @@ on:
       - 'build-insiders/**'
 
 jobs:
+  check_latest:
+    name: Get last released version
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Get last released version
+        id: latest_release
+        uses: thebritican/fetch-latest-release@v2.0.0
+        with:
+          repo_path: brimdata/zui-insiders
+    outputs:
+      version: ${{ steps.latest_release.outputs.tag_name }}
+
   release:
     name: Build
     strategy:
@@ -27,7 +39,7 @@ jobs:
         uses: ./.github/actions/setup-zui
 
       - name: Inject package.json
-        run: yarn nx inject insiders
+        run: yarn nx inject insiders ${{ needs.check_latest.outputs.version }}
 
       - name: Disable yarn immutable installs
         run: yarn config set enableImmutableInstalls false
@@ -39,7 +51,7 @@ jobs:
         uses: ./.github/actions/build-zui
         with:
           cmd: yarn nx package-insiders zui
-          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          gh_token: ${{ secrets.PAT_TOKEN }}
           # Windows
           csc_key_password: ${{ secrets.WINDOWS_SIGNING_PASSPHRASE }}
           csc_link: ${{ secrets.WINDOWS_SIGNING_PFX_BASE64 }}

--- a/.github/workflows/build-insiders.yml
+++ b/.github/workflows/build-insiders.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: Checkout Zui
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.zui-branch }}
 
       - name: Setup Zui
         uses: ./.github/actions/setup-zui


### PR DESCRIPTION
I tried to use this workflow for the first time in a while and it failed (https://github.com/brimdata/zui/actions/runs/6630692331). I dug into the history a bit and it looks like some changes to the regular Insiders Release workflow in #2833 and #2818 didn't make their way into this workflow. I've made what I think are the necessary changes to get it running again and have successfully built/installed/used an artifact based on this branch (https://github.com/brimdata/zui/actions/runs/6632098539).