### PR TITLE
Point to Brimcap that uses new build-zeek artifact

### DIFF
--- a/apps/zui/electron-builder.json
+++ b/apps/zui/electron-builder.json
@@ -4,11 +4,6 @@
   "asarUnpack": ["zdeps", "LICENSE.txt", "acknowledgments.txt", "**/*.node"],
   "directories": {"output": "../../dist/apps/zui"},
   "protocols": [{"name": "zui", "schemes": ["zui"]}],
-  "mac": {
-    "binaries": [
-      "zdeps/zeek/lib/zeek/plugins/Corelight_CommunityID/lib/Corelight-CommunityID.darwin-x86_64.so"
-    ]
-  },
   "linux": {"target": ["deb", "rpm"]},
   "rpm": {"depends": ["openssl"]},
   "deb": {"depends": ["openssl"]},

--- a/apps/zui/package.json
+++ b/apps/zui/package.json
@@ -75,7 +75,7 @@
     "acorn": "^7.4.1",
     "ajv": "^6.9.1",
     "animejs": "^3.2.0",
-    "brimcap": "brimdata/brimcap#v1.5.5",
+    "brimcap": "brimdata/brimcap#v1.6.0-alpha",
     "chalk": "^4.1.0",
     "chevrotain": "^10.5.0",
     "chrono-node": "^2.5.0",

--- a/apps/zui/package.json
+++ b/apps/zui/package.json
@@ -75,7 +75,7 @@
     "acorn": "^7.4.1",
     "ajv": "^6.9.1",
     "animejs": "^3.2.0",
-    "brimcap": "brimdata/brimcap#v1.6.0-alpha2",
+    "brimcap": "brimdata/brimcap#v1.6.0-alpha4",
     "chalk": "^4.1.0",
     "chevrotain": "^10.5.0",
     "chrono-node": "^2.5.0",

--- a/apps/zui/package.json
+++ b/apps/zui/package.json
@@ -75,7 +75,7 @@
     "acorn": "^7.4.1",
     "ajv": "^6.9.1",
     "animejs": "^3.2.0",
-    "brimcap": "brimdata/brimcap#v1.6.0-alpha4",
+    "brimcap": "brimdata/brimcap#v1.6.0-beta1",
     "chalk": "^4.1.0",
     "chevrotain": "^10.5.0",
     "chrono-node": "^2.5.0",

--- a/apps/zui/package.json
+++ b/apps/zui/package.json
@@ -75,7 +75,7 @@
     "acorn": "^7.4.1",
     "ajv": "^6.9.1",
     "animejs": "^3.2.0",
-    "brimcap": "brimdata/brimcap#v1.6.0-alpha",
+    "brimcap": "brimdata/brimcap#v1.6.0-alpha2",
     "chalk": "^4.1.0",
     "chevrotain": "^10.5.0",
     "chrono-node": "^2.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6815,12 +6815,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brimcap@brimdata/brimcap#v1.6.0-alpha4":
+"brimcap@brimdata/brimcap#v1.6.0-beta1":
   version: 1.1.2
-  resolution: "brimcap@https://github.com/brimdata/brimcap.git#commit=05d61aac5f79187bd27757f22748f3a3c105d5bd"
+  resolution: "brimcap@https://github.com/brimdata/brimcap.git#commit=48c5cd406c9b45a2ce30426b02df6ecdceed53c6"
   bin:
     brimcap: build/dist/brimcap
-  checksum: f9dc8437ae84025d2654c229918e176bef84b913febb346db65063aa888d0a148707c06ac813baf5d50e622409fdacc98721b56998ee156fbe6ff13565c7a12a
+  checksum: 30c7f2721128e707eaafaf97601644528e0d9bc88ecd895379ee61b0e8ce18cde71b9981eab472a791960a37620392b2a8aa25e4143cfbb2ff8db168c63201d0
   languageName: node
   linkType: hard
 
@@ -19213,7 +19213,7 @@ __metadata:
     acorn: ^7.4.1
     ajv: ^6.9.1
     animejs: ^3.2.0
-    brimcap: "brimdata/brimcap#v1.6.0-alpha4"
+    brimcap: "brimdata/brimcap#v1.6.0-beta1"
     chalk: ^4.1.0
     chevrotain: ^10.5.0
     chrono-node: ^2.5.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -6815,12 +6815,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brimcap@brimdata/brimcap#v1.6.0-alpha":
+"brimcap@brimdata/brimcap#v1.6.0-alpha2":
   version: 1.1.2
-  resolution: "brimcap@https://github.com/brimdata/brimcap.git#commit=ace294f6071f329c2652b9e247e9c3265cc13cee"
+  resolution: "brimcap@https://github.com/brimdata/brimcap.git#commit=2cf6c40de7d5aaaa05c5b37414ee0e4ee432ca03"
   bin:
     brimcap: build/dist/brimcap
-  checksum: 2807569c192eb9b4ffcf35cb8610e32cde0194246cab410d765df0d3861ef005d4a5a0bb8e28daba124ea476aa688ccc2b0d0cfcc8b35ef1f1d096def956075e
+  checksum: 05f96b0b740f0c7814e768f8b054daf045f61d592b25ec7d2359b02901058dc7561b2e5e1d2eba6d842e9b061605b37654baf12b3c4e162469376aabe0e9cd66
   languageName: node
   linkType: hard
 
@@ -19213,7 +19213,7 @@ __metadata:
     acorn: ^7.4.1
     ajv: ^6.9.1
     animejs: ^3.2.0
-    brimcap: "brimdata/brimcap#v1.6.0-alpha"
+    brimcap: "brimdata/brimcap#v1.6.0-alpha2"
     chalk: ^4.1.0
     chevrotain: ^10.5.0
     chrono-node: ^2.5.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -6815,12 +6815,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brimcap@brimdata/brimcap#v1.5.5":
+"brimcap@brimdata/brimcap#v1.6.0-alpha":
   version: 1.1.2
-  resolution: "brimcap@https://github.com/brimdata/brimcap.git#commit=c6873a9cac9c5735f0af438033f4a36c26292ad1"
+  resolution: "brimcap@https://github.com/brimdata/brimcap.git#commit=ace294f6071f329c2652b9e247e9c3265cc13cee"
   bin:
     brimcap: build/dist/brimcap
-  checksum: 32eed65d0f64dd61ee16c8bfb0dd70f88f8fd77b2f69356b62ac2c9de25db179d1e03fe6f31ac95887cd7b6526166f79c4948b21d4bd761b4aaf404106a7e0af
+  checksum: 2807569c192eb9b4ffcf35cb8610e32cde0194246cab410d765df0d3861ef005d4a5a0bb8e28daba124ea476aa688ccc2b0d0cfcc8b35ef1f1d096def956075e
   languageName: node
   linkType: hard
 
@@ -19213,7 +19213,7 @@ __metadata:
     acorn: ^7.4.1
     ajv: ^6.9.1
     animejs: ^3.2.0
-    brimcap: "brimdata/brimcap#v1.5.5"
+    brimcap: "brimdata/brimcap#v1.6.0-alpha"
     chalk: ^4.1.0
     chevrotain: ^10.5.0
     chrono-node: ^2.5.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -6815,12 +6815,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brimcap@brimdata/brimcap#v1.6.0-alpha2":
+"brimcap@brimdata/brimcap#v1.6.0-alpha4":
   version: 1.1.2
-  resolution: "brimcap@https://github.com/brimdata/brimcap.git#commit=2cf6c40de7d5aaaa05c5b37414ee0e4ee432ca03"
+  resolution: "brimcap@https://github.com/brimdata/brimcap.git#commit=05d61aac5f79187bd27757f22748f3a3c105d5bd"
   bin:
     brimcap: build/dist/brimcap
-  checksum: 05f96b0b740f0c7814e768f8b054daf045f61d592b25ec7d2359b02901058dc7561b2e5e1d2eba6d842e9b061605b37654baf12b3c4e162469376aabe0e9cd66
+  checksum: f9dc8437ae84025d2654c229918e176bef84b913febb346db65063aa888d0a148707c06ac813baf5d50e622409fdacc98721b56998ee156fbe6ff13565c7a12a
   languageName: node
   linkType: hard
 
@@ -19213,7 +19213,7 @@ __metadata:
     acorn: ^7.4.1
     ajv: ^6.9.1
     animejs: ^3.2.0
-    brimcap: "brimdata/brimcap#v1.6.0-alpha2"
+    brimcap: "brimdata/brimcap#v1.6.0-alpha4"
     chalk: ^4.1.0
     chevrotain: ^10.5.0
     chrono-node: ^2.5.0


### PR DESCRIPTION
[v6.0.2-brim3](https://github.com/brimdata/build-zeek/releases/tag/v6.0.2-brim3) is a new Zeek artifact that's included in the [Brimcap v1.6.0-beta1](https://github.com/brimdata/brimcap/releases/tag/v1.6.0-beta1) pre-release artifact pointed at by this branch. I propose merging this PR to allow us to start using the new Zeek in our own internal Zui testing and also encourage community users to start trying it out via Zui Insiders.

Assuming that all goes well, when prepping the next set of GA release, I'll make a GA Brimcap `v1.6.0` that points to the same [v6.0.2-brim3](https://github.com/brimdata/build-zeek/releases/tag/v6.0.2-brim3) Zeek, and Zui can start pointing at that GA Brimcap+Zeek combo.

I've made a [Zui dev build](https://github.com/brimdata/zui/actions/runs/7547974747) based off this branch and tested it successfully with multiple pcaps on macOS, Linux, Ubuntu (`.deb` installer) and Rocky (`.rpm` installer).