### PR TITLE
CI e2e option to always upload artifacts even for non-failures

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,6 +19,10 @@ on:
         - 'true'
         - 'false'
         required: true
+      always-upload:
+        description: Whether to always upload artifacts even if tests don't fail
+        type: boolean
+        required: false
 
 jobs:
   run-e2e-tests:
@@ -56,7 +60,7 @@ jobs:
           cp /var/log/sys*log* /var/log/kern.log* packages/zui-player/run/var_log || true
         shell: sh
       - uses: actions/upload-artifact@v2
-        if: failure() && steps.playwright.outcome == 'failure'
+        if: (failure() && steps.playwright.outcome == 'failure') || inputs.always-upload
         with:
           name: artifacts-${{ matrix.os }}
           path: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,7 +20,7 @@ on:
         - 'false'
         required: true
       always-upload:
-        description: Whether to always upload artifacts even if tests don't fail
+        description: Always upload artifacts even if tests don't fail?
         type: boolean
         required: false
 


### PR DESCRIPTION
Sometimes when I'm debugging e2e tests I want to see the uploaded artifacts (Playwright videos, etc.) even if the run is not a failure. This change adds an Actions Input toggle to allow for that.

I tested out that the new checkbox works as intended with [this run](https://github.com/brimdata/zui/actions/runs/7550945571) and also confirmed in [this run](https://github.com/brimdata/zui/actions/runs/7552033865) that it maintains its default behavior of always uploading artifacts if the run is a failure.