### PR TITLE
Update CONTRIBUTING with new Windows code signing info

### DIFF
--- a/apps/zui/CONTRIBUTING.md
+++ b/apps/zui/CONTRIBUTING.md
@@ -199,15 +199,13 @@ xcrun notarytool history --apple-id <apple-user-id> --password <app-specific-pas
 
 ### Windows Code Signing
 
-To create signed Windows packages by hand, set the following environment
-variables before running the `yarn` commands shown above.
-
-```bash
-export WIN_CSC_LINK=<base64-encoded-certificate>
-export WIN_CSC_KEY_PASSWORD=<certificate-password>
-```
-
-Where `WIN_CSC_LINK` contains the base64-encoded code signing certificate and `WIN_CSC_KEY_PASSWORD` is the password used to decrypt it (details [here](https://www.electron.build/code-signing.html#windows)).
+The changes in [ballot CSC-17](https://cabforum.org/2022/09/27/ballot-csc-17-subscriber-private-key-extension/)
+from the [CA/B Forum](https://cabforum.org/) have made it such that GA Zui
+releases on Windows are currently only signed using a cloud service.
+PR [zui/3050](https://github.com/brimdata/zui/pull/3050) provides details of
+how this is currently performed with [SSL.com's eSigner](https://www.ssl.com/esigner/).
+If you successfully sign Zui with another service or sign manually and have
+tips to share based on your experience, please [contact us](#questions).
 
 ## Licensing
 


### PR DESCRIPTION
The changes in #3050 make this part of the CONTRIBUTING doc out-of-date and in need of update.

I'm a little hand-wavy in terms of what I've written here since manual signing is surely still possible but I've never attempted it in this new world order since it would require purchasing the special FIPS/YubiKey hardware. Likewise I'm sure other signing services could be made to work just like we did with eSigner, but I have no clue if they're similar/easy/hard. Therefore I've chosen to effectively point at what we've done with eSigner as a reference, leave it up to the reader to make it work for their alternatives, and invite them to share what they learned since it might help others (or us if we need to switch approaches in the future).

Ultimately I'm guessing most community members aren't signing builds so maybe this is all moot, but at least we're not pointing at stuff that won't work anymore. 😄