### PR TITLE
Install whois in CI so right-click test can succeed

### DIFF
--- a/.github/workflows/advance-zed.yml
+++ b/.github/workflows/advance-zed.yml
@@ -36,6 +36,7 @@ jobs:
           # We need a token with permission to push.
           token: ${{ secrets.ZQ_UPDATE_PAT }}
       - uses: ./.github/actions/setup-zui
+      - run: sudo apt-get -y install whois
       - run: yarn workspace zui add zed@brimdata/zed#${{ env.zed_ref }}
       - run: yarn lint
       - run: yarn test

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,6 +21,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-zui
+      - name: Install dependencies (Linux)
+        if: startsWith(matrix.os, 'ubuntu-')
+        run: sudo apt-get -y install whois
+      - name: Install dependencies (Windows)
+        if: startsWith(matrix.os, 'windows-')
+        run: choco install -y --no-progress whois
       - run: yarn lint
       - run: yarn test
       - run: yarn build


### PR DESCRIPTION
The new `right-click-menus.spec.ts` e2e test set that was added as part of #2895 has failed 100% of the time in CI due to a problem with the `who is` test case. A recent example failure from [this run](https://github.com/brimdata/zui/actions/runs/7492874104):

```
2) right-click-menus.spec.ts:56:3 › right-click-menus › who is ───────────────────────────────────
    Test timeout of 30000ms exceeded.
    Error: locator.click: Application exited
    Call log:
      - waiting for getByRole('button', { name: 'Done', exact: true }).first()
      -   locator resolved to <button type="button">Done</button>
      - attempting click action
      -   waiting for element to be visible, enabled and stable
      -     element is not stable - waiting...
      - element was detached from the DOM, retrying
       at ../helpers/test-app.ts:162
      160 |
      161 |   async click(role: Role | RegExp, name?: string) {
    > 162 |     return this.locate(role, name).click();
          |                                    ^
      163 |   }
      164 |
      165 |   async rightClick(role: Role | RegExp, name?: string) {
        at TestApp.click (/home/runner/work/zui/zui/packages/zui-player/helpers/test-app.ts:162:[36](https://github.com/brimdata/zui/actions/runs/7492874104/job/20397350722#step:8:37))
        at /home/runner/work/zui/zui/packages/zui-player/tests/right-click-menus.spec.ts:63:15
```

Despite the scary "Application exited" wording, closer inspection reveals a simple explanation: The right-click **Whois lookup** in Zui still relies on a `whois` executable being present (see #1052). This PR just adds the executable to the Actions Runners where needed. The run https://github.com/brimdata/zui/actions/runs/7493437314/job/20399136004 on this branch shows the test now passing on all three OSes.