### PR TITLE
Specify explicit ZNG format from file loader

### DIFF
--- a/apps/zui/src/domain/loads/file-loader.ts
+++ b/apps/zui/src/domain/loads/file-loader.ts
@@ -33,6 +33,7 @@ export class FileLoader implements Loader {
       res = await client.load(body, {
         pool: ctx.poolId,
         branch: ctx.branch,
+        format: 'zng',
         message: {
           author: ctx.author,
           body: ctx.body,

--- a/apps/zui/src/domain/loads/file-loader.ts
+++ b/apps/zui/src/domain/loads/file-loader.ts
@@ -33,7 +33,7 @@ export class FileLoader implements Loader {
       res = await client.load(body, {
         pool: ctx.poolId,
         branch: ctx.branch,
-        format: 'zng',
+        format: "zng",
         message: {
           author: ctx.author,
           body: ctx.body,


### PR DESCRIPTION
The "auto-detect failure messages" described in the 4th bullet at #3025 were not something I expected to see. As far as I can tell the `zq`-based shaper is always present in Zui's "file loader" pipeline (but this is something I'm hoping can be confirmed via review!) By default `zq` will always output binary ZNG in such a pipeline. Normally a `load` operation to the Zed lake will always happily auto-detect binary ZNG input so this has not generally been a problem. However my repro details in https://github.com/brimdata/zed/issues/3865#issuecomment-1995839362 show that this `mun.json` test data from #3025 seems to pose a unique challenge because `zq`'s ZNG output from reading that particular JSON happens to fail `load` via auto-detect.

While that Zed issue remains a mystery for the moment, it seems we can avoid it entirely and address the main #3025 symptom by explicitly specifying ZNG as the expected load format.

Here's verification of the change in this branch fixing the main #3025 symptom.

https://github.com/brimdata/zui/assets/5934157/a86138cc-96f1-4b83-82cd-9d8d43529957

