### PR TITLE
Skip running e2e pool-load-fail test in CI

### DIFF
--- a/packages/zui-player/ci.config.js
+++ b/packages/zui-player/ci.config.js
@@ -3,5 +3,5 @@ const baseConfig = require('./playwright.config');
 module.exports = {
   ...baseConfig,
   /* This is the list of flaky tests to ignore when running on CI */
-  testIgnore: /(pool-load-fail.spec.ts|pool-groups).spec/,
+  testIgnore: /(pool-load-fail|pool-groups).spec/,
 };


### PR DESCRIPTION
This was supposed to be taken care of by the changes in #3033, but a [recent CI failure in Actions](https://github.com/brimdata/zui/actions/runs/8652204264) made me aware that I'd made a mistake in my prior change and the test was still being run in CI. I confirmed in [this Actions run based on this branch from this PR](https://github.com/brimdata/zui/actions/runs/8652951958/job/23727018507) that I made the correct change this time, since it shows 50 e2e tests being run rather than the prior 51.