### PR TITLE
Reference Settings, not Preferences

### DIFF
--- a/apps/zui/docs/support/Filesystem-Paths.md
+++ b/apps/zui/docs/support/Filesystem-Paths.md
@@ -69,7 +69,7 @@ categories of interest include:
      that it launches for data storage and query.
 
    * `appState.json` (file) - Persistent app settings such as changes you've
-     made to **Preferences**, contents of the **Query Library**, entries
+     made to **Settings**, contents of the **Query Library**, entries
      in the **History** panel, and so forth.
 
 Generally you should not need to directly access the saved user data, though


### PR DESCRIPTION
There once was a time when the pull-down menu for changing app config was called **Preferences** on macOS and **Settings** on Windows/Linux. This led to it being referenced inconsistently in the docs. Between changes in #2866 and general macOS trends, we've now standardized on **Settings**, so here I'm switching the one place in the Zui docs that still called it by the other.