### PR TITLE
Rename "release" target to avoid clash with "nx release"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Build Zui
         uses: ./.github/actions/build-zui
         with:
-          cmd: yarn nx package zui
+          cmd: yarn nx package-zui zui
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           # Windows
           csc_key_password: ${{ secrets.WINDOWS_SIGNING_PASSPHRASE }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           set -x
           case ${{ runner.os }} in
             Linux )
-              yarn nx package zui --linux=deb --publish never
+              yarn nx package-zui zui --linux=deb --publish never
               sudo apt install -y --no-install-recommends ./dist/apps/zui/*.deb
               ;;
           esac

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Build Zui
         uses: ./.github/actions/build-zui
         with:
-          cmd: yarn nx release zui
+          cmd: yarn nx release-zui zui
           gh_token: ${{ secrets.GITHUB_TOKEN }}
           # Windows
           csc_key_password: ${{ secrets.WINDOWS_SIGNING_PASSPHRASE }}

--- a/apps/zui/package.json
+++ b/apps/zui/package.json
@@ -26,8 +26,8 @@
     "tsc": "tsc",
     "postinstall": "node scripts/post-install",
     "prepare": "husky install",
-    "package": "electron-builder --publish never",
-    "release": "electron-builder",
+    "package-zui": "electron-builder --publish never",
+    "release-zui": "electron-builder",
     "package-insiders": "electron-builder --config electron-builder-insiders.json --publish never",
     "release-insiders": "electron-builder --config electron-builder-insiders.json --publish always"
   },


### PR DESCRIPTION
When trying to build the GA Zui v1.4.0 release candidates it became apparent that the move from `nx` `15.8.7` to `16.10.0` as part of #2834 caused an unexpected problem: Somewhere between those versions they introduced an [`nx release`](https://nx.dev/nx-api/nx/documents/release) command that happened to clash with our use of `release` as a target in Zui's `package.json`. Once that was understood, the workaround of changing the target name as shown in this PR got me up & running again quickly.

Since we already had `release-insiders` I opted to call the new target `release-zui` for symmetry. Then I did similar treatment turning the adjacent `package` target into `package-zui` for consistency, plus it insulates us against the possibility that the verb `package` gets claimed one day by `nx` as well. 😛 