### PR TITLE
Adapt to Zeek "files" log losing conn_uids+tx_hosts+rx_hosts and gaining uid+id

### DIFF
--- a/apps/zui/src/plugins/brimcap/zeek/correlations.ts
+++ b/apps/zui/src/plugins/brimcap/zeek/correlations.ts
@@ -29,7 +29,7 @@ export function activateZeekCorrelations() {
       return zedScript`
         from ${session.poolName} 
         | md5==${getMd5()} 
-        | count() by tx_hosts 
+        | count() by tx_host:=id.resp_h 
         | sort -r 
         | head 5`
     },
@@ -41,7 +41,7 @@ export function activateZeekCorrelations() {
       return zedScript`
           from ${session.poolName} 
           | md5==${getMd5()} 
-          | count() by rx_hosts 
+          | count() by rx_host:=id.orig_h 
           | sort -r 
           | head 5`
     },

--- a/apps/zui/src/plugins/brimcap/zeek/queries.ts
+++ b/apps/zui/src/plugins/brimcap/zeek/queries.ts
@@ -6,7 +6,7 @@ export function uidQuery(pool: string, uid: string) {
 }
 
 export function uidFilter(uid: string) {
-  return zedScript`uid==${uid} or ${uid} in conn_uids or ${uid} in uids or referenced_file.uid==${uid}`
+  return zedScript`uid==${uid} or ${uid} in uids or referenced_file.uid==${uid}`
 }
 
 export function communityConnFilter(data: CommunityConnArgs) {
@@ -25,6 +25,7 @@ export function findConnLog(pool: string, uid: string) {
   | (` +
     uidFilter(uid) +
     `)
+  | _path=="conn" 
   | is(ts, <time>) 
   | is(duration, <duration>) 
   | is(uid, <string>)

--- a/apps/zui/src/plugins/brimcap/zeek/util.ts
+++ b/apps/zui/src/plugins/brimcap/zeek/util.ts
@@ -7,7 +7,6 @@ export function findUid(value: zed.Value) {
   }
 
   const specialUids = {
-    files: "conn_uids",
     dhcp: "uids",
   }
   if (value.has("_path")) {

--- a/apps/zui/src/ppl/detail/models/Correlation.ts
+++ b/apps/zui/src/ppl/detail/models/Correlation.ts
@@ -2,7 +2,6 @@ import {get} from "lodash"
 import * as zed from "@brimdata/zed-js"
 
 const specialUids = {
-  files: "conn_uids",
   dhcp: "uids",
 }
 

--- a/apps/zui/src/ppl/zeek/descriptions.ts
+++ b/apps/zui/src/ppl/zeek/descriptions.ts
@@ -244,19 +244,14 @@ export default {
       desc: "An identifier associated with a single file.",
     },
     {
-      name: "tx_hosts",
-      type: "table",
-      desc: "If this file was transferred over a network connection this should show the host or hosts that the data sourced from.",
+      name: "uid",
+      type: "string",
+      desc: "Unique ID for the connection.",
     },
     {
-      name: "rx_hosts",
-      type: "table",
-      desc: "If this file was transferred over a network connection this should show the host or hosts that the data traveled to.",
-    },
-    {
-      name: "conn_uids",
-      type: "table",
-      desc: "Connection UIDs over which the file was transferred.",
+      name: "id",
+      type: "record conn_id",
+      desc: "The connection's 4-tuple of endpoint addresses/ports.",
     },
     {
       name: "source",


### PR DESCRIPTION
Fixes #2980

When #2971 merged, Zui went from using a Zeek artifact based on Zeek v3.2.1 to an artifact based on Zeek v6.0.2. This exposed Zui to a "breaking change" as part of Zeek [v5.1.0](https://github.com/zeek/zeek/releases/tag/v5.1.0) that broke the **Download Packets** feature in some circumstances as shown in #2980. From the Zeek release notes:

> By default, `files.log` does not have the fields `tx_hosts`, `rx_hosts` and `conn_uids` anymore. These have been replaced with the more commonly used `uid` and `id` fields.

Here's the affected code as it stands on the tip of `main`:

https://github.com/brimdata/zui/blob/e275ddd2040b5843d68609afb29648d2f5b7e781/apps/zui/src/plugins/brimcap/zeek/queries.ts#L21-L34

https://github.com/brimdata/zui/blob/e275ddd2040b5843d68609afb29648d2f5b7e781/apps/zui/src/plugins/brimcap/zeek/queries.ts#L8-L10

If I manually construct that query after loading the `ifconfig.pcapng` test data from #2980 and drop the `head 1`, we can see why it started failing.

![image](https://github.com/brimdata/zui/assets/5934157/3cbbad22-ffa6-408a-9c0a-8c24794d7d61)

This shows that the "breaking change" to the `files` record means it has taken on so many characteristics of the `conn` log that it ended up slipping through all the filter logic in `findConnLog()` only to be found unusable elsewhere when the pcap extraction logic looked for the `proto` field that's normally found on a true `conn` record. In this PR I've tightened up the logic so `findConnLog()` only finds a true `conn` record.

---

Once I became hip to the scope of the change, I looked into other possible side effects of the add/remove of those fields. As I recall it having been explained to me, the complexity with `conn_uids`, `tx_hosts`, and `rx_hosts` all being `set` types was an attempt to capture situations where multiple hosts could simultaneously be involved in send/receive of a given file, such as may happen in peer-to-peer file sharing protocols. And I seem to recall that the "breaking change" to the `files` log was effectively an acceptance of how that never really worked properly and just created confusion. Therefore the single `uid` would now correlate a `files` event with its corresponding `conn` record, and likewise the `id.orig_h` and `id.resp_h` would show the hosts involved in the transfer of a given file.

This all means that reacting to the change actually simplifies and fixes some things. Most of the other Zeek log types are trivially joined by `uid`, and now `files` is much the same, which means `conn_uids` can be dropped from the add-ons in our `uid` filtering logic. Likewise, while Zed v1.5.0 didn't have the #2980 problem, with `tx_hosts` and `rx_hosts` as sets, the Detail pane showed the count summary like this:

![image](https://github.com/brimdata/zui/assets/5934157/811295b1-bbb8-46de-a71c-228df8c6f200)

Whereas the primitive values plus the fixes in this branch means we can actually show meaningful IP addresses again.

![image](https://github.com/brimdata/zui/assets/5934157/920272a7-16ac-4211-a2ac-384ab5d4b454)

---

Other things to note:

1. After recognizing the impact this Zeek change had on us, I browsed all their release notes in versions since the Zeek v3.2.1 we used in the past. Nothing stood out.

2. I fixed the hover text descriptions in this PR, but then I realized they don't actually work anymore and broke when #2895 merged, so they were presumably a casualty of the "New Detail Pane Design" cited there. I don't know if this is a surprise but since we've not done another GA release since that merged we could make a call on if we're ready to let that functionality go (in which case we should probably remove the dead code) or if it can be fixed (I don't know how many users rely on it, but it always seemed to me like a nice proof-of-concept of something we could find a way for users to do with their own custom data sources, perhaps using plugins?)

3. The fact that the **Download Packets** button failed so quietly in the #2980 repro is somewhat concerning to me, but I doubt I have the skills to dive into that. I could perhaps open another issue to pursue that separately.