### PR TITLE
Point to repository setting in package.json

### DIFF
--- a/apps/zui/src/electron/meta.ts
+++ b/apps/zui/src/electron/meta.ts
@@ -6,6 +6,7 @@ import os from "os"
 export async function getAppMeta() {
   return {
     repo: new URL(pkg.repository).pathname.slice(1),
+    repository: pkg.repository,
     version: app.getVersion(),
     isFirstRun: await isFirstRun(),
     userName: os.userInfo().username,

--- a/apps/zui/src/electron/windows/search/app-menu.ts
+++ b/apps/zui/src/electron/windows/search/app-menu.ts
@@ -2,6 +2,7 @@ import {app, MenuItemConstructorOptions, shell, Menu} from "electron"
 import {createFromEditor} from "src/app/commands/pins"
 import env from "src/app/core/env"
 import links from "src/app/core/links"
+import pkg from "src/electron/pkg"
 import {closeWindowOp} from "../../ops/close-window-op"
 import {moveToCurrentDisplayOp} from "../../ops/move-to-current-display-op"
 import {openAboutWindowOp} from "../../ops/open-about-window-op"
@@ -269,7 +270,7 @@ export function compileTemplate(
       {
         label: "Github Repository",
         click() {
-          shell.openExternal("https://github.com/brimdata/zui")
+          shell.openExternal(pkg.repository)
         },
       },
       {

--- a/apps/zui/src/views/update-window/index.tsx
+++ b/apps/zui/src/views/update-window/index.tsx
@@ -46,7 +46,7 @@ function useTemplate() {
       return {
         title: "Up to Date!",
         text: (
-          <Link href="https://github.com/brimdata/zui/releases">
+          <Link href={globalThis.appMeta.repository + "/releases"}>
             View releases
           </Link>
         ),


### PR DESCRIPTION
While verifying #1211, I noticed that in the Zui Insider's pull-down menu options for:
* **Help > GitHub Repository**, and,
* the **View Releases** link that's shown when a **Check for Updates** finds nothing newer available

...the repository URL for "regular" Zui is provided instead of the one for Zui Insiders. This PR fixes that.

The following video shows the new functionality using a [Zui Insiders Dev Build](https://github.com/brimdata/zui/actions/runs/7269738279) based on this branch.

https://github.com/brimdata/zui/assets/5934157/89269fb5-b37c-4cef-b5ec-d659f941cc76
