### PR TITLE
Add --skip-nx-cache when running "yarn test"

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build-affected": "nx affected --target=build",
     "build": "nx run-many -t build --all",
     "lint": "nx run-many -t lint --all --exclude zui-player",
-    "test": "nx run-many -t test --all --exclude zui-player",
+    "test": "nx run-many -t test --all --exclude zui-player --skip-nx-cache",
     "start": "nx start zui",
     "e2e": "NODE_ENV=production nx test zui-player"
   },


### PR DESCRIPTION
I recently noticed when running tests locally that I'd often see output like this:

```
$ yarn test
 
    ✔  nx run zed-js:test  [existing outputs match the cache, left as is]
    ✔  nx run sample-data:test  [existing outputs match the cache, left as is]
    ✔  nx run zui-test-data:test  [existing outputs match the cache, left as is
    ✔  nx run zed-node:test  [existing outputs match the cache, left as is]
    ✔  nx run zui:test  [existing outputs match the cache, left as is]
    ✔  nx run insiders:test  [existing outputs match the cache, left as is]

 ——————————————————————————————————————————————————————————————————————————————

 >  NX   Successfully ran target test for 6 projects (319ms)
 
   Nx read the output from the cache instead of running the command for 6 out of 6 tasks.
```

@jameskerr explained that I could just do `yarn test --skip-nx-cache` to for the tests to run without using the cache. However, considering the frequency with which we debug tests that fail intermittently, it didn't seem like the speed of leveraging the cache is what we'd usually want. @jameskerr did confirm that he's also been tacking `--skip-nx-cache` a lot lately with tests, so rather than developing my own nervous habit of doing the same, instead this PR proposes just making it the new default behavior.