### PR TITLE
Use the Zeek is_orig field to set files tx_host/rx_host

### DIFF
--- a/apps/zui/src/plugins/brimcap/zeek/correlations.ts
+++ b/apps/zui/src/plugins/brimcap/zeek/correlations.ts
@@ -29,7 +29,7 @@ export function activateZeekCorrelations() {
       return zedScript`
         from ${session.poolName} 
         | md5==${getMd5()} 
-        | count() by tx_host:=id.resp_h 
+        | count() by tx_host := (is_orig ? id.orig_h : id.resp_h)
         | sort -r 
         | head 5`
     },
@@ -41,7 +41,7 @@ export function activateZeekCorrelations() {
       return zedScript`
           from ${session.poolName} 
           | md5==${getMd5()} 
-          | count() by rx_host:=id.orig_h 
+          | count() by rx_host := (is_orig ? id.resp_h : id.orig_h)
           | sort -r 
           | head 5`
     },


### PR DESCRIPTION
A recent [Zeek community Slack thread](https://zeekorg.slack.com/archives/CSZBXF6TH/p1706728046628519?thread_ts=1706727605.964379&cid=CSZBXF6TH) educated me about the `is_orig` field of Zeek [`files`](https://docs.zeek.org/en/master/scripts/base/frameworks/files/main.zeek.html#type-Files::Info) logs. As those docs explain:

> If the source of this file is a network connection, this field indicates if the file is being sent by the originator of the connection or the responder.

In the changes I pushed in #2981 I wasn't yet aware of this so for the result in the Correlation view I'd just set the `tx_host` to be the `id.resp_h` of the `files` event and likewise set the `rx_host` to be the `id.orig_h`. This all makes sense for the common case of a file download, but it's incorrect for file uploads.

To illustrate the effect I've attached some test data [query-aws.pcapng.gz](https://github.com/brimdata/zui/files/14254236/query-aws.pcapng.gz) which is a capture of my laptop (IP `199.83.220.169`) performing a [query over the lake API](https://zed.brimdata.io/docs/lake/api#query) to a Zed service running on an AWS EC2 instance (IP `3.138.203.14`).

When this pcap is imported into Zui, Zeek ends up finding two `files` events within this single connection, the first of which is a log of the query payload (`{"query":"from inventory@main | count() by warehouse"}`) and the second which is the query response ) (`{warehouse:"chicago",count:2(uint64)} {warehouse:"miami",count:1(uint64)}`).

With Zui commit cf615ef that's current tip of `main` before this PR's branch, both `files` events show the `tx_host` to be the same value: That of the AWS instance.

![image](https://github.com/brimdata/zui/assets/5934157/9d6b6b28-4b02-40da-8ca9-02fdf8df4f03)

![image](https://github.com/brimdata/zui/assets/5934157/21cc7dbc-0045-437d-a442-9784208798a1)

Now at commit ae287aa using the branch for this PR, the first `files` event shows my laptop as the `tx_host`, which is more in line with expectations since my laptop is what "originated" the sending of the query payload.

![image](https://github.com/brimdata/zui/assets/5934157/c2e4e310-5fbc-4fd0-86e2-2ec51f90425f)

While the second `files` event shows the AWS instance as the `tx_host`, which also makes sense since it's what "originated" the sending of the query response.

![image](https://github.com/brimdata/zui/assets/5934157/feb50060-9140-4a10-84d8-36facaebbd3b)
