### PR TITLE
Output the "Inputs" used for e2e run

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,6 +21,7 @@ jobs:
     steps:
       - name: Output inputs
         run: echo "${{ toJSON(inputs) }}"
+        shell: sh
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-zui
       - run: yarn lint

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,6 +19,8 @@ jobs:
       matrix:
         os: ${{ fromJSON(inputs.platforms) }}
     steps:
+      - name: Output inputs
+        run: echo "${{ toJSON(inputs) }}"
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-zui
       - run: yarn lint


### PR DESCRIPTION
Since I plan to make ample use of Inputs in this "Run e2e tests" Workflow, I went looking for the best way to log the inputs that were used for a given run. Of the ideas batted around [here](https://stackoverflow.com/questions/71155641/github-actions-how-to-view-inputs-for-workflow-dispatch) I chose one for this PR. When in use it looks like:

![image](https://github.com/brimdata/zui/assets/5934157/e39eb15d-9a2e-40b7-bbab-dd225e3bc8f3)
