### PR TITLE
Fix e2e test for query when no pool specified

### DIFF
--- a/apps/zui/src/views/results-pane/errors/missing-pool-error.tsx
+++ b/apps/zui/src/views/results-pane/errors/missing-pool-error.tsx
@@ -44,7 +44,7 @@ const Card = styled.section`
 `
 
 export function isMissingPoolError(e: unknown) {
-  return e === "pool name missing"
+  return e === "no pool name given"
 }
 
 function PoolsList({pools}: {pools: Pool[]}) {


### PR DESCRIPTION
While #3078 fixed the first test breakage that appeared from recent advanced in the Zed dependency, it turns out the e2e test failure shown in [this run](https://github.com/brimdata/zui/actions/runs/9340425556) was waiting in line behind that one. The root cause is what's captured in #3079. While the details in #3079 advocate fixing a wider user-facing issue, here I've made the smaller adjustment necessary for the test to start passing again such as shown in [this run](https://github.com/brimdata/zui/actions/runs/9340505035).