### PR TITLE
Pin Python to 3.11 to work around zui/2882

### DIFF
--- a/.github/actions/build-zui/action.yml
+++ b/.github/actions/build-zui/action.yml
@@ -48,7 +48,9 @@ runs:
       shell: bash
 
     - name: Build & Publish
-      run: ${{ inputs.cmd }}
+      run: |
+        python3 -m pip install packaging
+        ${{ inputs.cmd }}
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.gh_token }}

--- a/.github/actions/build-zui/action.yml
+++ b/.github/actions/build-zui/action.yml
@@ -48,9 +48,7 @@ runs:
       shell: bash
 
     - name: Build & Publish
-      run: |
-        python3 -m pip install packaging    # Workaround for https://github.com/brimdata/zui/issues/2882
-        ${{ inputs.cmd }}
+      run: ${{ inputs.cmd }}
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.gh_token }}

--- a/.github/actions/build-zui/action.yml
+++ b/.github/actions/build-zui/action.yml
@@ -49,7 +49,7 @@ runs:
 
     - name: Build & Publish
       run: |
-        python3 -m pip install packaging
+        python3 -m pip install packaging    # Workaround for https://github.com/brimdata/zui/issues/2882
         ${{ inputs.cmd }}
       shell: bash
       env:

--- a/.github/actions/setup-zui/action.yml
+++ b/.github/actions/setup-zui/action.yml
@@ -14,6 +14,13 @@ runs:
         cache: yarn
         node-version-file: .node-version
 
+    # Python version is pinned to something <3.12 to work around:
+    # https://github.com/brimdata/zui/issues/2882
+    - name: Install Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+
     - name: Cache NextJS Artifacts
       uses: jongwooo/next-cache@v1
 


### PR DESCRIPTION
https://github.com/brimdata/zui/issues/2882#issuecomment-1796838240 has background.

At first I tried the workaround `python3 -m pip install packaging` that's discussed most frequently at https://github.com/nodejs/node-gyp/issues/2869. My [first Dev build](https://github.com/brimdata/zui/actions/runs/6776425490) with that workaround came out fine on macOS. I then thought it'd be good to add a comment in the Actions YAML mentioning it's a workaround for this issue. Out of pure paranoia, I made [yet another Dev build](https://github.com/brimdata/zui/actions/runs/6777254187) and that one failed with the same `No module named 'distutils'` on macOS that started this all. I can't explain what was going on there since the run log shows it successfully running the `python3 -m pip install packaging` just like in the prior working build. 🤷‍♂️ 

Rather than try to understand if that workaround was somehow unreliable, I peeked at some of the other links in https://github.com/nodejs/node-gyp/issues/2869 where people work around the problem in their own projects. I saw someone doing something that I now realize makes more sense and is what I'm doing in this PR: Pinning the Python version to 3.11. With my paranoia in full effect, I made _three_ test builds this time ([1](https://github.com/brimdata/zui/actions/runs/6777719057), [2](https://github.com/brimdata/zui/actions/runs/6777859456), [3](https://github.com/brimdata/zui/actions/runs/6777869306)). None of them showed the `No module named 'distutils'` failure, so that seems to indicate the workaround of using Python 3.11 is effective as we'd hope. However, the second of the three builds happened to fail with the separate symptom `FetchError: request to https://www.electronjs.org/headers/v22.3.25/SHASUMS256.txt failed, reason: read ECONNRESET` that I'd previously only seen on Linux as mentioned in https://github.com/brimdata/zui/issues/2882#issuecomment-1796838240.

**Conclusion**: It seems like it must be down to particularly bad luck, but I've shown this all to @jameskerr and we are in agreement that it looks like we've been plagued by two separate problems that both happen to affect this `node-pipe` dependency. We've actually known about exposure here for 3+ years (#1165) but it's only just now been biting us in a big way. @jameskerr is looking at a fix for the general problem of making sure the overall build fails if `node-pipe` doesn't build successfully on macOS and Linux. In the meantime, _this_ PR should address the problem that was _always_ causing `node-pipe` to not build on macOS due when the GitHub Actions runners started using Python 3.12 by default.