### PR TITLE
Pin Playwright dependencies to 1.41.1

### DIFF
--- a/packages/zui-player/package.json
+++ b/packages/zui-player/package.json
@@ -7,9 +7,9 @@
     "ci": "playwright test -c ci.config.js"
   },
   "dependencies": {
-    "@playwright/test": "next",
+    "@playwright/test": "1.41.1",
     "fs-extra": "^11.2.0",
-    "playwright": "next",
-    "playwright-chromium": "next"
+    "playwright": "1.41.1",
+    "playwright-chromium": "1.41.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3817,14 +3817,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:next":
-  version: 1.41.0-alpha-dec-20-2023
-  resolution: "@playwright/test@npm:1.41.0-alpha-dec-20-2023"
+"@playwright/test@npm:1.41.1":
+  version: 1.41.1
+  resolution: "@playwright/test@npm:1.41.1"
   dependencies:
-    playwright: 1.41.0-alpha-dec-20-2023
+    playwright: 1.41.1
   bin:
     playwright: cli.js
-  checksum: 0b177a16bf503150268adb6165d8f7f58dd24f7ea8e942d94fcefcef8e4bdd60c2fd39b88c43eb726d43aaaaea0d613818924915229302820af6151b60c7b108
+  checksum: d9877e777a1a7f60f097df57b6abc2478e2ae342930a409c8546c8aa40d6e206cbc16bf1c71b23414ac3fbad36dcae1ad79635d7f4eb705ab54d3c705e82ea04
   languageName: node
   linkType: hard
 
@@ -15285,38 +15285,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-chromium@npm:next":
-  version: 1.41.0-alpha-dec-20-2023
-  resolution: "playwright-chromium@npm:1.41.0-alpha-dec-20-2023"
+"playwright-chromium@npm:1.41.1":
+  version: 1.41.1
+  resolution: "playwright-chromium@npm:1.41.1"
   dependencies:
-    playwright-core: 1.41.0-alpha-dec-20-2023
+    playwright-core: 1.41.1
   bin:
     playwright: cli.js
-  checksum: 3482da232430d58ce3f354cb877581638eec6338be540b30515615bfbc779bfed24d98cfa5fc0989cfac3611e0e825027f139a5443646e4c519374b14c00a674
+  checksum: c341090ed603b285cc4cbb8e35d1764c2d5ea4b60718c969e448f3a638480bc8696bbbc65acb38beafbcd20029e4480117118da8cfcb1fc59596b57f40c279f4
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.41.0-alpha-dec-20-2023":
-  version: 1.41.0-alpha-dec-20-2023
-  resolution: "playwright-core@npm:1.41.0-alpha-dec-20-2023"
+"playwright-core@npm:1.41.1":
+  version: 1.41.1
+  resolution: "playwright-core@npm:1.41.1"
   bin:
     playwright-core: cli.js
-  checksum: 4d07324fbd42753a9c5ba0606c619b4d0c79209b9f8d6c385da62eee3c7992ac247b4ac9bc3af0dcfe8c44b5be48c2172aac54dd4fc173dfd97ff3ea2b769eaa
+  checksum: c83446a560c6bd85f6f0cd586ff8c643b77e2005567386e12f85890936cc370673114b94cd883246018797cc1580e93b0296ade7d07275bb611b8962f5bb9693
   languageName: node
   linkType: hard
 
-"playwright@npm:1.41.0-alpha-dec-20-2023, playwright@npm:next":
-  version: 1.41.0-alpha-dec-20-2023
-  resolution: "playwright@npm:1.41.0-alpha-dec-20-2023"
+"playwright@npm:1.41.1":
+  version: 1.41.1
+  resolution: "playwright@npm:1.41.1"
   dependencies:
     fsevents: 2.3.2
-    playwright-core: 1.41.0-alpha-dec-20-2023
+    playwright-core: 1.41.1
   dependenciesMeta:
     fsevents:
       optional: true
   bin:
     playwright: cli.js
-  checksum: 102ab0df329a007c02b5418dd38da2e82734db156fdd46c9cc409461fe357a0b585d0ca8f29061f728862fa00929e53a8bad71135bcacd8b03dc7cb226bc2532
+  checksum: 3da7fb929abdec6adbdd8829f840580f5f210713214a8d230b130127f2270403eb2113c6c1418012221149707250fff896794c7c22c260dd09a92bf800227f31
   languageName: node
   linkType: hard
 
@@ -19154,10 +19154,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "zui-player@workspace:packages/zui-player"
   dependencies:
-    "@playwright/test": next
+    "@playwright/test": 1.41.1
     fs-extra: ^11.2.0
-    playwright: next
-    playwright-chromium: next
+    playwright: 1.41.1
+    playwright-chromium: 1.41.1
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
While prepping the Zui `v1.6.0` release I spotted the note from #2934 that said:

> Update playwright to @next until 1.41 is released

It looks like Playwright is now up to a release [v1.41.1](https://github.com/microsoft/playwright/releases/tag/v1.41.1) so here I've pinned the dependencies. While all tests pass at this new combo, please double check that I'm doing this the right way as I'm basically just following a pattern. Thanks!