### PR TITLE
Add a "close" at beforeunload

### DIFF
--- a/apps/zui/src/core/renderer.ts
+++ b/apps/zui/src/core/renderer.ts
@@ -1,3 +1,10 @@
 import EventEmitter from "events"
 
-export class Renderer extends EventEmitter {}
+export class Renderer extends EventEmitter {
+  constructor() {
+    super()
+    globalThis.addEventListener("beforeunload", () => {
+      this.emit("close")
+    })
+  }
+}


### PR DESCRIPTION
While on a Zoom showing @jameskerr some of my #3063 debug, he spotted that the change here should be in the code and was missing. We'd briefly hoped that this might address the #3063 symptom, but alas, a loop of the repro steps shown in that issue did not improve the failure rate (79 successful test runs and 14 failed before I stopped it, to be precise.) Nevertheless, since @jameskerr seemed confident the absence of this code was an oversight, I'm proposing the change in hopes it'll help us avoid some other problem in the future.