### PR TITLE
Run pool load e2e tests in CI again

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,18 +55,27 @@ jobs:
       - name: End to end tests
         id: playwright
         run: |
-          if [ "$RUNNER_OS" = "Linux" ]; then
-            # Mock for pcap slice opening to avoid hanging Actions Runner.
-            # See https://github.com/brimdata/zui/pull/2987
-            echo "application/vnd.tcpdump.pcap; /usr/bin/true" >> /home/runner/.mailcap
-            /usr/bin/xvfb-run --auto-servernum -s "-screen 0 1280x1024x24" ${{ inputs.run-target }}
-          else
-            ${{ inputs.run-target }}
-          fi
+          num=1
+          success=0
+          fail=0
+          while [ $num -le 1000 ]; do
+            if [ "$RUNNER_OS" = "Linux" ]; then
+              { /usr/bin/xvfb-run --auto-servernum -s "-screen 0 1280x1024x24" ${{ inputs.run-target }}; err="$?"; } || true
+            else
+              { ${{ inputs.run-target }}; err="$?"; } || true
+            fi
+            if [ $err -eq 0 ]; then
+              success=$(expr $success + 1)
+            else
+              fail=$(expr $fail + 1)
+            fi
+            num=$(expr $num + 1)
+            echo "success=$success fail=$fail"
+          done
         env:
           VIDEO: ${{ inputs.video }}
           DEBUG: ${{ inputs.debug }}
-        shell: sh
+        shell: bash
       - name: Put system logs alongside other artifacts
         run: |
           mkdir -p packages/zui-player/run/var_log

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,27 +55,18 @@ jobs:
       - name: End to end tests
         id: playwright
         run: |
-          num=1
-          success=0
-          fail=0
-          while [ $num -le 1000 ]; do
-            if [ "$RUNNER_OS" = "Linux" ]; then
-              { /usr/bin/xvfb-run --auto-servernum -s "-screen 0 1280x1024x24" ${{ inputs.run-target }}; err="$?"; } || true
-            else
-              { ${{ inputs.run-target }}; err="$?"; } || true
-            fi
-            if [ $err -eq 0 ]; then
-              success=$(expr $success + 1)
-            else
-              fail=$(expr $fail + 1)
-            fi
-            num=$(expr $num + 1)
-            echo "success=$success fail=$fail"
-          done
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            # Mock for pcap slice opening to avoid hanging Actions Runner.
+            # See https://github.com/brimdata/zui/pull/2987
+            echo "application/vnd.tcpdump.pcap; /usr/bin/true" >> /home/runner/.mailcap
+            /usr/bin/xvfb-run --auto-servernum -s "-screen 0 1280x1024x24" ${{ inputs.run-target }}
+          else
+            ${{ inputs.run-target }}
+          fi
         env:
           VIDEO: ${{ inputs.video }}
           DEBUG: ${{ inputs.debug }}
-        shell: bash
+        shell: sh
       - name: Put system logs alongside other artifacts
         run: |
           mkdir -p packages/zui-player/run/var_log

--- a/packages/zui-player/ci.config.js
+++ b/packages/zui-player/ci.config.js
@@ -3,5 +3,5 @@ const baseConfig = require('./playwright.config');
 module.exports = {
   ...baseConfig,
   /* This is the list of flaky tests to ignore when running on CI */
-  testIgnore: /(pool-loads|pool-groups).spec/,
+  testIgnore: /(pool-load-fail.spec.ts|pool-groups).spec/,
 };

--- a/packages/zui-player/tests/pool-load-fail.spec.ts
+++ b/packages/zui-player/tests/pool-load-fail.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@playwright/test';
+import TestApp from '../helpers/test-app';
+import { getPath } from 'zui-test-data';
+
+test.describe('Pool Loads (failures)', () => {
+  const app = new TestApp('Pool Loads (failures)');
+
+  test.beforeAll(async () => {
+    await app.init();
+  });
+
+  test.afterAll(async () => {
+    await app.shutdown();
+  });
+
+  test('bad data displays an error message', async () => {
+    await app.dropFile(getPath('soccer-ball.png'));
+    await app.attached(/Format Detection Error/i);
+    expect(app.locate('button', 'Load').isDisabled);
+  });
+});

--- a/packages/zui-player/tests/pool-load-success.spec.ts
+++ b/packages/zui-player/tests/pool-load-success.spec.ts
@@ -2,8 +2,8 @@ import { expect, test } from '@playwright/test';
 import TestApp from '../helpers/test-app';
 import { getPath } from 'zui-test-data';
 
-test.describe('Pool Loads', () => {
-  const app = new TestApp('Pool Loads');
+test.describe('Pool Loads (successes)', () => {
+  const app = new TestApp('Pool Loads (succeeses)');
 
   test.beforeAll(async () => {
     await app.init();
@@ -37,11 +37,5 @@ test.describe('Pool Loads', () => {
     await app.query('count()');
     const results = await app.getViewerResults();
     expect(results).toEqual(['this', '2']);
-  });
-
-  test('bad data displays an error message', async () => {
-    await app.dropFile(getPath('soccer-ball.png'));
-    await app.attached(/Format Detection Error/i);
-    expect(app.locate('button', 'Load').isDisabled);
   });
 });


### PR DESCRIPTION
The changes in #2972 made it such that our e2e tests now have a reliable way to check query results. In https://github.com/brimdata/zui/pull/2972#issuecomment-1971801505 I did some preliminary verification that this change was having the intended benefits, and that includes some baselining of how bad the problem was before and hence reminded us why we'd been skipping the "pool load" tests in CI. Now that #2972 is merged, in this PR I've banked that improvement by breaking out the e2e pool loads tests that are now reliable into their own set that we can run again in CI, while a separate test that remains unreliable is now broken out separately and is still skipped in CI (addressing that is tracked in #3021).

To verify, I did an Actions run on this branch with [these changes](https://github.com/brimdata/zui/commit/9a9f27dc160661895a7c1a1b2a4ff8a46c515d69) in place (since reverted) to run this set of `pool-load-success` tests in a loop on all platforms. As the results show, it ran successfully through all 1000 runs on both macOS and Windows without a single failure, and on Ubuntu it made it through 735 successful runs with no failures before Actions shot the job for running too long. So I think that shows things are pretty rock solid now!