### PR TITLE
Revert "Pin Python to 3.11 to work around zui/2882 (#2883)"

### DIFF
--- a/.github/actions/setup-zui/action.yml
+++ b/.github/actions/setup-zui/action.yml
@@ -14,13 +14,6 @@ runs:
         cache: yarn
         node-version-file: .node-version
 
-    # Python version is pinned to something <3.12 to work around:
-    # https://github.com/brimdata/zui/issues/2882
-    - name: Install Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.11'
-
     - name: Cache NextJS Artifacts
       uses: jongwooo/next-cache@v1
 


### PR DESCRIPTION
This reverts commit d29e6744b1cac6733dd47973c79843058d165bbb.

Reason for revert: #2956 removed the node-pipe dependency so this workaround for #2882 is no longer necessary.