### PR TITLE
Fix packets e2e test in CI

### DIFF
--- a/.github/workflows/advance-zed.yml
+++ b/.github/workflows/advance-zed.yml
@@ -44,7 +44,8 @@ jobs:
       - name: End to end tests
         id: playwright
         run: |
-          # Mock for pcap slice opening to avoid hanging Actions Runner. See 
+          # Mock for pcap slice opening to avoid hanging Actions Runner.
+          # See https://github.com/brimdata/zui/pull/2987
           echo "application/vnd.tcpdump.pcap; /usr/bin/true" >> /home/runner/.mailcap
           /usr/bin/xvfb-run --auto-servernum -s "-screen 0 1280x1024x24" yarn e2e:ci
 

--- a/.github/workflows/advance-zed.yml
+++ b/.github/workflows/advance-zed.yml
@@ -43,7 +43,10 @@ jobs:
       - run: yarn build
       - name: End to end tests
         id: playwright
-        run: /usr/bin/xvfb-run --auto-servernum -s "-screen 0 1280x1024x24" yarn e2e:ci
+        run: |
+          # Mock for pcap slice opening to avoid hanging Actions Runner. See 
+          echo "application/vnd.tcpdump.pcap; /usr/bin/true" >> /home/runner/.mailcap
+          /usr/bin/xvfb-run --auto-servernum -s "-screen 0 1280x1024x24" yarn e2e:ci
 
       - run: git -c user.name='Brim Automation' -c user.email=automation@brimdata.io commit -a -m 'upgrade Zed to ${{ env.zed_ref }}'
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,6 +56,7 @@ jobs:
         id: playwright
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
+            # Mock for pcap slice opening to avoid hanging Actions Runner. See 
             echo "application/vnd.tcpdump.pcap; /usr/bin/true" >> /home/runner/.mailcap
             /usr/bin/xvfb-run --auto-servernum -s "-screen 0 1280x1024x24" ${{ inputs.run-target }}
           else

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,7 +56,8 @@ jobs:
         id: playwright
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
-            # Mock for pcap slice opening to avoid hanging Actions Runner. See 
+            # Mock for pcap slice opening to avoid hanging Actions Runner.
+            # See https://github.com/brimdata/zui/pull/2987
             echo "application/vnd.tcpdump.pcap; /usr/bin/true" >> /home/runner/.mailcap
             /usr/bin/xvfb-run --auto-servernum -s "-screen 0 1280x1024x24" ${{ inputs.run-target }}
           else

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,6 +56,7 @@ jobs:
         id: playwright
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
+            echo "application/vnd.tcpdump.pcap; /usr/bin/true" >> /home/runner/.mailcap
             /usr/bin/xvfb-run --auto-servernum -s "-screen 0 1280x1024x24" ${{ inputs.run-target }}
           else
             ${{ inputs.run-target }}

--- a/packages/zui-player/ci.config.js
+++ b/packages/zui-player/ci.config.js
@@ -3,5 +3,5 @@ const baseConfig = require('./playwright.config');
 module.exports = {
   ...baseConfig,
   /* This is the list of flaky tests to ignore when running on CI */
-  testIgnore: /(pool-loads|pool-groups|title-bar-buttons|packets).spec/,
+  testIgnore: /(pool-loads|pool-groups).spec/,
 };


### PR DESCRIPTION
Ever since the e2e `packets.spec.ts` test was added, we've seen it fail consistently in CI. The failure always happens during the `afterAll` step, such as during [this Actions run](https://github.com/brimdata/zui/actions/runs/7620273940):

```
  1) packets.spec.ts:26:3 › packets.spec › loading a bad pcap displays an error message ────────────
    "afterAll" hook timeout of 30000ms exceeded.
       at ../index.ts:14
      12 |     });
      13 |
    > 14 |     test.afterAll(async () => {
         |          ^
      15 |       await app.shutdown();
      16 |     });
      17 |     body(app, test);
        at /home/runner/work/zui/zui/packages/zui-player/index.ts:14:10
```

Things I learned through hacking:

1. The failure did not occur on Actions Runners for macOS or Windows.
2. While I'd only observed the failure on the Actions Runner for Ubuntu, I couldn't repro it on a local Ubuntu VM, even if I provisioned it as a server with no desktop environment in an attempt to make it more like the Actions Runner.
3. It was not something simple like `wireshark` being absent. My local Ubuntu VM didn't have Wireshark installed and it ran fine there.
4. The root cause was in the middle test for `getting a slice of the packets back`. If I commented that one out the others would run and the `afterAll` succeeded fine.
5. Playwright's ability to capture videos unfortunately came up short since they showed the app reaching the end of the test without issue. It's as if something was hanging the Runner during that `afterAll` step where the app tries to exit, but I couldn't see what it was.

Ultimately what did the trick was to use [nrgok-ssh](https://github.com/philrz/ngrok-ssh) but with `ssh -Y` on the provided command line in order to enable X11 forwarding. Combining this with [XQuartz](https://www.xquartz.org/) for macOS allowed me to actually `yarn start` Zui and have it exported back to my desktop and manually click through the same steps the test does. While playing around with using Electron's `shell.openPath()` to open the pcap slice (something I'll cover in a separate PR), the smoking gun was revealed on the console after clicking the **Download Packets**:

```
Error: no "view" mailcap rules found for type "application/vnd.tcpdump.pcap"
```

Surprisingly, after a long wait, an additional window opened up containing (you'll never guess this...) a **Microsoft Edge web browser**! Exactly how it's wired up is still unclear to be, but something on the Actions Runner seems to fall back to opening unknown file types in web browsers. The choice of Edge seems like an unironic "Hey, guess who owns GitHub?" choice [ 🙄 ] and if I simply _deleted_ the Edge binary from the Runner it would instead open up Firefox. Geez! In any case, all this hanky panky seems to have the side effect of effectively hanging the Runner, as it not only tanks the packets test, but actually prevents future tests from running, which is why the `title-bar-buttons.spec.ts` test was unfairly believed to be cursed in CI as well: As it was recently added, it just happened to be in the unfortunate position of running _after_ the packets test that hung the Runner.

I wasn't previously familiar with `mailcap`, but it's basically a registry on the system that says what apps open what MIME types. After a quick crash course I settled on what feels like a simple and effective fix for CI: I just add a mock entry in the user's home directory `.mailcap` that runs `/usr/bin/true` whenever the pcap slice tries to open. Much like when it ran successfully on my local Linux VM when no Wireshark was present, the app still sees the `Packets extracted. Opening...` pop-up as a sign of success, the actual opening of a pcap helper app is a successful no-op, and everybody wins.

With the fixes in this branch, here's five successful e2e runs in a row on an Actions Ubuntu Runner that includes the restored `packets` and `title-bar-buttons` tests:

* https://github.com/brimdata/zui/actions/runs/7620546017
* https://github.com/brimdata/zui/actions/runs/7620547738
* https://github.com/brimdata/zui/actions/runs/7620549880
* https://github.com/brimdata/zui/actions/runs/7620552096
* https://github.com/brimdata/zui/actions/runs/7620553214
