### PR TITLE
Copy from /var/log into folder alongside Playwright artifacts

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -50,6 +50,11 @@ jobs:
           run: ${{ inputs.run-target }}
         env:
           VIDEO: ${{ inputs.video }}
+      - name: Put system logs alongside other artifacts
+        run: |
+          mkdir -p packages/zui-player/run/var_log
+          cp /var/log/sys*log* /var/log/kern.log* packages/zui-player/run/var_log || true
+        shell: sh
       - uses: actions/upload-artifact@v2
         if: failure() && steps.playwright.outcome == 'failure'
         with:
@@ -57,6 +62,5 @@ jobs:
           path: |
             packages/zui-player/run/playwright-itest
             packages/zui-player/run/videos
+            packages/zui-player/run/var_log
             packages/zui-player/test-results
-            /var/log/sys*log*
-            /var/log/kern.log*


### PR DESCRIPTION
When I started gathering system logs in #2962, this awakened an unfortunate behavior of the `upload-artifact` Action: Once I start asking it to include a root level path in the artifacts bundle, it uses root-based paths for _all_ the artifacts. So for instance on macOS the unpacked artifacts bundle was starting to look like:

![image](https://github.com/brimdata/zui/assets/5934157/bd15165b-baac-4c73-a6aa-cebb6d6e4c07)

This just creates lots of extra clicks to get to the good stuff. Therefore in this PR I make a directory alongside the other Playwright artifacts and put the system logs there so now I get the more sane hierarchy:

![image](https://github.com/brimdata/zui/assets/5934157/86d04af6-1a31-4743-bf5b-a7fbffffd841)

