### PR TITLE
Shortcut for Export

### DIFF
--- a/apps/zui/src/electron/windows/search/app-menu.ts
+++ b/apps/zui/src/electron/windows/search/app-menu.ts
@@ -70,6 +70,7 @@ export function compileTemplate(
 
   const exportResults: MenuItemConstructorOptions = {
     label: "Export Results As...",
+    accelerator: "CmdOrCtrl+Shift+E",
     click: () => window.send("showExportResults"),
   }
 


### PR DESCRIPTION
Adds the shortcut cmd+shift+e to pull up the export dialog.