### PR TITLE
Point to Brimcap that uses Zeek v6.2.0 artifact

### DIFF
--- a/apps/zui/package.json
+++ b/apps/zui/package.json
@@ -72,7 +72,7 @@
     "acorn": "^7.4.1",
     "ajv": "^6.9.1",
     "animejs": "^3.2.0",
-    "brimcap": "brimdata/brimcap#c74d4ffbac71e68b8c50e6b646818382fac089af",
+    "brimcap": "brimdata/brimcap#9b5db462f28984c900d32eb57f517e16762ac019",
     "chalk": "^4.1.0",
     "chevrotain": "^10.5.0",
     "chrono-node": "^2.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6868,12 +6868,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brimcap@brimdata/brimcap#c74d4ffbac71e68b8c50e6b646818382fac089af":
+"brimcap@brimdata/brimcap#9b5db462f28984c900d32eb57f517e16762ac019":
   version: 1.1.2
-  resolution: "brimcap@https://github.com/brimdata/brimcap.git#commit=c74d4ffbac71e68b8c50e6b646818382fac089af"
+  resolution: "brimcap@https://github.com/brimdata/brimcap.git#commit=9b5db462f28984c900d32eb57f517e16762ac019"
   bin:
     brimcap: build/dist/brimcap
-  checksum: 5eb61c7ed4c782677c470d08d713ed6523794af6ae9437f15c4a9b81870efd47c1d71e2775471122b71ac23f5cafbe894319c103431632187e610f5a43a36264
+  checksum: 1d83333919b5a34793de177c7134d27c3d2407a5b9871378d76bf6a802a910efa2cbfc166344358f4872048ece6f0111b40f83cced6a7ffbbe2795e6aa29308d
   languageName: node
   linkType: hard
 
@@ -19311,7 +19311,7 @@ __metadata:
     acorn: ^7.4.1
     ajv: ^6.9.1
     animejs: ^3.2.0
-    brimcap: "brimdata/brimcap#c74d4ffbac71e68b8c50e6b646818382fac089af"
+    brimcap: "brimdata/brimcap#9b5db462f28984c900d32eb57f517e16762ac019"
     chalk: ^4.1.0
     chevrotain: ^10.5.0
     chrono-node: ^2.5.0


### PR DESCRIPTION
https://github.com/brimdata/brimcap/pull/338 includes an artifact based on the latest Zeek release. When I next prep GA releases I'll tag a proper Brimcap release, but as early prep for that, I'd like to get Zui pointing at that new Brimcap ASAP so I can push a Zui Insiders release to the community for testing before those GA releases get assembled.