### PR TITLE
Adapt to change in VNG format from zed/4834

### DIFF
--- a/apps/zui/package.json
+++ b/apps/zui/package.json
@@ -157,7 +157,7 @@
     "use-resize-observer": "^8.0.0",
     "web-file-polyfill": "^1.0.4",
     "web-streams-polyfill": "^3.2.0",
-    "zed": "brimdata/zed#c3d787d0eee18e17a396717779b0a80bbd8b5f3a",
+    "zed": "brimdata/zed#f89f970ecc0d42d3441d06d84beb03dda1e6baeb",
     "zui-test-data": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/zui-player/tests/export.spec.ts
+++ b/packages/zui-player/tests/export.spec.ts
@@ -11,7 +11,7 @@ const formats = [
   { label: 'CSV', expectedSize: 10851 },
   { label: 'JSON', expectedSize: 13659 },
   { label: 'NDJSON', expectedSize: 13657 },
-  { label: 'VNG', expectedSize: 7753 },
+  { label: 'VNG', expectedSize: 8025 },
   { label: 'Zeek', expectedSize: 10138 },
   { label: 'ZJSON', expectedSize: 18007 },
   { label: 'ZNG', expectedSize: 3745 },

--- a/yarn.lock
+++ b/yarn.lock
@@ -19067,10 +19067,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zed@brimdata/zed#c3d787d0eee18e17a396717779b0a80bbd8b5f3a":
+"zed@brimdata/zed#f89f970ecc0d42d3441d06d84beb03dda1e6baeb":
   version: 0.33.0-dev
-  resolution: "zed@https://github.com/brimdata/zed.git#commit=c3d787d0eee18e17a396717779b0a80bbd8b5f3a"
-  checksum: 65f162435d76eeda3ae07964662ebd5e22e473f4186a664a418150820eaff48d0e62688ec3d755c83a18e37753ea6e28a15bd08473a2d4f4de2a7e782ef21bd5
+  resolution: "zed@https://github.com/brimdata/zed.git#commit=f89f970ecc0d42d3441d06d84beb03dda1e6baeb"
+  checksum: 71c30cfca70a5f04638b56027c68c99710fa140bcf32420fb3723282d56a79b9a153ca3cede2d49e6d6c7f9136a41460253ebe0752dc07c95cb9532ffbd803e0
   languageName: node
   linkType: hard
 
@@ -19264,7 +19264,7 @@ __metadata:
     use-resize-observer: ^8.0.0
     web-file-polyfill: ^1.0.4
     web-streams-polyfill: ^3.2.0
-    zed: "brimdata/zed#c3d787d0eee18e17a396717779b0a80bbd8b5f3a"
+    zed: "brimdata/zed#f89f970ecc0d42d3441d06d84beb03dda1e6baeb"
     zui-test-data: "workspace:*"
   peerDependencies:
     react: ^18.0.0


### PR DESCRIPTION
The automation at https://github.com/brimdata/zui/actions/runs/6726418931 triggered by the merge of https://github.com/brimdata/zed/pull/4834 saw a test failure because the exported VNG file size changed slightly due to the changes in that PR. Based on the description in that PR I'm assuming this was expected and indeed the size change is reproducible with just `zq`. @nwt since you reviewed that PR I'll merge this change if you'd agree this seems to be in line with your expectations.

(I'm guessing the VNG format may change repeatedly in the weeks ahead as more work is being done on the vector engine. I therefore assume a case could be made for dropping the automation that checks the size of the VNG file and treats it as an error when it doesn't match. Personally, though, I like knowing we have something to catch _unintentional_ format changes and I don't mind being the one to react to it when it happens. So if it doesn't offend anyone else, I'm inclined to keep doing this.)