### PR TITLE
Make the release notes test flexible to repo changes

### DIFF
--- a/apps/zui/src/app/release-notes/test.tsx
+++ b/apps/zui/src/app/release-notes/test.tsx
@@ -7,16 +7,17 @@ import {rest} from "msw"
 import {SystemTest} from "src/test/system"
 import ReleaseNotes from "./release-notes"
 import {screen} from "@testing-library/react"
+import pkg from "../../../package.json"
 
 const system = new SystemTest("release-notes")
+const url =
+  pkg.repository.replace("github.com", "api.github.com/repos") +
+  "/releases/tags/v0.0.0"
 
 system.network.use(
-  rest.get(
-    "https://api.github.com/repos/brimdata/zui/releases/tags/v0.0.0",
-    (req, res, ctx) => {
-      return res(ctx.status(200), ctx.json({body: "Testing Release Notes"}))
-    }
-  )
+  rest.get(url, (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json({body: "Testing Release Notes"}))
+  })
 )
 
 test("fetches the release notes", async () => {


### PR DESCRIPTION
I sometimes do upgrade testing in a personal fork Zui repo. When starting a round of this recently as part of the work on #1266, a test failed because of the hard-coded "brimdata" in the GitHub URL. Like we've done in other spots, this PR just makes it flexible to whatever `repository` is set to in `package.json`, which is something I always change when doing those kinds of tests in a personal fork.