### PR TITLE
Give the export modal a max width

### DIFF
--- a/apps/zui/src/views/export-modal/index.tsx
+++ b/apps/zui/src/views/export-modal/index.tsx
@@ -29,7 +29,7 @@ export function ExportModal() {
   useSubmitKey(ref)
 
   return (
-    <PopoverModal ref={popover.ref} className="max-width:fit">
+    <PopoverModal ref={popover.ref} style={{maxWidth: "53ch"}}>
       <div className="stack-3 box-1">
         <div className="stack--2">
           <H1>Export Results</H1>
@@ -40,7 +40,7 @@ export function ExportModal() {
           className={classNames(forms.form, "stack-4")}
           onSubmit={(e) => ctl.submit(e)}
         >
-          <section className="stack-1 max-width:measure">
+          <section className="stack-1">
             <div className="field">
               <label>Export To</label>
               <div className="cluster">


### PR DESCRIPTION
As I was making the screen cast to share on twitter, I noticed the export modal changes it's width when you change export destinations between file and pool. This PR gives the export modal a consistent width.


![CleanShot 2024-02-26 at 12 46 11@2x](https://github.com/brimdata/zui/assets/3460638/041b8468-b4cb-4a18-b178-d581686f798b)

