### PR TITLE
Replace the tab entries on first load

### DIFF
--- a/apps/zui/src/models/browser-tab.ts
+++ b/apps/zui/src/models/browser-tab.ts
@@ -38,7 +38,18 @@ export class BrowserTab extends DomainModel<Attrs> {
     if (this.history.location.pathname === pathname) {
       this.history.replace(pathname)
     } else {
+      // Whenever a tab is created it constructs itself with a root entry "/".
+      // This can mess up the tab history back button, allowing the user to
+      // get back to this "root" url which does not contain forward/back buttons.
+      // Instead, this if statement resets the entries and index for this tab
+      // if the only url in the entries array is "/", making it the
+      // first entry in the history the first pathname given to browerTab.load()
+      if (this.history.length == 1 && this.history.location.pathname === "/") {
+        this.history.entries = []
+        this.history.index = -1
+      }
       this.history.push(pathname)
+      console.log(this.history)
     }
   }
 

--- a/packages/zui-player/tests/queries.spec.ts
+++ b/packages/zui-player/tests/queries.spec.ts
@@ -15,6 +15,11 @@ test.describe('Query tests', () => {
     await app.shutdown();
   });
 
+  test('session initializes with the back button disabled', async () => {
+    const backButton = app.locate('button', 'Go Back');
+    await expect(backButton).toBeDisabled();
+  });
+
   test('session queries are the default and ordered properly in history', async () => {
     await app.query('1');
     await app.query('2');


### PR DESCRIPTION
**Context**
When a tab history object is created, it already contains a single entry with the root pathname "/". In a previous PR, I changed the order of creating session tabs to 1) create the tab, 2) load the url in that tab. This made the code much easier to reason about, but it left this dangling "/" entry in the tab history. The meant the back button was enabled on a newly created session tab. If clicked, the tab would go back to the "/" url which renders a blank page without any buttons. You could not get back to your session if you ended up in this state. Could be very irritating if you needed those session history queries.

**Changes**
So this PR changes the BrowserTab#load function. It checks if the tab history entries equals ["/"]. If it does, it resets the entries to [] and the index to -1, the pushes the new pathname onto the history. This is exactly what we want. The "action" on the entry is still "push" instead of "replace" so that all the normal things happen.

**Tests**
There is an e2e test added that checks the back button on a newly created session tab to ensure it is disabled, meaning there is only one item in the tab history entries.