### PR TITLE
Adjust expected VNG size in export test

### DIFF
--- a/apps/zui/package.json
+++ b/apps/zui/package.json
@@ -157,7 +157,7 @@
     "utopia-core-scss": "^1.0.1",
     "web-file-polyfill": "^1.0.4",
     "web-streams-polyfill": "^3.2.0",
-    "zed": "brimdata/zed#183e432f39938c48ae3226ba2e45479131288959",
+    "zed": "brimdata/zed#ce9626eb3c418f429de6e589af100ef5b2aa56e0",
     "zui-test-data": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/zui-player/tests/export.spec.ts
+++ b/packages/zui-player/tests/export.spec.ts
@@ -12,7 +12,7 @@ const formats = [
   { label: 'JSON', expectedSize: 13659 },
   { label: 'NDJSON', expectedSize: 13657 },
   { label: 'TSV', expectedSize: 10797 },
-  { label: 'VNG', expectedSize: 7983 },
+  { label: 'VNG', expectedSize: 7972 },
   { label: 'Zeek', expectedSize: 10138 },
   { label: 'ZJSON', expectedSize: 18007 },
   { label: 'ZNG', expectedSize: 3745 },

--- a/yarn.lock
+++ b/yarn.lock
@@ -19153,10 +19153,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zed@brimdata/zed#183e432f39938c48ae3226ba2e45479131288959":
+"zed@brimdata/zed#ce9626eb3c418f429de6e589af100ef5b2aa56e0":
   version: 0.33.0-dev
-  resolution: "zed@https://github.com/brimdata/zed.git#commit=183e432f39938c48ae3226ba2e45479131288959"
-  checksum: 590b1aaafe28fe1c1bde281aa7567c9e1f07d706bb80d3acb8081c1e70fababe3b8bfe699ad5c01bec2612ba66e8058ac9a87c6d69eca49de9cfd8606fb89828
+  resolution: "zed@https://github.com/brimdata/zed.git#commit=ce9626eb3c418f429de6e589af100ef5b2aa56e0"
+  checksum: 8bdd7dd2cff70a1d5a5275b5f6931d6f0cd9afaf9b14c3d657001146f07ad0575eb75081607eff36eb1e66230eab51781a7e52a3bef835a68c12733e9a052ee2
   languageName: node
   linkType: hard
 
@@ -19353,7 +19353,7 @@ __metadata:
     utopia-core-scss: ^1.0.1
     web-file-polyfill: ^1.0.4
     web-streams-polyfill: ^3.2.0
-    zed: "brimdata/zed#183e432f39938c48ae3226ba2e45479131288959"
+    zed: "brimdata/zed#ce9626eb3c418f429de6e589af100ef5b2aa56e0"
     zui-test-data: "workspace:*"
   peerDependencies:
     react: ^18.0.0


### PR DESCRIPTION
While #3062 addressed one of our recent failures in Zui CI due to a Zed change, [this recent Actions run](https://github.com/brimdata/zui/actions/runs/9086663026) shows that the very next Zed change at commit `ce9626e` was ready to cause a CI failure next. Assuming it's no surprise that the changes in https://github.com/brimdata/zed/pull/5118 would cause a change in the VNG file size, this PR adjusts the test to expect the new size.

```
$ zq -version
Version: v1.15.0-16-g183e432f

$ zq -f vng 'sort ts, _path' ./apps/zui/src/test/shared/data/sample.zeektsv | wc -c
    7983

$ zq -version
Version: v1.15.0-17-gce9626eb

$ zq -f vng 'sort ts, _path' ./apps/zui/src/test/shared/data/sample.zeektsv | wc -c
    7972
```
