### PR TITLE
New electron-updater

### DIFF
--- a/apps/insiders/src/insiders-packager.ts
+++ b/apps/insiders/src/insiders-packager.ts
@@ -40,7 +40,7 @@ export class InsidersPackager {
     const version =
       this.strategy === 'match-stable'
         ? this.stableVersion
-        : semver.inc(this.lastVersion, 'prerelease');
+        : semver.inc(this.lastVersion, 'prerelease', 'insiders');
 
     return version;
   }

--- a/apps/zui/package.json
+++ b/apps/zui/package.json
@@ -91,7 +91,7 @@
     "electron-localshortcut": "^3.2.1",
     "electron-log": "5.0.0-beta.6",
     "electron-mock-ipc": "^0.3.12",
-    "electron-updater": "^4.3.8",
+    "electron-updater": "6.2.1",
     "esbuild": "^0.18.14",
     "eslint": "^8.11.0",
     "eslint-config-prettier": "^8.5.0",

--- a/apps/zui/src/domain/updates/linux-updater.ts
+++ b/apps/zui/src/domain/updates/linux-updater.ts
@@ -13,7 +13,6 @@ autoUpdater.forceDevUpdateConfig = true
 export class LinuxUpdater implements Updater {
   async check() {
     const {updateInfo} = await autoUpdater.checkForUpdates()
-    console.log(updateInfo)
     const latest = updateInfo.version
     const current = app.getVersion()
     if (semver.lt(current, latest)) {

--- a/apps/zui/src/domain/updates/linux-updater.ts
+++ b/apps/zui/src/domain/updates/linux-updater.ts
@@ -13,6 +13,7 @@ autoUpdater.forceDevUpdateConfig = true
 export class LinuxUpdater implements Updater {
   async check() {
     const {updateInfo} = await autoUpdater.checkForUpdates()
+    console.log(updateInfo)
     const latest = updateInfo.version
     const current = app.getVersion()
     if (semver.lt(current, latest)) {

--- a/apps/zui/src/domain/updates/linux-updater.ts
+++ b/apps/zui/src/domain/updates/linux-updater.ts
@@ -1,15 +1,19 @@
-import {app, shell} from "electron"
-import fetch from "node-fetch"
+import {autoUpdater} from "electron-updater"
+import {Updater} from "./types"
 import semver from "semver"
+import {app, shell} from "electron"
 import env from "src/app/core/env"
 import links from "src/app/core/links"
 import pkg from "src/electron/pkg"
-import {Updater} from "./types"
-import {getMainObject} from "src/core/main"
+
+autoUpdater.autoDownload = false
+autoUpdater.autoInstallOnAppQuit = false
+autoUpdater.forceDevUpdateConfig = true
 
 export class LinuxUpdater implements Updater {
   async check() {
-    const latest = await this.latest()
+    const {updateInfo} = await autoUpdater.checkForUpdates()
+    const latest = updateInfo.version
     const current = app.getVersion()
     if (semver.lt(current, latest)) {
       return latest
@@ -20,19 +24,6 @@ export class LinuxUpdater implements Updater {
 
   async install() {
     shell.openExternal(this.downloadUrl())
-  }
-
-  private async latest() {
-    const resp = await fetch(this.latestUrl())
-    if (resp.status === 204) return app.getVersion()
-    const data = await resp.json()
-    return data.name
-  }
-
-  private latestUrl() {
-    const repo = getMainObject().appMeta.repo
-    const platform = "darwin-x64" // If the mac version exists, the linux does too
-    return `https://update.electronjs.org/${repo}/${platform}/${app.getVersion()}`
   }
 
   private downloadUrl() {

--- a/apps/zui/src/domain/updates/mac-win-updater.ts
+++ b/apps/zui/src/domain/updates/mac-win-updater.ts
@@ -11,7 +11,6 @@ autoUpdater.forceDevUpdateConfig = true
 export class MacWinUpdater implements Updater {
   async check() {
     const {updateInfo} = await autoUpdater.checkForUpdates()
-    console.log(updateInfo)
     const latest = updateInfo.version
     const current = app.getVersion()
     if (semver.lt(current, latest)) {

--- a/apps/zui/src/domain/updates/mac-win-updater.ts
+++ b/apps/zui/src/domain/updates/mac-win-updater.ts
@@ -6,6 +6,7 @@ import {getMainObject} from "src/core/main"
 
 autoUpdater.autoDownload = false
 autoUpdater.autoInstallOnAppQuit = false
+autoUpdater.forceDevUpdateConfig = true
 
 export class MacWinUpdater implements Updater {
   async check() {

--- a/apps/zui/src/domain/updates/mac-win-updater.ts
+++ b/apps/zui/src/domain/updates/mac-win-updater.ts
@@ -11,6 +11,7 @@ autoUpdater.forceDevUpdateConfig = true
 export class MacWinUpdater implements Updater {
   async check() {
     const {updateInfo} = await autoUpdater.checkForUpdates()
+    console.log(updateInfo)
     const latest = updateInfo.version
     const current = app.getVersion()
     if (semver.lt(current, latest)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5579,7 +5579,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/semver@npm:^7.3.3, @types/semver@npm:^7.3.4":
+"@types/semver@npm:^7.3.3":
   version: 7.3.4
   resolution: "@types/semver@npm:7.3.4"
   checksum: 577dc7f607fbf46cf185f61ba726e4cfecea41c4b17e55069e70a64b6cd92658f8286aa075a607303455658e87ed045d3d14c32a513c0eff381d64aecd7b72a7
@@ -7296,16 +7296,6 @@ __metadata:
     base64-js: ^1.3.1
     ieee754: ^1.1.13
   checksum: e2cf8429e1c4c7b8cbd30834ac09bd61da46ce35f5c22a78e6c2f04497d6d25541b16881e30a019c6fd3154150650ccee27a308eff3e26229d788bbdeb08ab84
-  languageName: node
-  linkType: hard
-
-"builder-util-runtime@npm:8.7.3":
-  version: 8.7.3
-  resolution: "builder-util-runtime@npm:8.7.3"
-  dependencies:
-    debug: ^4.3.2
-    sax: ^1.2.4
-  checksum: eaf55ffcbde90a65639d7e102626ea819d0c0e4b296984755dab8d9df2bd85c56fb586e536a175b9229477d7e122c8f553aa232827aa7e275b43274b87a6e3e5
   languageName: node
   linkType: hard
 
@@ -9219,18 +9209,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-updater@npm:^4.3.8":
-  version: 4.3.8
-  resolution: "electron-updater@npm:4.3.8"
+"electron-updater@npm:6.2.1":
+  version: 6.2.1
+  resolution: "electron-updater@npm:6.2.1"
   dependencies:
-    "@types/semver": ^7.3.4
-    builder-util-runtime: 8.7.3
-    fs-extra: ^9.1.0
-    js-yaml: ^4.0.0
-    lazy-val: ^1.0.4
+    builder-util-runtime: 9.2.4
+    fs-extra: ^10.1.0
+    js-yaml: ^4.1.0
+    lazy-val: ^1.0.5
+    lodash.escaperegexp: ^4.1.2
     lodash.isequal: ^4.5.0
-    semver: ^7.3.4
-  checksum: 1814fe7c99eb6c1cb2251fc24eb62f51df716e44c891d5433e8e036a77ff2beec241249f7ba26b33a60cf134158c2160a74117dff7751b4d2e59c57e688ae17a
+    semver: ^7.3.8
+    tiny-typed-emitter: ^2.1.0
+  checksum: 92a064610a3c9df747dce9c3eccd69c48adb2c8b37b9d7c13d1c39f7e2a9ffaef4e909ab50e6973d557566bde6de7ec9c64e2cc3a2cdef18b3220c5d91333e1c
   languageName: node
   linkType: hard
 
@@ -13287,7 +13278,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:4.1.0, js-yaml@npm:^4.0.0, js-yaml@npm:^4.1.0":
+"js-yaml@npm:4.1.0, js-yaml@npm:^4.1.0":
   version: 4.1.0
   resolution: "js-yaml@npm:4.1.0"
   dependencies:
@@ -13756,6 +13747,13 @@ __metadata:
   version: 4.0.8
   resolution: "lodash.debounce@npm:4.0.8"
   checksum: a3f527d22c548f43ae31c861ada88b2637eb48ac6aa3eb56e82d44917971b8aa96fbb37aa60efea674dc4ee8c42074f90f7b1f772e9db375435f6c83a19b3bc6
+  languageName: node
+  linkType: hard
+
+"lodash.escaperegexp@npm:^4.1.2":
+  version: 4.1.2
+  resolution: "lodash.escaperegexp@npm:4.1.2"
+  checksum: 6d99452b1cfd6073175a9b741a9b09ece159eac463f86f02ea3bee2e2092923fce812c8d2bf446309cc52d1d61bf9af51c8118b0d7421388e6cead7bd3798f0f
   languageName: node
   linkType: hard
 
@@ -18197,6 +18195,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tiny-typed-emitter@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "tiny-typed-emitter@npm:2.1.0"
+  checksum: 709bca410054e08df4dc29d5ea0916328bb2900d60245c6a743068ea223887d9fd2c945b6070eb20336275a557a36c2808e5c87d2ed4b60633458632be4a3e10
+  languageName: node
+  linkType: hard
+
 "tiny-warning@npm:^1.0.0, tiny-warning@npm:^1.0.3":
   version: 1.0.3
   resolution: "tiny-warning@npm:1.0.3"
@@ -19701,7 +19706,7 @@ __metadata:
     electron-localshortcut: ^3.2.1
     electron-log: 5.0.0-beta.6
     electron-mock-ipc: ^0.3.12
-    electron-updater: ^4.3.8
+    electron-updater: 6.2.1
     esbuild: ^0.18.14
     eslint: ^8.11.0
     eslint-config-prettier: ^8.5.0


### PR DESCRIPTION
Fixes #3082, which has detailed background on what's being fixed here and what else we expect to gain by moving to a newer `electron-updater`.

Starting from the code on this branch, I've done an exhaustive set of successful upgrade tests in personal fork repos of Zui and Zui Insiders on both macOS and Ubuntu (`.deb`). If this PR should get approved, after having updated the branch with any suggestions from reviewers, I'll catch it up with `main` and repeat the tests one last time including both Windows and Rocky Linux (`.rpm`) as well for completeness. I happened to skip those on the first pass since in the past I've found update behavior on Windows closely tracks what we see on macOS and likewise between the different Linux installers, so I figured I'd save a little time on the first pass since I assumed I'd want to re-test again after merging suggestions anyway.

Here's a complete run down of all the tests I performed and the results.

1. Make personal forks of both Zui and Zui Insiders repos per instructions [here](https://lookylabs.atlassian.net/wiki/spaces/PROD/pages/1804730369/Making+a+Personal+Fork+of+the+App+Repo)
   * I manually staged an initial Zui Insiders release based on `v1.6.1-33` from the "official" Insiders repo so that way there'd be an existing release to increment from. I then deleted the release and its tag after I made the first proper Insiders release in my fork repo.
   * In the Zui fork, I made the repo name changes from `brimdata` to `philrz` in both the `main` branch and the `release/v1.7.0` branch

2. In the Zui fork, delete the `v1.7.0` tag and create a new `v1.7.0` release based off the `release/v1.7.0` branch
   * This will serve as a baseline similar to our production users running GA Zui `v1.7.0` today, which has the old electron-updater

3. In the Zui Insiders fork, create a new release based off the `release/v1.7.0` branch
   * This will serve as a baseline similar to our production users running GA Zui Insiders builds that pre-date the changes in #3077
   * Test result: Zui Insiders release `v1.7.0` was created

4. In the Zui Insiders fork, create a new release in my personal repo based off the tip of `main`
   * This will serve as a baseline similar to our production users running GA Zui Insiders builds in the time since the changes from #3077 have merged
   * Test result: Zui Insiders release `v1.7.1-0` was created
   * Test result: On my Mac, I installed the Insiders `v1.7.0` and it found/auto-updated to `v1.7.1-0`
   * Test result: On my Linux VM, I installed the Insiders `v1.7.0` and it did **not** initially see the `v1.7.1-0` as an eligible update target, but this is due to the known "Problem 1" described in #3082. Therefore I manually downloaded the `Zui---Insiders-1.7.1-0-x64.zip` artifact, renamed it to `Zui---Insiders-1.7.1-0-mac.zip`, and uploaded that to the Release. After waiting about 15 minutes, now the app _did_ find `v1.7.1-0` as an eligible update target.

5. In the Zui fork, advance the version string in `package.json` to `1.8.0` and merge the `new-electron-updater` PR
   * This is effectively the same step we'll do before prepping the next GA Zui release.

6. In the Zui fork, create a new `v1.8.0` release
   * Since the older `v1.7.0` Linux release still has the "Problem 1" from #3082, I manually added the `Zui-1.8.0-mac.zip` to its Release page so Linux users would see this release as an eligible update target
   * Test result: On my Mac, I installed the `v1.7.0` release and it auto-updated to `v1.8.0`
   * Test result: On my Linux VM, I installed the `v1.7.0` release and it saw `v1.8.0` as an eligible update target

7. In the Zui Insiders fork, create a new Zui Insiders release
   * Test result: Zui Insiders release `v1.8.0` was created. Since the older Insiders releases still have the "Problem 1" from #3082, I manually added the `Zui---Insiders-1.8.0-mac.zip` to its Release page so Linux users would see this release as an eligible update target.
   * Test result: On my Mac, I installed the `v1.7.0` release and it auto-updated to the `v1.8.0` release
   * Test result: On my Mac, I installed the `v1.7.1-0` release and it auto-updated to the `v1.8.0` release
   * Test result: On my Linux VM, I installed the `v1.7.0` release and it saw `v1.8.0` as an eligible update target
   * Test result: On my Linux VM, I installed the `v1.7.1-0` release and it saw the `v1.8.0` release as an eligible update target.

8. In the Zui Insiders fork, trigger creation of releases `-insiders.1`, `-insiders.12`, ... , `-insiders.10`
   * Test result: On my Mac, I installed `v1.7.0` and auto-updated to `v1.8.1-insiders.10`
   * Test result: On my Mac, I installed `v1.7.1-0` and auto-updated to `v1.8.1-insiders.10`
   * Test result: On my Mac, I installed `v1.8.0` and auto-updated to `v1.8.1-insiders.10`
   * Test result: On my Mac, I installed `v1.8.1-insiders.9` it auto-updated to `v1.8.1-insiders.10`
   * Test: On my Linux VM, I installed `v1.7.0` and it found `v1.8.0` as the latest available, but of course clicking the **Install** button brought up the `/releases/latest` page on GitHub such that I was shown `v1.8.1-insiders.10` as the update target
   * Test result: On my Linux VM, I installed `v1.7.0` and it found `v1.8.0` as the latest available, but of course clicking the Install button brought up the `/releases/latest` page on GitHub such that I was shown `v1.8.1-insiders.10` as the update target
   * Test result: On my Linux VM, I installed `v1.7.1-0` and it found `v1.8.0` as the latest available, but of course clicking the **Install** button brought up the `/releases/latest` page on GitHub such that I was shown `v1.8.1-insiders.10` as the update target
   * Test result: On my Linux VM, I installed `v1.8.0` and it found `v1.8.1-insiders.10` as the latest available (and I'd not had to manually add any "mac ZIP" file for the release)
   * Test result: On my Linux VM, I installed  `v1.8.1-insiders.9` and it found `v1.8.1-insiders.10 `as the latest available (and I'd not had to manually add any "mac ZIP" file for the release)

9. In the Zui fork, create a new `v1.9.0` release
   * Test result: On my Mac, I installed the `v1.7.0` release and it auto-updated to the `v1.9.0` release
   * Test result: On my Mac, I installed the `v1.8.0` release and it auto-updated to the `v1.9.0` release
   * Test result: On my Linux VM, I installed `v1.7.0` and it found `v1.8.0` as the latest available, but of course clicking the Install button brought up the brimdata.io **Downloads** that would offer `v1.9.0` as the update target
   * Test result: On my Linux VM, I installed `v1.8.0` and it found `v1.9.0` as the latest available (and I'd not had to manually add any "mac ZIP" file for the release)

Conclusion: Once users get on to one of the builds running the newer `electron-updater`, they'll find the proper "latest" release for both Zui and Zui Insiders without any manual intervention on our part. The test results indicate that auto-update users (macOS) will make this transition without any manual intervention on our part. On Linux, we'll need to manually provide the "mac ZIP" file as part of the first releases that have the newer `electron-updater`, but once they make that leap, their apps will keep finding "latest" releases based on just the presence of the `latest-linux.yml` that's created automatically by our build process. And since our Linux "helper" just lands them on a "manually download the latest" web page whenever a newer release is detected, they complete this hop easily.