### PR TITLE
Add new "Features" docs section and Preview & Load video

### DIFF
--- a/apps/zui/docs/advanced/README.md
+++ b/apps/zui/docs/advanced/README.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 # Advanced Guides

--- a/apps/zui/docs/developer/README.md
+++ b/apps/zui/docs/developer/README.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 # Developer Resources

--- a/apps/zui/docs/features/Preview-Load.md
+++ b/apps/zui/docs/features/Preview-Load.md
@@ -1,0 +1,19 @@
+---
+sidebar_position: 1
+---
+
+# Preview & Load
+
+The video below shows how you can preview and
+[shape](https://zed.brimdata.io/docs/language/shaping) your data as you load it
+into a [Zed lake](https://zed.brimdata.io/docs/commands/zed) with Zui. It also
+touches on the significance of setting a
+[pool key](https://zed.brimdata.io/docs/commands/zed#pool-key) and customizing
+the stacked bar chart.
+
+To further explore the Zed concepts shown in the video, you may want to read
+the [`zq` tutorial](https://zed.brimdata.io/docs/tutorials/zq) and use the
+[`prs.json`](https://github.com/brimdata/zed/raw/main/docs/tutorials/prs.json)
+test data.
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/ywPG1a9FLX0?si=xykqAgIPpsocYhJz" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/apps/zui/docs/features/README.md
+++ b/apps/zui/docs/features/README.md
@@ -1,0 +1,9 @@
+---
+sidebar_position: 4
+---
+
+# Features
+
+Learn how to get the most from Zui features. Topics described here include:
+
+* [Preview and load data](Preview-Load.md)


### PR DESCRIPTION
I've made a video showing off the new Preview & Load feature that's due to go out with the upcoming GA Zui v1.4 release. To give it a home, here I've made a new "Features" section of the Zui docs site and a entry there that links to the video along with supporting materials.

![image](https://github.com/brimdata/zui/assets/5934157/c5770cfc-5f0e-4528-9cc4-5e692feed863)

I hope to make similar videos soon to touch on some other features in the app that users tell us they discovered late, e.g., the right-click menu.