### PR TITLE
README adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Please browse the [support resources](https://zui.brimdata.io/docs/support) to r
 
 ## Contributing
 
-We welcome your contributions! Please refer to our [contributing guide](CONTRIBUTING.md) for information on how to get involved in development.
+We welcome your contributions! Please refer to our [contributing guide](apps/zui/CONTRIBUTING.md) for information on how to get involved in development.
 
 ## Join the Community
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,67 @@
-# Zealot
+# Zui
 
-The Zealot monorepo is the home to JavaScript apps and libraries related to the [Zed](https://github.com/brimdata/zed) data platform.
+_The Official Front-End to the [Zed Lake](https://zed.brimdata.io/docs/commands/zed)_
 
-This project is managed with the [nx](https://nx.dev) monorepo tool.
+![Zui](https://user-images.githubusercontent.com/3460638/216508967-6936f8fd-0579-4e85-8097-f0e22e6ebc27.png)
 
-Inside the /packages/ folder you'll find the source code for:
+Zui is a desktop app for exploring and working with data.
 
-- **zed-js**: the JavaScript library for browsers
-- **zed-node**: the JavaScript library for node
-- **zed-wasm**: the Zed cli tools in the browser
+Highlights:
+
+- **Drag-and-drop** data ingest
+- **Automatic detection** of common data formats
+- **Schema inference** during ingest
+- **Beautiful result views** for nested or tabular data
+- **Named queries** with version history
+- **Query session history** to keep track of your work
+- **Pinnable query fragments** to keep your search box uncluttered
+- **Right-click menus** for pivoting and filtering
+
+## Ready To Try It Out?
+
+**[Download Zui](https://www.brimdata.io/download/)** for your operating system.
+
+Refer to the [installation guide](https://zui.brimdata.io/docs/Installation) and
+[release notes](https://github.com/brimdata/zui/releases) for more information.
+
+## Powered By Zed
+
+[Zed](https://zed.brimdata.io/docs) offers an innovative approach to working with data known as "[Super-Structured Data](https://www.brimdata.io/blog/super-structured-data/)".
+
+Behind Zui is a local [Zed Lake](https://zed.brimdata.io/docs/commands/zed) instance where you can load your data into [pools](https://zed.brimdata.io/docs/commands/zed#data-pools) and use the powerful Zed [language](https://zed.brimdata.io/docs/language) to search, analyze, and transform it. Use it to:
+
+- Explore deeply nested JSON objects
+- View Parquet and Arrow IPC stream files
+- Clean up CSV files by adding type information
+- Search heterogeneous NDJSON logs
+- Transform data from a legacy database's CDC logs
+- Investigate [Zeek](https://zeek.org/) security logs
+
+Zed provides a system to make working with data easier and more efficient. The [storage layer](https://zed.brimdata.io/docs/formats), [type system](https://zed.brimdata.io/docs/formats/zed), [query language](https://zed.brimdata.io/docs/language/overview), and [`zq`](https://zed.brimdata.io/docs/commands/zq) command-line utility are just a few of the tools Zed offers to the data community.
+
+## Formerly Known as "Brim"
+
+For many years, the app was known as Brim, named after the company [Brim Data](https://www.brimdata.io/) that created it. In 2023, it was renamed to Zui (a play on "Zed User Interface") to better reflect its connection to the Zed technology that powers it.
+
+Zui retains the security-specific features that made Brim popular while expanding its reach to anyone who has data to work with. For example, you'll still find the customized views, histograms, and correlations relevant to the security domain appearing in Zui via its nascent plugin system. In the future, developers will be able to create custom plugins that make Zui even more effective for their specific needs.
+
+## Related Packages
+
+This Zui code repository is actually a [monorepo](https://en.wikipedia.org/wiki/Monorepo) (managed with [nx](https://nx.dev)) that includes several [packages](packages) on which the app depends. They may also be used as standalone tools. These include:
+
+- [**zed-js**](packages/zed-js): the JavaScript library for browsers
+- [**zed-node**](packages/zed-node): the JavaScript library for [Node.js](https://nodejs.org/)
+- [**zed-wasm**](packages/zed-wasm): the Zed [command-line tools](https://zed.brimdata.io/docs/commands) in the browser
+- [**zui-player**](packages/zui-player): the end-to-end testing framework for Zui
+
+## Need Help?
+
+Please browse the [support resources](https://zui.brimdata.io/docs/support) to review common problems and helpful tips before [opening an issue](https://zui.brimdata.io/docs/support/Troubleshooting#opening-an-issue).
+
+## Contributing
+
+We welcome your contributions! Please refer to our [contributing guide](CONTRIBUTING.md) for information on how to get involved in development.
+
+## Join the Community
+
+[Join our public Slack](https://www.brimdata.io/join-slack/) workspace to stay up to date on announcements, ask questions, and exchange tips with other users.

--- a/apps/zui/CONTRIBUTING.md
+++ b/apps/zui/CONTRIBUTING.md
@@ -144,7 +144,7 @@ See the [Adding Migrations](https://zui.brimdata.io/docs/developer/Adding-Migrat
 
 ### Zed
 
-The [Zed service](https://zed.brimdata.io/docs/commands/zed#213-serve) is the daemon responsible for data ingestion and query execution. As a postinstall step, the `zed` binary is downloaded and stored in the `./zdeps` directory. Zui will automatically execute and terminate the service when it starts and stops.
+The [Zed service](https://zed.brimdata.io/docs/commands/zed#serve) is the daemon responsible for data ingestion and query execution. As a postinstall step, the `zed` binary is downloaded and stored in the `./zdeps` directory. Zui will automatically execute and terminate the service when it starts and stops.
 
 ## Pull Requests
 

--- a/apps/zui/README.md
+++ b/apps/zui/README.md
@@ -1,58 +1,5 @@
 # Zui
 
-_The Official Front-End to the [Zed Lake](https://zed.brimdata.io/docs/commands/zed)_
-
-![Zui](https://user-images.githubusercontent.com/3460638/216508967-6936f8fd-0579-4e85-8097-f0e22e6ebc27.png)
-
 Zui is a desktop app for exploring and working with data.
 
-Highlights:
-
-- **Drag-and-drop** data ingestion
-- **Automatic detection** of common data formats
-- **Schema inference** during ingestion
-- **Beautiful result views** for nested or tabular data
-- **Named queries** with version history
-- **Query session history** to keep track of your work
-- **Pinnable query fragments** to keep your search box uncluttered
-- **Right-click menus** for pivoting and filtering
-
-## Ready To Try It Out?
-
-**[Download Zui](https://www.brimdata.io/download/)** for your operating system.
-
-Refer to the [installation guide](https://zui.brimdata.io/docs/Installation) and
-[release notes](https://github.com/brimdata/zui/releases) for more information.
-
-## Powered By Zed
-
-[Zed](https://zed.brimdata.io/docs) offers an innovative approach to working with data known as "[Super-Structured Data](https://www.brimdata.io/blog/super-structured-data/)".
-
-Behind Zui is a local Zed lake instance where you can load your data into pools and use the powerful Zed language to search, analyze, and transform it. Use it to:
-
-- Explore deeply nested JSON objects
-- View Parquet and Arrow IPC stream files
-- Clean up CSV files by adding type information
-- Search heterogeneous NDJSON logs
-- Transform data from a legacy database's CDC logs
-- Investigate Zeek security logs
-
-Zed provides a system to makes working with data easier and more efficient. The [storage layer](https://zed.brimdata.io/docs/formats), [type system](https://zed.brimdata.io/docs/formats/zed), [query language](https://zed.brimdata.io/docs/language/overview), and [zq](https://zed.brimdata.io/docs/commands/zq) command-line utility are just a few of the tools Zed offers to the data community.
-
-## Formerly Known as "Brim"
-
-For many years, the app was known as Brim, named after the company [Brim Data](https://www.brimdata.io/) that created it . In 2023, it was renamed to Zui, a play on "Zed User Interface", to better reflect its connection to the Zed technology that powers it.
-
-Zui retains the security-specific features that made Brim popular while expanding its reach to anyone who has data to work with. For example, you'll still find the customized views, histograms, and correlations relevant to the security domain appearing in Zui via our nascent plugin system. In the future, developers will be able to create custom plugins that make Zui even more effective for their specific needs.
-
-## Need Help?
-
-Please browse the [support resources](https://zui.brimdata.io/docs/support) to review common problems and helpful tips before [opening an issue](https://zui.brimdata.io/docs/support/Troubleshooting#opening-an-issue).
-
-## Contributing
-
-We welcome your contributions! Please refer to our [contributing guide](CONTRIBUTING.md) for information on how to get involved in development.
-
-## Join the Community
-
-[Join our public Slack](https://www.brimdata.io/join-slack/) workspace to stay up to date on announcements, ask questions, and exchange tips with other users.
+See this repo's [top-level README](../../README.md) for details.


### PR DESCRIPTION
In the time since #2818 merged, the top-level README for the repo has been incomplete/inaccurate. In this PR I propose moving the Zui app README detail to the top-level README and including a section that describes it all being a monorepo and what other packages are available. I've included a few other clean-ups along the way, which is mostly just adding/fixing hyperlinks.