### PR TITLE
Prevent packing of native modules

### DIFF
--- a/apps/zui/electron-builder.json
+++ b/apps/zui/electron-builder.json
@@ -1,7 +1,7 @@
 {
   "appId": "io.brimdata.zui",
   "asar": true,
-  "asarUnpack": ["zdeps", "LICENSE.txt", "acknowledgments.txt"],
+  "asarUnpack": ["zdeps", "LICENSE.txt", "acknowledgments.txt", "**/*.node"],
   "directories": {"output": "../../dist/apps/zui"},
   "protocols": [{"name": "zui", "schemes": ["zui"]}],
   "mac": {


### PR DESCRIPTION
#2914 has the background and repro. The change in this PR is based on what I found in https://github.com/vector-im/element-web/issues/17188 and how they fixed it via https://github.com/vector-im/element-desktop/pull/337/files, since their symptom looks exactly like ours.

I made a Dev build https://github.com/brimdata/zui/actions/runs/7064639612 using the change on this branch and it tested out fine. I used it to repeat the same repro steps shown in the video in https://github.com/brimdata/zui/issues/2914#issuecomment-1834932637 and none of the `.org.chromium.Chromium.*` accumulated this time. The app also ran otherwise healthy, and in particular, I was able to import/query data, which is a sign that `node-pipe` (one of the modules now subject to different packaging) was still working fine, since it's my understanding that the successful launch of the `zed serve` process is dependent on that.

On my Linux VM I also did a `find` of the contents below `/opt/Zui/resources` with GA Zui v1.4.1 and then also with the Dev build just to confirm I saw only the expected differences, and that does seem to be the case.

```
$ diff 1.4.1.find devbuild.find
742a743,751
> app.asar.unpacked/node_modules
> app.asar.unpacked/node_modules/node-pipe
> app.asar.unpacked/node_modules/node-pipe/build
> app.asar.unpacked/node_modules/node-pipe/build/Release
> app.asar.unpacked/node_modules/node-pipe/build/Release/pipe.node
> app.asar.unpacked/node_modules/keytar
> app.asar.unpacked/node_modules/keytar/build
> app.asar.unpacked/node_modules/keytar/build/Release
> app.asar.unpacked/node_modules/keytar/build/Release/keytar.node
```

Fixes #2914