### PR TITLE
Add Setting for folder to store extracted pcap slices

### DIFF
--- a/apps/zui/src/domain/configurations/plugin-api.ts
+++ b/apps/zui/src/domain/configurations/plugin-api.ts
@@ -15,6 +15,7 @@ export type ConfigItem = {
   command?: string
   defaultValue?: string | boolean
   enum?: string[] | [string, string][]
+  placeholder?: string
 }
 
 export type Config = {

--- a/apps/zui/src/plugins/brimcap/config.ts
+++ b/apps/zui/src/plugins/brimcap/config.ts
@@ -1,3 +1,4 @@
 export const pluginNamespace = "brimcap"
 export const yamlConfigPropName = "yamlConfigPath"
 export const suricataLocalRulesPropName = "suricataLocalRulesPath"
+export const pcapFolderPropName = "pcapExtractionFolderPath"

--- a/apps/zui/src/plugins/brimcap/configurations.ts
+++ b/apps/zui/src/plugins/brimcap/configurations.ts
@@ -2,6 +2,7 @@ import {
   pluginNamespace,
   yamlConfigPropName,
   suricataLocalRulesPropName,
+  pcapFolderPropName,
 } from "./config"
 import {configurations} from "src/zui"
 
@@ -25,6 +26,13 @@ export function activateBrimcapConfigurations() {
         type: "folder",
         label: "Local Suricata Rules Folder",
         defaultValue: "",
+      },
+      [pcapFolderPropName]: {
+        name: pcapFolderPropName,
+        type: "folder",
+        label: "Folder For Extracted pcaps",
+        defaultValue: "",
+        placeholder: "Default OS tmpdir",
       },
     },
   })

--- a/apps/zui/src/plugins/brimcap/packets/download.ts
+++ b/apps/zui/src/plugins/brimcap/packets/download.ts
@@ -6,6 +6,8 @@ import {window, commands} from "src/zui"
 import {queryForConnLog} from "./query-conn-log"
 import {DOWNLOAD} from "./types"
 import {shell} from "electron"
+import {configurations} from "src/zui"
+import {pluginNamespace, pcapFolderPropName} from "../config"
 
 function getSearchArgsFromConn(conn: zed.Record) {
   const dur = conn.try("duration") as zed.Duration
@@ -22,7 +24,9 @@ function getSearchArgsFromConn(conn: zed.Record) {
 
 function getPacketDest(conn: zed.Record) {
   const tsString = conn.get("ts").toString()
-  return join(os.tmpdir(), `packets-${tsString}.pcap`.replace(/:/g, "_"))
+  const pcapExtractionDir =
+    configurations.get(pluginNamespace, pcapFolderPropName) || os.tmpdir()
+  return join(pcapExtractionDir, `packets-${tsString}.pcap`.replace(/:/g, "_"))
 }
 
 export async function downloadPackets(root: string, pool: string, uid: string) {

--- a/apps/zui/src/views/settings-modal/input.tsx
+++ b/apps/zui/src/views/settings-modal/input.tsx
@@ -66,7 +66,7 @@ export function Input(props: SettingProps) {
             type="text"
             defaultValue={value}
             onBlur={onChange}
-            placeholder="None"
+            placeholder={field.placeholder || "None"}
           />
           <button
             onClick={async () => {


### PR DESCRIPTION
As described in #1423, we've recognized that a user might find it useful to specify a specific directory to hold extracted pcap slices, e.g., if they're gathering them up as part of an investigation. The changes in #3049 made me realize how easy it would be to add this as a **Setting**, so that's what I've done here.

The attached video shows the feature working as intended using the branch from this PR at commit 651e403. As a baseline I show the default app behavior of extracting to `$TMPDIR`. Then I apply the new setting and show the pcap going to the selected directory. Then I clear out the setting and show the pcaps going back to `$TMPDIR` again.

https://github.com/brimdata/zui/assets/5934157/ea524209-183a-4231-8a0b-0e772ad1cd96

Closes #1423