### PR TITLE
Point to Brimcap that has the cooked/SLL fix

### DIFF
--- a/apps/zui/package.json
+++ b/apps/zui/package.json
@@ -72,7 +72,7 @@
     "acorn": "^7.4.1",
     "ajv": "^6.9.1",
     "animejs": "^3.2.0",
-    "brimcap": "brimdata/brimcap#v1.6.0",
+    "brimcap": "brimdata/brimcap#c74d4ffbac71e68b8c50e6b646818382fac089af",
     "chalk": "^4.1.0",
     "chevrotain": "^10.5.0",
     "chrono-node": "^2.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6841,12 +6841,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brimcap@brimdata/brimcap#v1.6.0":
+"brimcap@brimdata/brimcap#c74d4ffbac71e68b8c50e6b646818382fac089af":
   version: 1.1.2
-  resolution: "brimcap@https://github.com/brimdata/brimcap.git#commit=3aaa41225c6aeb2dcf64179cf2c67d61b4721ea5"
+  resolution: "brimcap@https://github.com/brimdata/brimcap.git#commit=c74d4ffbac71e68b8c50e6b646818382fac089af"
   bin:
     brimcap: build/dist/brimcap
-  checksum: 0f8ae038108819bbba3b7e690350fd2c1cdcb81bec8619e12ed89bdf8a9a5bf430dff6dcfe841c6d2aa8e163859f0357915574aa44b04cc9bff6bd2e7b9269c2
+  checksum: 5eb61c7ed4c782677c470d08d713ed6523794af6ae9437f15c4a9b81870efd47c1d71e2775471122b71ac23f5cafbe894319c103431632187e610f5a43a36264
   languageName: node
   linkType: hard
 
@@ -19207,7 +19207,7 @@ __metadata:
     acorn: ^7.4.1
     ajv: ^6.9.1
     animejs: ^3.2.0
-    brimcap: "brimdata/brimcap#v1.6.0"
+    brimcap: "brimdata/brimcap#c74d4ffbac71e68b8c50e6b646818382fac089af"
     chalk: ^4.1.0
     chevrotain: ^10.5.0
     chrono-node: ^2.5.0


### PR DESCRIPTION
This points Zui at a Brimcap commit that includes the fix from https://github.com/brimdata/brimcap/pull/336. By merging this into Zui ASAP we can get it into a Zui Insiders release so the community user that reported the problem can benefit immediately.

The attached video is run with this branch to show the symptom shown in https://github.com/brimdata/brimcap/issues/19#issuecomment-1939379105 has been addressed.

https://github.com/brimdata/zui/assets/5934157/d204ddd9-f2f2-436b-b851-933f9aa35252
