### PR TITLE
On GitHub Actions, run only the e2e tests that are reliable there

### DIFF
--- a/.github/workflows/advance-zed.yml
+++ b/.github/workflows/advance-zed.yml
@@ -40,12 +40,17 @@ jobs:
       - run: yarn lint
       - run: yarn test
       - run: yarn build
+      - name: Trim to just the e2e tests that run reliably on GitHub Actions
+        run: |
+          cd packages/zui-player/tests
+          echo "tests=$(ls -1 | egrep -v pool-loads\.spec\.ts\|pool-groups.spec\.ts\|title-bar-buttons\.spec\.ts | xargs echo)" >> $GITHUB_OUTPUT
+        id: actions_reliable
       - name: End to end tests
         id: playwright
         uses: GabrielBB/xvfb-action@v1
         with:
           options: -screen 0 1280x1024x24
-          run: yarn e2e
+          run: yarn e2e ${{ steps.actions_reliable.outputs.tests }}
       - uses: actions/upload-artifact@v2
         if: failure() && steps.playwright.outcome == 'failure'
         with:

--- a/.github/workflows/advance-zed.yml
+++ b/.github/workflows/advance-zed.yml
@@ -40,17 +40,12 @@ jobs:
       - run: yarn lint
       - run: yarn test
       - run: yarn build
-      - name: Trim to just the e2e tests that run reliably on GitHub Actions
-        run: |
-          cd packages/zui-player/tests
-          echo "tests=$(ls -1 | egrep -v pool-loads\.spec\.ts\|pool-groups.spec\.ts\|title-bar-buttons\.spec\.ts | xargs echo)" >> $GITHUB_OUTPUT
-        id: actions_reliable
       - name: End to end tests
         id: playwright
         uses: GabrielBB/xvfb-action@v1
         with:
           options: -screen 0 1280x1024x24
-          run: yarn e2e ${{ steps.actions_reliable.outputs.tests }}
+          run: yarn e2e:ci
       - uses: actions/upload-artifact@v2
         if: failure() && steps.playwright.outcome == 'failure'
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,36 @@
+name: Run e2e tests
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run-e2e-tests:
+    name: Run e2e tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-zui
+      - run: yarn lint
+      - run: yarn test
+      - run: yarn build
+      - name: Trim to just the e2e tests that run reliably on GitHub Actions
+        run: |
+          cd packages/zui-player/tests
+          echo "tests=$(ls -1 | egrep -v pool-loads\.spec\.ts\|pool-groups.spec\.ts\|title-bar-buttons\.spec\.ts | xargs echo)" >> $GITHUB_OUTPUT
+        id: actions_reliable
+      - name: End to end tests
+        id: playwright
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          options: -screen 0 1280x1024x24
+          run: yarn e2e ${{ steps.actions_reliable.outputs.tests }}
+      - uses: actions/upload-artifact@v2
+        if: failure() && steps.playwright.outcome == 'failure'
+        with:
+          name: artifacts-${{ matrix.os }}
+          path: |
+            run/playwright-itest
+            !run/**/SS

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,17 +16,12 @@ jobs:
       - run: yarn lint
       - run: yarn test
       - run: yarn build
-      - name: Trim to just the e2e tests that run reliably on GitHub Actions
-        run: |
-          cd packages/zui-player/tests
-          echo "tests=$(ls -1 | egrep -v pool-loads\.spec\.ts\|pool-groups.spec\.ts\|title-bar-buttons\.spec\.ts | xargs echo)" >> $GITHUB_OUTPUT
-        id: actions_reliable
       - name: End to end tests
         id: playwright
         uses: GabrielBB/xvfb-action@v1
         with:
           options: -screen 0 1280x1024x24
-          run: yarn e2e ${{ steps.actions_reliable.outputs.tests }}
+          run: yarn e2e:ci
       - uses: actions/upload-artifact@v2
         if: failure() && steps.playwright.outcome == 'failure'
         with:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lint": "nx run-many -t lint --all --exclude zui-player",
     "test": "nx run-many -t test --all --exclude zui-player --skip-nx-cache",
     "start": "nx start zui",
-    "e2e": "NODE_ENV=production nx test zui-player"
+    "e2e": "NODE_ENV=production nx test zui-player",
+    "e2e:ci": "NODE_ENV=production nx ci zui-player"
   },
   "devDependencies": {
     "@nx-go/nx-go": "^2.7.0",

--- a/packages/zui-player/ci.config.js
+++ b/packages/zui-player/ci.config.js
@@ -1,0 +1,7 @@
+const baseConfig = require('./playwright.config');
+
+module.exports = {
+  ...baseConfig,
+  /* This is the list of flaky tests to ignore when running on CI */
+  testIgnore: /(pool-loads|pool-groups|title-bar-buttons).spec/,
+};

--- a/packages/zui-player/package.json
+++ b/packages/zui-player/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "main": "./index.ts",
   "scripts": {
-    "test": "playwright test --config playwright.config.js"
+    "test": "playwright test -c playwright.config.js",
+    "ci": "playwright test -c ci.config.js"
   },
   "dependencies": {
     "@playwright/test": "next",


### PR DESCRIPTION
## tl;dr

For the "Advance Zed" workflow, this PR proposes trimming the set of e2e tests to only those that have a history of running reliably in GitHub Actions.

To test it, I created a separate workflow that just runs the e2e tests. Rather than scrapping it, I'd propose keeping it around since exercises like this have come up a couple times in the past and it seems a little silly to keep recreating it every time.

## Details

The `title-bar-buttons.spec.ts` test that was just added as part of #2953 seems to run reliably locally on macOS, but in [first attempts to run in Actions](https://github.com/brimdata/zui/actions/runs/7425676367) it failed 5 times out of 5 (`Test timeout of 30000ms exceeded. / Error: locator.click: Application exited`). While we could invest cycles into seeing why this particular test doesn't work in Actions, it can also be seen as another in a series of "Playwright doesn't run reliably enough on CI" data points.

This poses a challenge because the e2e tests have traditionally been the best at catching when the app breaks due to unexpected changes in Zed. In the past when before we ran e2e tests as a prerequisite to advancing the Zed pointer, sometimes multiple breakages would stack atop each other and this would become very difficult to untangle. Therefore in theory we'd like to have them running frequently. However, their perceived flakiness has had the effect of desensitizing us from failures. We've also often wasted time smashing **Re-run** just for the satisfaction of seeing the green status and advancing the pointer. In effect, the "automation" became less automated.

While we've toyed with the idea of turning off the e2e tests in Actions and running them exclusively by hand, @nwt proposed that we see if we can just eliminate the unreliable ones. In preparation for this PR, I did an audit of the last 3 months of "Advance Zed" run outputs (that's as far back as it goes) and have concluded that we could eliminate the bad runs if we skip `pool-loads.spec.ts` and `pool-groups.spec.ts` in addition to the just-added `title-bar-buttons.spec.ts`.

## Audit & Observations

Here's a summary of which failures-due-to-apparent-unreliability we had in which runs.

	• https://github.com/brimdata/zui/actions/runs/7427850158
		○ pool-loads.spec.ts:42:7 › Pool Loads › bad data displays an error message
		○ title-bar-buttons.spec.ts:9:3 › title bar buttons › toggle left sidebar
		○ title-bar-buttons.spec.ts:16:3 › title bar buttons › toggle right sidebar
	• https://github.com/brimdata/zui/actions/runs/7425676367
		○ pool-loads.spec.ts:42:7 › Pool Loads › bad data displays an error message
		○ title-bar-buttons.spec.ts:9:3 › title bar buttons › toggle left sidebar
		○ title-bar-buttons.spec.ts:16:3 › title bar buttons › toggle right sidebar
	• https://github.com/brimdata/zui/actions/runs/7424306865
		○ pool-loads.spec.ts:42:7 › Pool Loads › bad data displays an error message
	• https://github.com/brimdata/zui/actions/runs/7360182387
		○ pool-groups.spec.ts:63:7 › Pool Groups › delete group
		○ pool-loads.spec.ts:42:7 › Pool Loads › bad data displays an error message
	• https://github.com/brimdata/zui/actions/runs/7050085559
		○ pool-loads.spec.ts:42:3 › Pool Loads › bad data displays an error message
	• https://github.com/brimdata/zui/actions/runs/7038166640
		○ pool-loads.spec.ts:42:3 › Pool Loads › bad data displays an error message
	• https://github.com/brimdata/zui/actions/runs/6961214026
		○ pool-loads.spec.ts:42:3 › Pool Loads › bad data displays an error message
	• https://github.com/brimdata/zui/actions/runs/6910207870
		○ pool-loads.spec.ts:42:3 › Pool Loads › bad data displays an error message
	• https://github.com/brimdata/zui/actions/runs/6897010755
		○ pool-loads.spec.ts:42:3 › Pool Loads › bad data displays an error message
	• https://github.com/brimdata/zui/actions/runs/6868975835
		○ pool-loads.spec.ts:42:3 › Pool Loads › bad data displays an error message
	• https://github.com/brimdata/zui/actions/runs/6830941052
		○ pool-groups.spec.ts:33:3 › Pool Groups › edge cases
	• https://github.com/brimdata/zui/actions/runs/6777567934
		○ pool-loads.spec.ts:42:3 › Pool Loads › bad data displays an error message
	• https://github.com/brimdata/zui/actions/runs/6763656722
		○ pool-loads.spec.ts:42:3 › Pool Loads › bad data displays an error message
	• https://github.com/brimdata/zui/actions/runs/6755689465
		○ pool-groups.spec.ts:33:3 › Pool Groups › edge cases
	• https://github.com/brimdata/zui/actions/runs/6755688207
		○ pool-groups.spec.ts:33:3 › Pool Groups › edge cases
		○ pool-loads.spec.ts:42:3 › Pool Loads › bad data displays an error message
	• https://github.com/brimdata/zui/actions/runs/6746521793
		○ pool-loads.spec.ts:42:3 › Pool Loads › bad data displays an error message
	• https://github.com/brimdata/zui/actions/runs/6671607413
		○ pool-loads.spec.ts:42:3 › Pool Loads › bad data displays an error message
	• https://github.com/brimdata/zui/actions/runs/6565561412
		○ pool-groups.spec.ts:44:3 › Pool Groups › rename group

### `pool-groups.spec.ts`

In the past I've eyeballed failures such as the one below:

```
1) pool-groups.spec.ts:44:3 › Pool Groups › rename group =========================================

    Error: expect(received).toEqual(expected) // deep equality

    - Expected  - 1
    + Received  + 1

      Array [
    +   "backups / yesterday",
        "bkups / today",
    -   "bkups / yesterday",
      ]

      55 |
      56 |     const pools = await app.zealot.getPools()
    > 57 |     expect(pools.map((p) => p.name).sort()).toEqual([
         |                                             ^
      58 |       "bkups / today",
      59 |       "bkups / yesterday",
      60 |     ])

        at /home/runner/work/zui/zui/packages/e2e-tests/tests/pool-groups.spec.ts:57:45
        at runMicrotasks (<anonymous>)
```

To which I observed (and @jameskerr agreed):

> So it would imply that either only some of the pool renames succeeded or the test is checking the contents of the updated pools list too fast. Given problems we've had in the past, I'm inclined to suspect the latter.

Therefore perhaps at some point we could work to make that one reliable and bring it back into the mix.

### `pool-loads.spec.ts`

The pattern of failures here remains mysterious. One observation I'll make is that it _is_ capable of running reliably, e.g., it ran reliably on Actions through pretty much the whole month of December. But then sometimes we'll see it fail multiple times close together. One suspicion we've always had about Actions is that the shared nature of the infrastructure just makes it prone to slowness or limited resources resulting in processes getting shot, so maybe its bad runs just correlate with bad times in Actions overall.

![image](https://github.com/brimdata/zui/assets/5934157/c7e6e851-f847-400d-95a2-695e9031c6c6)

### `title-bar-buttons.spec.ts`

100% a mystery right now.

### Others (not shown above)

There were several legit failures observed in the Export VNG test because that area of Zed has been undergoing intentional changes in the format that affect the file size. Given the frequency of failures we've toyed with the idea of temporarily disabling that test until VNG stabilizes, but really, to me it illustrates the very benefit we want from these tests: I observe the failure, confirm the change was unsurprising, adapt the test, and move foward.

There also were a couple failures surely due to things like temporary network outages, e.g., timing out when downloading some dependency or uploading an artifact at the end of a run. That just life in Actions, baby!