### PR TITLE
Add Setting for pointing at local Suricata rules

### DIFF
--- a/apps/zui/src/domain/configurations/plugin-api.ts
+++ b/apps/zui/src/domain/configurations/plugin-api.ts
@@ -1,12 +1,7 @@
 import ConfigPropValues from "src/js/state/ConfigPropValues"
 import {Store} from "src/js/state/types"
 
-export type ConfigItemType =
-  | "file"
-  | "string"
-  | "directory"
-  | "boolean"
-  | "char"
+export type ConfigItemType = "file" | "string" | "folder" | "boolean" | "char"
 
 export type ConfigItem = {
   name: string

--- a/apps/zui/src/domain/configurations/plugin-api.ts
+++ b/apps/zui/src/domain/configurations/plugin-api.ts
@@ -1,5 +1,6 @@
 import ConfigPropValues from "src/js/state/ConfigPropValues"
 import {Store} from "src/js/state/types"
+import {onStateChange} from "src/core/on-state-change"
 
 export type ConfigItemType = "file" | "string" | "folder" | "boolean" | "char"
 
@@ -50,5 +51,9 @@ export class ConfigurationsApi {
       if (this.get(config.name, prop) !== undefined) continue
       this.set(config.name, prop, config.properties[prop].defaultValue)
     }
+  }
+
+  watch(namespace: string, name: string, onChange: (val: any) => void) {
+    onStateChange(this.store, ConfigPropValues.get(namespace, name), onChange)
   }
 }

--- a/apps/zui/src/plugins/brimcap/config.ts
+++ b/apps/zui/src/plugins/brimcap/config.ts
@@ -1,2 +1,3 @@
 export const pluginNamespace = "brimcap"
 export const yamlConfigPropName = "yamlConfigPath"
+export const suricataLocalRulesPropName = "suricataLocalRulesPath"

--- a/apps/zui/src/plugins/brimcap/configurations.ts
+++ b/apps/zui/src/plugins/brimcap/configurations.ts
@@ -23,7 +23,7 @@ export function activateBrimcapConfigurations() {
       [suricataLocalRulesPropName]: {
         name: suricataLocalRulesPropName,
         type: "folder",
-        label: "Local Suricata Rule Folder",
+        label: "Local Suricata Rules Folder",
         defaultValue: "",
       },
     },

--- a/apps/zui/src/plugins/brimcap/configurations.ts
+++ b/apps/zui/src/plugins/brimcap/configurations.ts
@@ -22,8 +22,8 @@ export function activateBrimcapConfigurations() {
       },
       [suricataLocalRulesPropName]: {
         name: suricataLocalRulesPropName,
-        type: "file",
-        label: "Local Suricata Rules",
+        type: "folder",
+        label: "Local Suricata Rule Folder",
         defaultValue: "",
       },
     },

--- a/apps/zui/src/plugins/brimcap/configurations.ts
+++ b/apps/zui/src/plugins/brimcap/configurations.ts
@@ -1,4 +1,8 @@
-import {pluginNamespace, yamlConfigPropName} from "./config"
+import {
+  pluginNamespace,
+  yamlConfigPropName,
+  suricataLocalRulesPropName,
+} from "./config"
 import {configurations} from "src/zui"
 
 export function activateBrimcapConfigurations() {
@@ -15,6 +19,12 @@ export function activateBrimcapConfigurations() {
           label: "docs",
           url: "https://github.com/brimdata/brimcap/wiki/Custom-Brimcap-Config",
         },
+      },
+      [suricataLocalRulesPropName]: {
+        name: suricataLocalRulesPropName,
+        type: "file",
+        label: "Local Suricata Rules",
+        defaultValue: "",
       },
     },
   })

--- a/apps/zui/src/plugins/brimcap/suricata/update.ts
+++ b/apps/zui/src/plugins/brimcap/suricata/update.ts
@@ -6,10 +6,8 @@ import {pluginNamespace, suricataLocalRulesPropName} from "../config"
 
 let proc: ChildProcess = null
 
-function updateSuricata() {
+function updateSuricata(suricataLocalRulesPath) {
   const exe = env.getExePath("suricata/suricataupdater")
-  const suricataLocalRulesPath =
-    configurations.get(pluginNamespace, suricataLocalRulesPropName) || ""
 
   if (suricataLocalRulesPath) {
     proc = spawn(exe, ["--local", suricataLocalRulesPath])
@@ -17,7 +15,6 @@ function updateSuricata() {
     proc = spawn(exe)
   }
 
-  proc = spawn(exe)
   proc
     .on("error", (e) => {
       error(`Error updating Suricata rules: ${e.message || e}`)
@@ -29,5 +26,11 @@ function updateSuricata() {
 
 export function activateSuricataUpdater() {
   if (env.isTest) return
-  updateSuricata()
+  configurations.watch(
+    pluginNamespace,
+    suricataLocalRulesPropName,
+    (suricataLocalRulesPath) => {
+      updateSuricata(suricataLocalRulesPath)
+    }
+  )
 }

--- a/apps/zui/src/plugins/brimcap/suricata/update.ts
+++ b/apps/zui/src/plugins/brimcap/suricata/update.ts
@@ -1,11 +1,22 @@
 import {env} from "src/zui"
+import {configurations} from "src/zui"
 import {spawn, ChildProcess} from "child_process"
 import {error, debug} from "electron-log"
+import {pluginNamespace, suricataLocalRulesPropName} from "../config"
 
 let proc: ChildProcess = null
 
 function updateSuricata() {
   const exe = env.getExePath("suricata/suricataupdater")
+  const suricataLocalRulesPath =
+    configurations.get(pluginNamespace, suricataLocalRulesPropName) || ""
+
+  if (suricataLocalRulesPath) {
+    proc = spawn(exe, ["--local", suricataLocalRulesPath])
+  } else {
+    proc = spawn(exe)
+  }
+
   proc = spawn(exe)
   proc
     .on("error", (e) => {

--- a/apps/zui/src/views/settings-modal/input.tsx
+++ b/apps/zui/src/views/settings-modal/input.tsx
@@ -3,6 +3,7 @@ import {useSelector} from "react-redux"
 import {useDispatch} from "src/app/core/state"
 import ConfigPropValues from "src/js/state/ConfigPropValues"
 import {SettingProps} from "./section"
+import {invoke} from "src/core/invoke"
 
 export function Input(props: SettingProps) {
   const dispatch = useDispatch()
@@ -55,6 +56,30 @@ export function Input(props: SettingProps) {
             name={name}
             onChange={(e) => update(e.currentTarget.files[0]?.path)}
           />
+        </div>
+      )
+    case "folder":
+      return (
+        <div className="flex items-center gap-s">
+          <input
+            key={value}
+            type="text"
+            defaultValue={value}
+            onBlur={onChange}
+            placeholder="None"
+          />
+          <button
+            onClick={async () => {
+              const {canceled, filePaths} = await invoke("openDirectory")
+              if (!canceled && filePaths[0]) {
+                update(filePaths[0])
+              }
+            }}
+            className="button"
+            type="button"
+          >
+            Choose Folder
+          </button>
         </div>
       )
     case "string":


### PR DESCRIPTION
We've had a couple community issues recently where users mistakenly thought Zui's **Brimcap YAML Config File** setting may have been intended for loading additional local Suricata rules (#3047, #2949). We've never intended to expose UX in Zui to control all the possible customizations in bundled tools like Suricata and instead of tried to maintain a set of sensible defaults to which we've added modest enhancements over time when resources allow. When users ask for customizations that are more ambitious than we can easily offer, our catch-all/fallback answer is to refer them to the [Custom Brimcap Config](https://github.com/brimdata/brimcap/wiki/Custom-Brimcap-Config) article that guides them through how they can point Zui at their own installs of pcap analyzers like Suricata that they've customized as much as they'd like.

All that said, I recognize that following the Custom Brimcap Config steps could be seen as fairly heavyweight by a user that wants to do something simple such as loading additional Suricata rules. Furthermore, for that specific use case, I already put in most of the hard work via https://github.com/brimdata/build-suricata/pull/63 to make sure that the Suricata rules updater that ships with Brimcap is capable of loading additional rule sets if they're specified on the command line. The user that spawned the inquiry that led to that Brimcap PR only seemed to be interested in standalone Brimcap, so at the time I did not pursue exposing the functionality at the Zui layer. But now that we've established that some Zui users are looking for this functionality, I figure our time is better spent delivering the enhancement rather than repeatedly pointing them at heavyweight docs and hoping for the best.

As described in the [`suricata-update` docs](https://suricata-update.readthedocs.io/en/latest/update.html#cmdoption-local), loading such additional rules is accomplished by appending `--local` and a pathname to a file or directory of rule files to include. This PR leverages this by exposing a new **Local Suricata Rules Folder** setting in Zui that allows the user to select a directory that may contain any number of Suricata rules files. The end result is that the additional rules will be included in the final set used by Zui alongside the default Emerging Threats Open rule set that's always present by default.

The following video taken on macOS shows the feature working as intended using a [Dev build](https://github.com/brimdata/zui/actions/runs/8743245710) based on commit c75e955 from this PR's branch. It uses the attached test data in [example.pcap.gz](https://github.com/brimdata/zui/files/14964797/example.pcap.gz) which is a capture of me pinging one of the IP addresses associated with the "stalkerware" rules requested in #3047.

First I baseline by loading the pcap with the default Emerging Threats Open rules and we see no Suricata alert is generated. Then I use the new setting to point at the folder on my desktop that contains the [additional stalkerware rules](https://github.com/AssoEchap/stalkerware-indicators/blob/master/generated/suricata.rules). Changing the setting triggers the re-run of the Suricata rules updater, and we can see the size of the assembled `suricata.rules` file increase as a result. I then re-import the pcap and we can see the expected alert now appears. Finally, I delete the setting such that the Suricata rules updater re-runs to bring me back to just the default Emerging Threats Open rule set again. Re-processing the pcap one last time, we see the alert is once again gone.

https://github.com/brimdata/zui/assets/5934157/2a72c57b-c028-4fd6-855f-a611eef931e2

I re-ran this same set of steps with the Windows build and saw the same successful outcome there.

If this merges, what I'll likely do right after is write a new article in the [Features](https://zui.brimdata.io/docs/features) section of the Zui docs that covers both this new feature and the existing **Brimcap YAML Config File** setting. Regarding the latter, up to now its "docs" link in **Settings** has pointed directly at the [Custom Brimcap Config](https://github.com/brimdata/brimcap/wiki/Custom-Brimcap-Config) article in the Brimcap wiki. That's been fine, but I feel like a standalone Zui doc that covers pcap processing (maybe reference the plugin system, etc.) in addition to these other topics would be more user-friendly.

Closes #3047