### PR TITLE
Make console logs more accessible during Playwright e2e test runs

### DIFF
--- a/apps/zui/src/electron/run-main/before-boot.ts
+++ b/apps/zui/src/electron/run-main/before-boot.ts
@@ -5,12 +5,16 @@ import {windowsPre25Exists} from "../windows-pre-25"
 import {MainArgs} from "./args"
 import {setLogLevel} from "../set-log-level"
 import {runMigrations} from "./run-migrations"
+import log from "electron-log"
 
 app.disableHardwareAcceleration()
 
 export async function beforeBoot(
   args: Partial<MainArgs>
 ): Promise<string | null> {
+  // Ensure all console logs go through electron-log
+  console.log = log.log
+
   // Disable security warnings
   // process.env.ELECTRON_DISABLE_SECURITY_WARNINGS = "true"
   // Setup app paths, this must be first

--- a/packages/zui-player/helpers/test-app.ts
+++ b/packages/zui-player/helpers/test-app.ts
@@ -45,6 +45,11 @@ export default class TestApp {
     if (bin) launchOpts.executablePath = bin;
     this.zui = await electron.launch(launchOpts);
 
+    // Pipe the stdout from the electron process into the test runner process
+    if (process.env['VERBOSE']) {
+      this.zui.process().stdout.pipe(process.stdout);
+    }
+
     await waitForTrue(() => this.zui.windows().length === 2);
     await waitForTrue(async () => !!(await this.getWindowByTitle('Zui')));
     await waitForTrue(


### PR DESCRIPTION
While starting to debug #3063, I tried adding some `console.log()` debug statements to `packages/zed-node/src/lake.ts`, but the messages weren't visible in the shell window from which I ran `yarn e2e` nor in the `packages/zui-player/run/playwright-itest/Pool Loads (succeeses)/1/logs/main.log`. @jameskerr hacked at this with me a bit over Zoom and came up with these two improvements that make the messages show up in both locations. I'll put comments inline that explain which does what.