### PR TITLE
Playwright videos

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,11 @@ on:
         required: true
       video:
         description: Whether to record videos of Playwright test runs
+        type: choice
         default: 'true'
+        options:
+        - 'true'
+        - 'false'
         required: true
 
 jobs:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,6 +11,11 @@ on:
         description: OS platforms to test on (list of strings in JSON format)"
         default: '["ubuntu-20.04"]'
         required: true
+      video:
+        description: Whether to record videos of Playwright test runs
+        default: 'true'
+        required: true
+
 jobs:
   run-e2e-tests:
     name: Run e2e tests
@@ -39,6 +44,8 @@ jobs:
         with:
           options: -screen 0 1280x1024x24
           run: ${{ inputs.run-target }}
+        env:
+          VIDEO: ${{ inputs.video }}
       - uses: actions/upload-artifact@v2
         if: failure() && steps.playwright.outcome == 'failure'
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,6 +45,7 @@ jobs:
           name: artifacts-${{ matrix.os }}
           path: |
             packages/zui-player/run/playwright-itest
+            packages/zui-player/run/videos
             packages/zui-player/test-results
             /var/log/sys*log*
             /var/log/kern.log*

--- a/packages/zui-player/README.md
+++ b/packages/zui-player/README.md
@@ -8,7 +8,7 @@ The Zui end-to-end test suite uses [Playwright](https://playwright.dev/) as the 
 
 When you are writing or debugging tests, you will usually be changing code in zui, then running the tests. To make this workflow streamlined, you will need to start the Zui dev renderer server and watch the main process code for changes.
 
-You can do this with the commaned:
+You can do this with the command:
 
 ```
 nx watch-code zui
@@ -20,7 +20,7 @@ In another terminal instance, you may run your tests like so:
 nx test zui-player
 ```
 
-To run just one of the tests, specify the name of the file in the `tests` directory, e.g., The -g stands for 'grep' and can take a regex pattern argument.
+To run just one of the tests, specify the name of the file in the `tests` directory, e.g., The `-g` stands for 'grep' and can take a regex pattern argument.
 
 ```
 nx test zui-player -g pool-loads.spec.ts
@@ -28,13 +28,23 @@ nx test zui-player -g pool-loads.spec.ts
 
 ## Running Tests in CI
 
-When the tests run in CI, there will not be a dev server running, serving the HTML. Instead, the workflow will build the app and place static html files on the disk. Zui Player will then test agains those files.
+When the tests run in CI, there will not be a dev server running, serving the HTML. Instead, the workflow will build the app and place static html files on the disk. Zui Player will then test against those files.
 
 To simulate this locally, run the following commands:
 
 ```
 nx build zui
 NODE_ENV=production nx test zui-player
+```
+
+## Artifacts
+
+The [user data folder](https://zui.brimdata.io/docs/support/Filesystem-Paths#user-data) at the end of each test run can be found below the `run/playwright-itest` directory.
+
+If you also want Playwright to record each test run, set the environment variable `VIDEO=true` and the videos can be found in the `run/videos` directory.
+
+```
+VIDEO=true NODE_ENV=production nx test zui-player
 ```
 
 ## Writing a test
@@ -70,7 +80,7 @@ These are the four methods you need to know to get most work done.
 ```ts
 await app.click();
 await app.attached();
-await app.detacted();
+await app.detached();
 await app.hidden();
 await app.visible();
 await app.locate();

--- a/packages/zui-player/helpers/test-app.ts
+++ b/packages/zui-player/helpers/test-app.ts
@@ -35,8 +35,11 @@ export default class TestApp {
       args: [`--user-data-dir=${userDataDir}`, entry],
       bypassCSP: true,
       timeout: 10000,
-      ...(process.env.VIDEO == 'true' && {recordVideo: {dir: path.join('run', 'videos')}}),
-    };
+    } as any;
+
+    if (process.env.VIDEO == 'true') {
+      launchOpts.recordVideo = { dir: path.join('run', 'videos') };
+    }
 
     // @ts-ignore
     if (bin) launchOpts.executablePath = bin;

--- a/packages/zui-player/helpers/test-app.ts
+++ b/packages/zui-player/helpers/test-app.ts
@@ -35,9 +35,7 @@ export default class TestApp {
       args: [`--user-data-dir=${userDataDir}`, entry],
       bypassCSP: true,
       timeout: 10000,
-      recordVideo: {
-        dir: path.join('run', 'videos'),
-      }
+      ...(process.env.VIDEO == 'true' && {recordVideo: {dir: path.join('run', 'videos')}}),
     };
 
     // @ts-ignore

--- a/packages/zui-player/helpers/test-app.ts
+++ b/packages/zui-player/helpers/test-app.ts
@@ -35,6 +35,9 @@ export default class TestApp {
       args: [`--user-data-dir=${userDataDir}`, entry],
       bypassCSP: true,
       timeout: 10000,
+      recordVideo: {
+        dir: path.join('run', 'videos'),
+      }
     };
 
     // @ts-ignore


### PR DESCRIPTION
I've been trying out Playwright's ability to capture videos during tests. It's been a little tricky getting the full story (https://github.com/microsoft/playwright/issues/8208 points to some of the work-in-progress), but based on what I've tried thus far it seems that the [top-level `use.video` config](https://playwright.dev/docs/videos) does _not_ work for Electron apps. This is a mild bummer since that has some nice granular options like `retain-on-failure` so you don't bother storing video for all successful runs. But in the spirit of "better than nothing", I _have_ had some success with the [Electron-specific `recordVideo` config](https://playwright.dev/docs/api/class-electron#electron-launch-option-record-video) I'm using in this PR's branch. Per the doc it "enables video recording for all pages", so it's kind of an all-or-nothing thing.

That said, even in this crude form it's already proving quite useful. For instance I ran the Export test on macOS in [this run](https://github.com/brimdata/zui/actions/runs/7506152551). The text output from the run provided a familar high-level "something timed out" with not much else to go on.

```
> nx run zui-player:test -g export.spec.ts

Running [10](https://github.com/brimdata/zui/actions/runs/7506152551/job/20436914347#step:10:11) tests using 1 worker
T°°°°°°°°°
  1) export.spec.ts:37:9 › Export tests › Exporting in Arrow IPC Stream format succeeds ────────────
    "beforeAll" hook timeout of 30000ms exceeded.
      23 |   const app = new TestApp('Export tests');
      24 |
    > 25 |   test.beforeAll(async () => {
         |        ^
      26 |     await app.init();
      27 |     await app.createPool([getPath('sample.zeektsv')]);
      28 |     await app.click('button', 'Query Pool');
        at /Users/runner/work/zui/zui/packages/zui-player/tests/export.spec.ts:25:8
    Error: locator.click: Target page, context or browser has been closed
      46 |         .getByRole('radio', { name: `${label}`, exact: true })
      47 |         .click();
    > 48 |       await dialog.getByRole('button').filter({ hasText: 'Export' }).click();
         |                                                                      ^
      49 |       await app.mainWin
      50 |         .getByText(new RegExp('Export Completed: .*results\\.' + label))
      51 |         .waitFor();
        at /Users/runner/work/zui/zui/packages/zui-player/tests/export.spec.ts:48:70
  1 failed
    export.spec.ts:37:9 › Export tests › Exporting in Arrow IPC Stream format succeeds ─────────────
  9 skipped
```

However, the captured video (which is in the artifact bundle for that run, attached below for convenience) tells a much richer story, and it's only 1 MB in size. Here we can see that when loading the data at the start of the test Zui happened to be slow to respond. It didn't appear to hang or die. Each step just took longer than we'd have liked, so it looks like it ended up timing out when in the middle of entering the Zed query before starting to perform Export operations.

[050a0108187d1baafca8fe1a4921b99b.webm](https://github.com/brimdata/zui/assets/5934157/064f07a7-c269-490f-9694-9d6347d08ca5)

In conclusion, this is helpful info that might help us make an informed decision about maybe increasing test timeouts. I know we've toyed with that in the past, but it's often been difficult to know if it's helping at all or if it's just making inevitable failures take longer.

After some guidance from @jameskerr, this branch is rigged up so videos will be taken whenever Zui Player is run with env variable `VIDEO=true`. The Actions Workflow for "Run e2e Tests" is rigged to set this env var by default. I've verified it's behaving as expected in separate runs [with videos](https://github.com/brimdata/zui/actions/runs/7508908186) and [without](https://github.com/brimdata/zui/actions/runs/7508942389).


