### PR TITLE
Add flexible inputs to Actions Workflow for running e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,14 +2,22 @@ name: Run e2e tests
 
 on:
   workflow_dispatch:
-
+    inputs:
+      run-target:
+        description: Command line for running e2e tests
+        default: 'yarn e2e:ci'
+        required: true
+      platforms:
+        description: OS platforms to test on (list of strings in JSON format)"
+        default: '["ubuntu-20.04"]'
+        required: true
 jobs:
   run-e2e-tests:
     name: Run e2e tests
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: ${{ fromJSON(inputs.platforms) }}
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-zui
@@ -21,7 +29,7 @@ jobs:
         uses: GabrielBB/xvfb-action@v1
         with:
           options: -screen 0 1280x1024x24
-          run: yarn e2e:ci
+          run: ${{ inputs.run-target }}
       - uses: actions/upload-artifact@v2
         if: failure() && steps.playwright.outcome == 'failure'
         with:


### PR DESCRIPTION
I'm hoping to invest some time to better understand and hopefully fix some of the problems we have with e2e test reliability in GitHub Actions CI. As a step toward that, in this PR I've added some flexible Inputs to the "Run e2e tests" Workflow. After this change, if the Workflow is invoked with all inputs at their defaults, it'll still run the e2e tests the same way they are in the "Advance Zed" workflow. But those inputs can now be varied to run any command line (e.g., `yarn e2e` ...) on any set of OS platforms, which makes it easier to repro specific problems and confirm fixes.

For instance, in [this run](https://github.com/brimdata/zui/actions/runs/7483368374) I ran only the `copy-paste` tests and did it across all OSes.

![image](https://github.com/brimdata/zui/assets/5934157/17c2f327-ca42-414d-9f80-ebd3f2601e12)
