### PR TITLE
Point to Brimcap that uses Zeek v6.0.3-based artifact

### DIFF
--- a/apps/zui/package.json
+++ b/apps/zui/package.json
@@ -72,7 +72,7 @@
     "acorn": "^7.4.1",
     "ajv": "^6.9.1",
     "animejs": "^3.2.0",
-    "brimcap": "brimdata/brimcap#v1.6.0-beta1",
+    "brimcap": "brimdata/brimcap#v1.6.0-beta2",
     "chalk": "^4.1.0",
     "chevrotain": "^10.5.0",
     "chrono-node": "^2.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6841,12 +6841,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brimcap@brimdata/brimcap#v1.6.0-beta1":
+"brimcap@brimdata/brimcap#v1.6.0-beta2":
   version: 1.1.2
-  resolution: "brimcap@https://github.com/brimdata/brimcap.git#commit=48c5cd406c9b45a2ce30426b02df6ecdceed53c6"
+  resolution: "brimcap@https://github.com/brimdata/brimcap.git#commit=979db041f1431ee74dd6549dda60528bb6e35c79"
   bin:
     brimcap: build/dist/brimcap
-  checksum: 30c7f2721128e707eaafaf97601644528e0d9bc88ecd895379ee61b0e8ce18cde71b9981eab472a791960a37620392b2a8aa25e4143cfbb2ff8db168c63201d0
+  checksum: 8b989f4f733247241f8b23280c839134b7b5a6ebf1e3a89249e95fcff4888f4a8d5fe4855bcafd9ead45d03be0ec39c3828e96196ca534e4619568f6c5b0b677
   languageName: node
   linkType: hard
 
@@ -19207,7 +19207,7 @@ __metadata:
     acorn: ^7.4.1
     ajv: ^6.9.1
     animejs: ^3.2.0
-    brimcap: "brimdata/brimcap#v1.6.0-beta1"
+    brimcap: "brimdata/brimcap#v1.6.0-beta2"
     chalk: ^4.1.0
     chevrotain: ^10.5.0
     chrono-node: ^2.5.0


### PR DESCRIPTION
Companion to https://github.com/brimdata/build-zeek/pull/8.