### PR TITLE
Assume Zed docs are not made for Zed patch releases

### DIFF
--- a/apps/zui/src/app/core/links.ts
+++ b/apps/zui/src/app/core/links.ts
@@ -1,7 +1,9 @@
 import pkg from "../../../package.json"
 
 const currentZedTag = pkg.devDependencies.zed.split("#")[1] || "main"
-const zedDocsTag = currentZedTag.startsWith("v") ? currentZedTag : "next"
+const zedDocsTag = currentZedTag.startsWith("v")
+  ? currentZedTag.replace(/\.\d+$/, ".0")
+  : "next"
 
 export default {
   ZED_DOCS_ROOT: `https://zed.brimdata.io/docs/${zedDocsTag}/commands/zed`,


### PR DESCRIPTION
The motivation for creating the recent Zui [v1.4.1](https://github.com/brimdata/zui/releases/tag/v1.4.1) patch release was to make sure app users had the corresponding Zed [v1.11.1](https://github.com/brimdata/zed/releases/tag/v1.11.1) patch release. We've not traditionally tagged new sets of Zed docs on https://zed.brimdata.io for each patch release since there's usually not something doc-worthy, extra docs tags for no reason would clutter the "versions" drop-down, and it would add bulk to the zed-docs-site repo. However, Zui has traditionally been wired up to tie the Zed docs URL in the **Help** pull-down to whatever tagged Zed release it shipped with, so when that patch release was built the assembled docs URL was a broken link. Our CI caught this and I was easily able to work around the problem by [hard-coding the docs tag in the release branch](https://github.com/brimdata/zui/commit/3875ee2f6c3d9d0ea4b0c49b81ce2a74ba341f26). However, to save a little time and avoid such hacks when this comes up again in the future, in this PR I just make sure that any Zed docs tag ends in `.0`.