### PR TITLE
Increase timeouts for e2e Packets tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,6 +19,12 @@ on:
         - 'true'
         - 'false'
         required: true
+      debug:
+        description: Playwright debug logging
+        type: choice
+        options:
+        - 'pw:api'
+        - ''
       always-upload:
         description: Always upload artifacts even if tests don't fail?
         type: boolean
@@ -56,6 +62,7 @@ jobs:
           fi
         env:
           VIDEO: ${{ inputs.video }}
+          DEBUG: ${{ inputs.debug }}
         shell: sh
       - name: Put system logs alongside other artifacts
         run: |

--- a/packages/zui-player/tests/packets.spec.ts
+++ b/packages/zui-player/tests/packets.spec.ts
@@ -1,8 +1,15 @@
 import { play } from 'zui-player';
 import { getPath } from 'zui-test-data';
+import { isCI } from '../helpers/env';
 
+// Timeouts are increased due to observed long pcap load times in CI.
+// See
 play('packets.spec', (app, test) => {
   test('dropping a pcap does not pop up preview and load', async () => {
+    if (isCI()) {
+      test.setTimeout(120000);
+      app.page.setDefaultTimeout(120000);
+    }
     await app.dropFile(getPath('sample.pcap'));
     await app.attached(/Successfully loaded into sample.pcap/);
   });
@@ -17,6 +24,10 @@ play('packets.spec', (app, test) => {
   });
 
   test('loading a bad pcap displays an error message', async () => {
+    if (isCI()) {
+      test.setTimeout(120000);
+      app.page.setDefaultTimeout(120000);
+    }
     await app.dropFile(getPath('bad.pcapng'));
     await app.attached(/Unable to generate full summary logs from PCAP/);
   });

--- a/packages/zui-player/tests/packets.spec.ts
+++ b/packages/zui-player/tests/packets.spec.ts
@@ -3,7 +3,7 @@ import { getPath } from 'zui-test-data';
 import { isCI } from '../helpers/env';
 
 // Timeouts are increased due to observed long pcap load times in CI.
-// See
+// See https://github.com/brimdata/zui/pull/2978
 play('packets.spec', (app, test) => {
   test('dropping a pcap does not pop up preview and load', async () => {
     if (isCI()) {


### PR DESCRIPTION
## tl;dr

Data shows that loading pcaps in CI can take a long time. Therefore this PR proposes increasing timeouts for tests that load pcaps.

Some additional Playwright debug logging was useful in crafting this PR, so I'm also proposing keeping that around.

## Details

I've been on a mission to understand why the e2e `packets.spec.ts` test consistently fails in CI on Ubuntu. During my research, I also found that the test actually runs fine on both Windows and macOS, but the variance on the time to load the pcap test data is significant, with observed load times sometimes getting above 1-minute. If we hit the default 30-second test timeout in CI, that does little more than interrupt us to examine the failure, conclude that our run got landed on an Actions Runner that's having a bad day, and click re-run. Therefore it seems defensible to just increase the test timeout and be patient to see the likely successful run.

When figuring out how to best increase the timeouts, I learned some subtleties about where Playwright timeouts are set and where they take effect. For instance, increasing the top-level `timeout` Playwright config beyond the 30-second default does indeed trickle down that timeout value to each individual `beforeAll()`, `afterAll()` and `test()`. However, while `setTimeout()` can be used within an individual `test()` to change the timeout for just that test (e.g., as we might like to do here for a `test()` that loads a pcap), that alone does _not_ increase the timeouts for the individual steps within the test (e.g., the locators such as the [`waitFor()`](https://playwright.dev/docs/api/class-locator#locator-wait-for) inevitably used to pause until the app pops up a message saying the pcap load was successful). Like many other Playwright methods, `waitFor()` has a `timeout` option that would also need to be increased in this case to the maximum amount of time we expect the pcap load might take to succeed.

I discussed with @jameskerr how to best cleanly change the timeout only where needed. The ideal surgical option would be to pass an optional `timeout` argument into our `attached()` helper function and pass that along in its call to `waitFor()`. However, the way the existing parameters are wired up in `attached()` makes this difficult to add without reworking how `attached()` is called in all the places that don't currently need any timeout changes, so this feels heavy-handed.

As a "good enough" approach, @jameskerr spotted [`page.setDefaultTimeout()`](https://playwright.dev/docs/api/class-page#page-set-default-timeout) which can be set at the test level and "changes the default maximum time for all the methods accepting timeout option", i.e., including the `waitFor()` that's ultimately called by `attached()`. In theory that approach has the potential to increase timeouts in other operations within a test that shouldn't need super long timeouts (e.g, clicks on buttons) and hence cause long wait times on legit failures. But these pcap load tests are so narrow in scope that it absolutely does the trick here.

To quantify the need, I did four Actions runs in both macOS and Windows Runners with the increased timeouts from this branch. While the Playright videos and traces provide a handy way to see how operations take, the Playwright debug logging that can be turned on with the env var `DEBUG=pw:api` allows this info to be seen right in the Actions run log, so I've added an Input here to the Actions Workflow and made use of it. Here's examples of the long steps in each of the pcap load tests as seen in one of the runs, showing them taking 20 seconds and 24 seconds, respectively.

```
...
pw:api   locator resolved to visible <div role="status" aria-live="polite" class="go141521…>Successfully loaded into sample.pcap</div> +20s
...
pw:api   locator resolved to visible <div role="status" aria-live="polite" class="go141521…>Load error Unable to generate full summary logs f…</div> +24s
...
```

A summary of these results across all four runs:

|**Actions Run**|**Load sample.pcap<br>(macOS)**|**Unable to load bad.pcap<br>(macOS)**|**Load sample.pcap<br>(Windows)**|**Unable to load bad.pcap<br>(Windows)**|
|-|-|-|-|-|
|[#1](https://github.com/brimdata/zui/actions/runs/7587252023)|36 seconds|60 seconds|3 seconds|35 seconds|
|[#2](https://github.com/brimdata/zui/actions/runs/7587259956)|22 seconds|29 seconds|3 seconds|37 seconds|
|[#3](https://github.com/brimdata/zui/actions/runs/7587264238)|40 seconds|40 seconds|3 seconds|41 seconds|
|[#4](https://github.com/brimdata/zui/actions/runs/7587272062)|20 seconds|24 seconds|2 seconds|40 seconds|

In conclusion, since we've seen it hit a full 60 seconds and still succeed, that leaves me inclined to double it to 120 seconds as I've done in my PR and hope that's enough for all but the worst infrastructure mishaps.