### PR TITLE
Fix Bugs Discovered by Steve

### DIFF
--- a/apps/zui/src/app/features/inspector/views/type-record-view.ts
+++ b/apps/zui/src/app/features/inspector/views/type-record-view.ts
@@ -8,7 +8,7 @@ export class TypeRecordView extends ContainerView<zed.TypeRecord> {
   }
 
   count() {
-    return this.value.fields.length
+    return this.value.fields?.length || 0
   }
 
   openToken() {
@@ -21,6 +21,7 @@ export class TypeRecordView extends ContainerView<zed.TypeRecord> {
 
   *iterate(n?: number) {
     const fields = this.value.fields
+    if (!fields) return
     const length = n ? Math.min(n, fields.length) : fields.length
 
     for (let i = 0; i < fields.length; ++i) {

--- a/apps/zui/src/core/query/run.ts
+++ b/apps/zui/src/core/query/run.ts
@@ -34,19 +34,13 @@ function run(id: string): Thunk<Promise<ResultStream | null>> {
     const paginatedQuery = Results.getPaginatedQuery(id)(getState())
 
     try {
-      const res = await api.query(paginatedQuery, {
-        id,
-        tabId,
-      })
-      res.collect(({rows, shapesMap}) => {
-        const values = isFirstPage ? [...rows] : [...prevVals, ...rows]
-        const shapes = isFirstPage
-          ? {...shapesMap}
-          : {...prevShapes, ...shapesMap}
+      const res = await api.query(paginatedQuery, {id, tabId})
+      await res.collect(({rows, shapesMap}) => {
+        const values = isFirstPage ? rows : [...prevVals, ...rows]
+        const shapes = isFirstPage ? shapesMap : {...prevShapes, ...shapesMap}
         dispatch(Results.setValues({id, tabId, values}))
         dispatch(Results.setShapes({id, tabId, shapes}))
       })
-      await res.promise
       dispatch(Results.success({id, tabId, count: res.rows.length}))
       return res
     } catch (e) {

--- a/apps/zui/src/js/api/zui-api.ts
+++ b/apps/zui/src/js/api/zui-api.ts
@@ -54,11 +54,7 @@ export default class ZuiApi {
   }
 
   createAbortable(tab?: string, tag?: string) {
-    try {
-      this.abortables.abort({tab, tag})
-    } catch (e) {
-      console.log("Abort Handled", e)
-    }
+    this.abortables.abort({tab, tag})
     const ctl = new AbortController()
     const id = this.abortables.add({
       abort: () => ctl.abort(),
@@ -74,7 +70,7 @@ export default class ZuiApi {
     const [signal, cleanup] = this.createAbortable(opts.tabId, opts.id)
     try {
       const resp = await zealot.query(body, {signal})
-      resp.promise.finally(cleanup)
+      resp.on("success", cleanup)
       return resp
     } catch (e) {
       cleanup()

--- a/packages/zed-js/src/query/channel.ts
+++ b/packages/zed-js/src/query/channel.ts
@@ -56,7 +56,9 @@ export class Channel extends EventEmitter {
     let timeId: ReturnType<typeof setTimeout>;
 
     const flush = () => {
-      collector({ rows: this.rows, shapesMap: this.shapesMap });
+      // Return shallow copies so that comsumers can do what they want
+      // with the rows and shapes
+      collector({ rows: [...this.rows], shapesMap: { ...this.shapesMap } });
       first = false;
       count = 0;
       clearTimeout(timeId);


### PR DESCRIPTION
1. Fix presentation of null record types.
2. Properly abort queries.
3. Provide shallow copies of objects in the collect callback.


**Details**

We were not catching the abort error properly when issuing a query before the previous query finished.

We also were not aborting all of the histogram queries when re-issuing a search.

This stuff is really hard to write tests for. There are no tests in this PR. 🤷‍♂️

To test this, re-issue the search with a large pool over and over again rapidly. Open the network tab and view all the in-flight requests properly cancelling when a new search is issued.

Fixes #2997
Fixes #2999