### PR TITLE
Brimcap Settings -> pcap Settings

### DIFF
--- a/apps/zui/src/plugins/brimcap/configurations.ts
+++ b/apps/zui/src/plugins/brimcap/configurations.ts
@@ -8,7 +8,7 @@ import {configurations} from "src/zui"
 export function activateBrimcapConfigurations() {
   configurations.create({
     name: pluginNamespace,
-    title: "Brimcap Settings",
+    title: "pcap Settings",
     properties: {
       [yamlConfigPropName]: {
         name: yamlConfigPropName,

--- a/apps/zui/src/views/settings-modal/index.tsx
+++ b/apps/zui/src/views/settings-modal/index.tsx
@@ -19,7 +19,9 @@ class Controller {
   constructor(public props: Props, public state: State) {}
 
   get sections() {
-    return this.props.configs.sort((a, b) => (a.title < b.title ? -1 : 1))
+    return this.props.configs.sort((a, b) =>
+      a.title.toLowerCase() < b.title.toLowerCase() ? -1 : 1
+    )
   }
 
   get activeSection() {


### PR DESCRIPTION
In thinking about documenting some recent enhancements, I'm sensing that **pcap Settings** is arguably a better title for the section of settings currently called **Brimcap Settings**. Thinking about it through the eyes of a new Zui user, "Brimcap" is the name of a tool that delivers a subset of functionality surfaced in Zui, but that's effectively an implementation detail and not something we'd expect a new Zui user to know right out of the gate, nor do I think educating users about "What is Brimcap?" should be a cost of entry. Instead I imagine a new user that's heard of Zui for the pcap-centric use cases would benefit more from a section title that mentions pcaps by name, so that's what I'm proposing here. Once they land in that section, I feel no shame about calling out Brimcap, e.g., for the **Brimcap YAML Config File** setting, because they certainly _do_ need to go off and learn "What is Brimcap?" if they want to start making use of that setting (hence the"docs" link).

I recognize it looks a little funny leading with the lowercase "pcap", but we've been down this road before. Our own Steve has gone on record as saying that "pcap" in lowercase is correct and [Wikipedia](https://en.wikipedia.org/wiki/Pcap) reflects this. That said, plenty of people have gone ahead and said "PCAP" or "Pcap" so I suppose we could follow that trend, but I'm inclined to lead with the purity. For that reason I've changed the section sort order to be case-insensitive because without that change it put **pcap Settings** _below_ **Pools** which looked extra weird!

![image](https://github.com/brimdata/zui/assets/5934157/d6043c4f-02dd-4eba-b1db-e6ff47521f4e)
