### PR TITLE
Improve timing in e2e Export test

### DIFF
--- a/packages/zui-player/tests/export.spec.ts
+++ b/packages/zui-player/tests/export.spec.ts
@@ -23,7 +23,11 @@ test.describe('Export tests', () => {
   const app = new TestApp('Export tests');
 
   test.beforeAll(async () => {
+
+    // Increase timeout due to observed long load times on test data in CI.
+    // See https://github.com/brimdata/zui/pull/2967
     test.setTimeout(60000);
+
     await app.init();
     await app.createPool([getPath('sample.zeektsv')]);
     await app.click('button', 'Query Pool');

--- a/packages/zui-player/tests/export.spec.ts
+++ b/packages/zui-player/tests/export.spec.ts
@@ -41,11 +41,13 @@ test.describe('Export tests', () => {
           Promise.resolve({ canceled: false, filePath });
       }, file);
       await app.click('button', 'Export Results');
+      await app.attached('dialog');
       const dialog = app.mainWin.getByRole('dialog');
       await dialog
         .getByRole('radio', { name: `${label}`, exact: true })
         .click();
       await dialog.getByRole('button').filter({ hasText: 'Export' }).click();
+      await app.detached('dialog');
       await app.mainWin
         .getByText(new RegExp('Export Completed: .*results\\.' + label))
         .waitFor();

--- a/packages/zui-player/tests/export.spec.ts
+++ b/packages/zui-player/tests/export.spec.ts
@@ -23,6 +23,7 @@ test.describe('Export tests', () => {
   const app = new TestApp('Export tests');
 
   test.beforeAll(async () => {
+    test.setTimeout(60000);
     await app.init();
     await app.createPool([getPath('sample.zeektsv')]);
     await app.click('button', 'Query Pool');

--- a/packages/zui-player/tests/export.spec.ts
+++ b/packages/zui-player/tests/export.spec.ts
@@ -40,7 +40,7 @@ test.describe('Export tests', () => {
         dialog.showSaveDialog = () =>
           Promise.resolve({ canceled: false, filePath });
       }, file);
-      app.click('button', 'Export Results');
+      await app.click('button', 'Export Results');
       const dialog = app.mainWin.getByRole('dialog');
       await dialog
         .getByRole('radio', { name: `${label}`, exact: true })


### PR DESCRIPTION
Now that I can capture Playwright test failures on video (#2966) I've been reproducing them and trying to figure out where we can make improvements.

While we run our e2e tests for "Advance Zed" only on Ubuntu, one thing I've noticed is that it seems I can reproduce problems with some of our tests more frequently by using alternate Actions Runners such as macOS. I'm not 100% certain _why_ this is the case, but since the intermittent failures often come down to timing issues, it seems like fixing them where they happen most often could reduce the (rarer) failures on Ubuntu runners or our own laptops and maybe lead us to a future where we actually run e2e tests regularly on all OSes to get better coverage.

The one I've been studying most recently and am attempting to improve in this PR is [export.spec.ts](https://github.com/brimdata/zui/blob/main/packages/zui-player/tests/export.spec.ts). After seeing it fail several times on macOS, I ran a controlled set of five repro attempts in a row and saw it fail twice. The failures came in two flavors, both of which I'd seen in my previous repros.

## 1. Test data takes too long to load ([run](https://github.com/brimdata/zui/actions/runs/7514850222))

The failure description looks like:

```
  1) export.spec.ts:37:9 › Export tests › Exporting in Arrow IPC Stream format succeeds ────────────
    "beforeAll" hook timeout of 30000ms exceeded.
      23 |   const app = new TestApp('Export tests');
      24 |
    > 25 |   test.beforeAll(async () => {
         |        ^
      26 |     await app.init();
      27 |     await app.createPool([getPath('sample.zeektsv')]);
      28 |     await app.click('button', 'Query Pool');
        at /Users/runner/work/zui/zui/packages/zui-player/tests/export.spec.ts:25:8
    Error: locator.click: Application exited
    Call log:
      - waiting for getByRole('dialog').getByRole('radio', { name: 'Arrow IPC Stream', exact: true })
      45 |       await dialog
      46 |         .getByRole('radio', { name: `${label}`, exact: true })
    > 47 |         .click();
         |          ^
      48 |       await dialog.getByRole('button').filter({ hasText: 'Export' }).click();
      49 |       await app.mainWin
      50 |         .getByText(new RegExp('Export Completed: .*results\\.' + label))
        at /Users/runner/work/zui/zui/packages/zui-player/tests/export.spec.ts:47:10
```

Captured on video, we can see that the app is just sluggish as the Zeek TSV log is being loaded. It never hangs completely. Each step just takes longer than we like. I won't bother digging it up, but in a repro from a prior attempt, at the end of the video it timed out was while the automation was in the middle of typing out the query before performing the export.

[1c80d4d2a8b648899fced327ddc7d1e3.webm](https://github.com/brimdata/zui/assets/5934157/dbeaf4d3-661b-49af-9f6f-fbb5aa1e97ff)

Obviously it's a bummer that these Actions Runners can be so weak, but I'm inclined to just be more patient with it rather than risk having a failure to react to when the GitHub infrastructure is having a rough day.

**Conclusion** - In the branch for this PR I'm proposing we increase this test's timeout from the default 30 seconds to 60 seconds.

## 2. Exports of non-ZNG formats fail because they see the expected size of the ZNG export ([run](https://github.com/brimdata/zui/actions/runs/7514853427))

The failure description looks like:

```
1) export.spec.ts:37:9 › Export tests › Exporting in JSON format succeeds ────────────────────────
    Error: expect(received).toBe(expected) // Object.is equality
    Expected: 13659
    Received: 3745
      51 |         .waitFor();
      52 |
    > 53 |       expect(fsExtra.statSync(file).size).toBe(expectedSize);
         |                                           ^
      54 |     });
      55 |   });
      56 | });
        at /Users/runner/work/zui/zui/packages/zui-player/tests/export.spec.ts:53:43
  2) export.spec.ts:37:9 › Export tests › Exporting in ZJSON format succeeds ───────────────────────
    Error: expect(received).toBe(expected) // Object.is equality
    Expected: [18](https://github.com/brimdata/zui/actions/runs/7514853427/job/20458183160#step:10:19)007
    Received: 3745
      51 |         .waitFor();
      52 |
    > 53 |       expect(fsExtra.statSync(file).size).toBe(expectedSize);
         |                                           ^
      54 |     });
      55 |   });
      56 | });
        at /Users/runner/work/zui/zui/packages/zui-player/tests/export.spec.ts:53:43
  2 failed
    export.spec.ts:37:9 › Export tests › Exporting in JSON format succeeds ─────────────────────────
    export.spec.ts:[37](https://github.com/brimdata/zui/actions/runs/7514853427/job/20458183160#step:10:38):9 › Export tests › Exporting in ZJSON format succeeds ────────────────────────
```

Captured on video, the failure to export JSON

[JSON Failure.webm](https://github.com/brimdata/zui/assets/5934157/205fc289-0924-4b40-b8eb-5199d99c860d)

The failure to export ZJSON:

[ZJSON Failure.webm](https://github.com/brimdata/zui/assets/5934157/4d563462-fc02-45ff-a1d8-3a374630bbc9)

I think these two important pieces of evidence point us in the right direction:

1. The failures are always because it finds the Export produced a `3745` byte file expected from the ZNG format rather than the size of the non-ZNG file it's trying to export
2. When the Export Results dialog comes up, the radio button for ZNG happens to be pre-checked by default

Then thinking about this sequence as it's been in the tip of `main`:

https://github.com/brimdata/zui/blob/a55b0dffa7a65acaf1e70f5e47db5ad145755211/packages/zui-player/tests/export.spec.ts#L43-L47

In both of the videos we see a similar effect in the final frame at the moment of failure: The Export Results dialog is in the middle of coming up at what's believed to be the precise moment when the attempted export has failed. It got me to wondering if the lack of an `await` on the initial click to bring up the Export dialog might have made it such that the contents of the dialog were in some half-baked state at the moment that it attempted the next click on the intended Export format causing the click to go through while the default ZNG was still selected. That's just a theory, though.

**Conclusion** - I've added an `await` on the first button click as well as explicit `await` on attach/detach of the dialog box in an attempt to make sure it proceeds serially and everything is fully present before clicks are executed and we start expecting what comes next. With these changes in place, I've done ten successful runs in a row on macOS without any failures.

1. https://github.com/brimdata/zui/actions/runs/7515111029
2. https://github.com/brimdata/zui/actions/runs/7515112296
3. https://github.com/brimdata/zui/actions/runs/7515114241
4. https://github.com/brimdata/zui/actions/runs/7515114622
5. https://github.com/brimdata/zui/actions/runs/7515115761
6. https://github.com/brimdata/zui/actions/runs/7515117996
7. https://github.com/brimdata/zui/actions/runs/7515118500
8. https://github.com/brimdata/zui/actions/runs/7515120107
9. https://github.com/brimdata/zui/actions/runs/7515121415
10. https://github.com/brimdata/zui/actions/runs/7515121720
