### PR TITLE
Wait on rejected promise in "bad zed" test

### DIFF
--- a/packages/zed-node/src/zq.test.ts
+++ b/packages/zed-node/src/zq.test.ts
@@ -111,7 +111,7 @@ test('zq with a bad zed ', async () => {
     input: createReadStream(path),
   });
 
-  expect(promise).rejects.toThrowError('error parsing Zed');
+  await expect(promise).rejects.toThrowError('error parsing Zed');
 });
 
 test('head 100 on guns ', async () => {


### PR DESCRIPTION
One of our tests that does _not_ typically fail in CI failed twice close together this morning:

* https://github.com/brimdata/zui/actions/runs/7463628055/job/20308754610
* https://github.com/brimdata/zui/actions/runs/7465184326/job/20313785582

The failure looks like:

```
FAIL zed-node packages/zed-node/src/zq.test.ts (5.579 s)
  ● head 100 on guns 

    expect(received).rejects.toThrowError()

    Received promise resolved instead of rejected
    Resolved to value: []

      112 |   });
      113 |
    > 114 |   expect(promise).rejects.toThrowError('error parsing Zed');
          |   ^
      115 | });
      116 |
      117 | test('head 100 on guns ', async () => {

      at expect (../../node_modules/expect/build/index.js:105:15)
      at Object.expect (src/zq.test.ts:114:3)
```

What sticks out about this is that the `head 100 on guns` is from the test _after_ the one with the highlighted line 114 shown. This led me to suspect a timing issue, and indeed, just looking at the pattern, the test that includes line 114 lacked any `await`. @jameskerr confirmed the `await` belongs at the spot where I've added it in this PR, and https://jestjs.io/docs/asynchronous cites this as a known gotcha.

I've run the tests five times in a row via https://github.com/brimdata/zui/actions/runs/7465421936 and it came out green every time.