### PR TITLE
Playwright screenshots for e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -60,7 +60,5 @@ jobs:
         with:
           name: artifacts-${{ matrix.os }}
           path: |
-            packages/zui-player/run/playwright-itest
-            packages/zui-player/run/videos
-            packages/zui-player/run/var_log
+            packages/zui-player/run/**
             packages/zui-player/test-results

--- a/packages/zui-player/helpers/test-app.ts
+++ b/packages/zui-player/helpers/test-app.ts
@@ -224,6 +224,10 @@ export default class TestApp {
     this.zui.process().stdout.on('data', (d) => console.log(d.toString()));
     this.zui.process().stderr.on('data', (d) => console.log(d.toString()));
   }
+
+  async takeScreenshot(filename: string) {
+    return await this.page.screenshot({ path: path.join('run', 'screenshots', filename), fullPage: true });
+  }
 }
 
 const getAppInfo = () => {

--- a/packages/zui-player/tests/export.spec.ts
+++ b/packages/zui-player/tests/export.spec.ts
@@ -58,7 +58,6 @@ test.describe('Export tests', () => {
         .waitFor();
 
       expect(fsExtra.statSync(file).size).toBe(expectedSize);
-      await app.takeScreenshot('export-' + label + '.png');
     });
   });
 });

--- a/packages/zui-player/tests/export.spec.ts
+++ b/packages/zui-player/tests/export.spec.ts
@@ -58,6 +58,7 @@ test.describe('Export tests', () => {
         .waitFor();
 
       expect(fsExtra.statSync(file).size).toBe(expectedSize);
+      await app.takeScreenshot('export-' + label + '.png');
     });
   });
 });


### PR DESCRIPTION
Per https://github.com/microsoft/playwright/issues/8208, one of the general Playwright features that's not quite there yet for Playwright-on-electron is fancy screenshot options such as top-level config that would capture them automatically in the event of test failures. However, it's quite easy to take them during debug iterations using a helper function like the one I'm adding in this PR. https://github.com/brimdata/zui/commit/a71fbad9f1a1c46dbd9dfd139086b56c97f5b171 shows an example where I used this helper function in [this Actions run](https://github.com/brimdata/zui/actions/runs/7562784692) to take screenshots during the Exports test right after each export succeeds.

![image](https://github.com/brimdata/zui/assets/5934157/666d0bb2-8015-4b2f-87df-7494e76d02ef)

![image](https://github.com/brimdata/zui/assets/5934157/181bda77-225e-4056-ba66-25a16160bfa8)
