### PR TITLE
Non-Action xvfb

### DIFF
--- a/.github/workflows/advance-zed.yml
+++ b/.github/workflows/advance-zed.yml
@@ -43,10 +43,7 @@ jobs:
       - run: yarn build
       - name: End to end tests
         id: playwright
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          options: -screen 0 1280x1024x24
-          run: yarn e2e:ci
+        run: /usr/bin/xvfb-run --auto-servernum -s "-screen 0 1280x1024x24" yarn e2e:ci
 
       - run: git -c user.name='Brim Automation' -c user.email=automation@brimdata.io commit -a -m 'upgrade Zed to ${{ env.zed_ref }}'
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,12 +48,15 @@ jobs:
       - run: yarn build
       - name: End to end tests
         id: playwright
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          options: -screen 0 1280x1024x24
-          run: ${{ inputs.run-target }}
+        run: |
+          if [ $(uname) = Linux ]; then
+            /usr/bin/xvfb-run --auto-servernum -s "-screen 0 1280x1024x24" ${{ inputs.run-target }}
+          else
+            ${{ inputs.run-target }}
+          fi
         env:
           VIDEO: ${{ inputs.video }}
+        shell: sh
       - name: Put system logs alongside other artifacts
         run: |
           mkdir -p packages/zui-player/run/var_log

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,7 +49,7 @@ jobs:
       - name: End to end tests
         id: playwright
         run: |
-          if [ "$RUNNER_OS" == "Linux" ]; then
+          if [ "$RUNNER_OS" = "Linux" ]; then
             /usr/bin/xvfb-run --auto-servernum -s "-screen 0 1280x1024x24" ${{ inputs.run-target }}
           else
             ${{ inputs.run-target }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,7 +49,7 @@ jobs:
       - name: End to end tests
         id: playwright
         run: |
-          if [ $(uname) = Linux ]; then
+          if [ "$RUNNER_OS" == "Linux" ]; then
             /usr/bin/xvfb-run --auto-servernum -s "-screen 0 1280x1024x24" ${{ inputs.run-target }}
           else
             ${{ inputs.run-target }}


### PR DESCRIPTION
While working on the e2e tests I saw notification that the [`GabrielBB/xvfb-action`](https://github.com/marketplace/actions/gabrielbb-xvfb-action) we've been using to run Zui inside X11 in CI has been deprecated. While they point to a maintained replacement [`coactions/setup-xvfb`](https://github.com/coactions/setup-xvfb), someone points out in https://github.com/coactions/setup-xvfb/issues/21 that `xvfb` is now built right into the hosted GitHub Actions Ubuntu Runners. This PR switches us using the built-in `xvfb` instead.

One of the features of the Action was:

> If it detects you're not using linux then your tests still run, but without xvfb, which is very practical for multi-platform workflows.

This is why there's a conditional now in `e2e.yml`. [This](https://github.com/brimdata/zui/actions/runs/7563264061) is a test run with this branch on all three platforms showing that's working as expected, e..g., video recordings in the artifacts.