### PR TITLE
Remove node-pipe dependency

### DIFF
--- a/apps/zui/package.json
+++ b/apps/zui/package.json
@@ -35,9 +35,6 @@
   "dependencies": {
     "keytar": "^7.7.0"
   },
-  "optionalDependencies": {
-    "node-pipe": "^0.1.1"
-  },
   "devDependencies": {
     "@babel/core": "^7.17.9",
     "@brimdata/zed-js": "workspace:*",

--- a/apps/zui/scripts/esbuild.mjs
+++ b/apps/zui/scripts/esbuild.mjs
@@ -10,7 +10,7 @@ const context = await esbuild.context({
   platform: "node",
   sourcemap: true,
   target: "node16",
-  external: ["keytar", "electron", "node-pipe"],
+  external: ["keytar", "electron"],
   tsconfig: "./tsconfig.json",
 })
 

--- a/packages/zed-node/src/lake.ts
+++ b/packages/zed-node/src/lake.ts
@@ -54,14 +54,12 @@ export class Lake {
       stdio: ['inherit', 'inherit', 'inherit'],
       windowsHide: true,
     };
-    // For unix systems, pass posix pipe read file descriptor into lake process.
+    // For unix systems, pass a pipe file descriptor into the lake process.
     // In the event of Zui getting shutdown via `SIGKILL`, this will let lake
     // know that it has been orphaned and to shutdown.
 
     if (process.platform !== 'win32') {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const { readfd } = require('node-pipe').pipeSync();
-      opts.stdio.push(readfd);
+      opts.stdio.push('pipe');
       args.push(`-brimfd=${opts.stdio.length - 1}`);
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14264,15 +14264,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-addon-api@npm:*":
-  version: 6.1.0
-  resolution: "node-addon-api@npm:6.1.0"
-  dependencies:
-    node-gyp: latest
-  checksum: 3a539510e677cfa3a833aca5397300e36141aca064cdc487554f2017110709a03a95da937e98c2a14ec3c626af7b2d1b6dabe629a481f9883143d0d5bff07bf2
-  languageName: node
-  linkType: hard
-
 "node-addon-api@npm:^1.6.3":
   version: 1.7.2
   resolution: "node-addon-api@npm:1.7.2"
@@ -14356,16 +14347,6 @@ __metadata:
   version: 1.1.12
   resolution: "node-machine-id@npm:1.1.12"
   checksum: e23088a0fb4a77a1d6484b7f09a22992fd3e0054d4f2e427692b4c7081e6cf30118ba07b6113b6c89f1ce46fd26ec5ab1d76dcaf6c10317717889124511283a5
-  languageName: node
-  linkType: hard
-
-"node-pipe@npm:^0.1.1":
-  version: 0.1.1
-  resolution: "node-pipe@npm:0.1.1"
-  dependencies:
-    node-addon-api: "*"
-    node-gyp: latest
-  conditions: (os=darwin | os=linux)
   languageName: node
   linkType: hard
 
@@ -19261,7 +19242,6 @@ __metadata:
     msw: ^0.36.8
     next: ^13.3.0
     node-fetch: ^2.6.1
-    node-pipe: ^0.1.1
     nodemon: ^2.0.22
     npm-run-all: ^4.1.5
     ohm-js: ^17.0.4
@@ -19303,8 +19283,5 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  dependenciesMeta:
-    node-pipe:
-      optional: true
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Rely on child_process.spawn() to create a pipe instead.

Closes #1165.