### PR TITLE
Adjust paths for finding artifacts

### DIFF
--- a/.github/workflows/advance-zed.yml
+++ b/.github/workflows/advance-zed.yml
@@ -51,8 +51,10 @@ jobs:
         with:
           name: artifacts-${{ matrix.os }}
           path: |
-            run/playwright-itest
-            !run/**/SS
+            packages/zui-player/run/playwright-itest
+            !packages/zui-player/run/**/SS
+            /var/log/sys*log*
+            /var/log/kern.log*
 
       - run: git -c user.name='Brim Automation' -c user.email=automation@brimdata.io commit -a -m 'upgrade Zed to ${{ env.zed_ref }}'
 

--- a/.github/workflows/advance-zed.yml
+++ b/.github/workflows/advance-zed.yml
@@ -46,15 +46,6 @@ jobs:
         with:
           options: -screen 0 1280x1024x24
           run: yarn e2e:ci
-      - uses: actions/upload-artifact@v2
-        if: failure() && steps.playwright.outcome == 'failure'
-        with:
-          name: artifacts-${{ matrix.os }}
-          path: |
-            packages/zui-player/run/playwright-itest
-            !packages/zui-player/run/**/SS
-            /var/log/sys*log*
-            /var/log/kern.log*
 
       - run: git -c user.name='Brim Automation' -c user.email=automation@brimdata.io commit -a -m 'upgrade Zed to ${{ env.zed_ref }}'
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,7 +36,6 @@ jobs:
           name: artifacts-${{ matrix.os }}
           path: |
             packages/zui-player/run/playwright-itest
-            !packages/zui-player/run/**/SS
             packages/zui-player/test-results
             /var/log/sys*log*
             /var/log/kern.log*

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,5 +35,8 @@ jobs:
         with:
           name: artifacts-${{ matrix.os }}
           path: |
-            run/playwright-itest
-            !run/**/SS
+            packages/zui-player/run/playwright-itest
+            !packages/zui-player/run/**/SS
+            packages/zui-player/test-results
+            /var/log/sys*log*
+            /var/log/kern.log*


### PR DESCRIPTION
I started looking into using artifacts to debug our e2e test failures in CI, and that's when it became apparent that we need to update the paths to reflect the new paths in the monorepo.

As part of that I also wanted to start looking at [Playwright traces](https://playwright.dev/docs/trace-viewer) that are now easy to enable due to the changes in #2961, but they land in a different path so I've added that too.

Also, some of our recent test failures have scary-sounding "Application exited" messages that have sometimes had me wondering if out-of-memory killers have been shooting our software in the middle of test runs. My research thus far indicates that's _not_ the case, but just to be sure, I've added some system log paths to the artifact gathering to make that easy to rule out. I logged into a Runner using [nrgok-ssh](https://github.com/philrz/ngrok-ssh) and triggered an OOM intentionally to confirm these log files have the evidence.

https://github.com/brimdata/zui/actions/runs/7491797930 has example artifacts from a run based on this branch that was invoked with:

![image](https://github.com/brimdata/zui/assets/5934157/9b894b41-03e0-4b10-b054-674b20d9b31a)

Finally, @nwt suggested removing artifact collection entirely from the "Advance Zed" workflow, as it's seen as a waste of time to collect them and a waste of space to store them. Therefore I've dropped that here. This means a likely workflow will be that if I see failures in "Advance Zed" runs I may repro them in the standalone "Run e2e tests" workflow where I _do_ have the benefit of all the traces and other artifacts. If I find I become so proficient at fixing failures from artifacts on the first try I may circle back one day and lobby to have artifacts turned on again in "Advance Zed".