### PR TITLE
Parse Error UI Improvement

### DIFF
--- a/apps/zui/src/js/state/QueryInfo/selectors.ts
+++ b/apps/zui/src/js/state/QueryInfo/selectors.ts
@@ -9,12 +9,17 @@ export const get = activeTabSelect((tab) => {
 export const getParseError = createSelector(get, (info) => info.error)
 export const getIsParsed = createSelector(get, (info) => info.isParsed)
 export const getPoolName = createSelector(get, (info) => {
-  let source = find(info.sources, {kind: "Pool"})
+  let source = find(info.sources || [], {kind: "Pool"})
   return source ? source.name : null
 })
 export const getGroupByKeys = createSelector(get, (info) => {
-  return info.channels[0].aggregation_keys
+  const {channels} = info
+  if (channels) {
+    return channels[0].aggregation_keys || []
+  } else {
+    return []
+  }
 })
-export const hasAggregation = createSelector(get, (info) => {
-  return !!info.channels[0].aggregation_keys
+export const hasAggregation = createSelector(getGroupByKeys, (keys) => {
+  return keys.length > 0
 })

--- a/apps/zui/src/models/browser-tab.ts
+++ b/apps/zui/src/models/browser-tab.ts
@@ -49,7 +49,6 @@ export class BrowserTab extends DomainModel<Attrs> {
         this.history.index = -1
       }
       this.history.push(pathname)
-      console.log(this.history)
     }
   }
 

--- a/apps/zui/src/views/histogram-pane/index.tsx
+++ b/apps/zui/src/views/histogram-pane/index.tsx
@@ -8,13 +8,15 @@ import {Toolbar} from "src/components/toolbar"
 import {Title} from "./title"
 import {Resizer} from "./resizer"
 import {useRef} from "react"
+import QueryInfo from "src/js/state/QueryInfo"
 
 export function HistogramPane() {
   const {Parent, width = 0, height = 0} = useParentSize()
   const show = useSelector(Layout.getShowHistogram)
   const chartHeight = useSelector(Layout.getChartHeight)
+  const parseError = useSelector(QueryInfo.getParseError)
   const ref = useRef<HTMLDivElement>()
-  if (!show) return null
+  if (!show || parseError) return null
 
   return (
     <div

--- a/apps/zui/src/views/histogram-pane/run-query.ts
+++ b/apps/zui/src/views/histogram-pane/run-query.ts
@@ -40,7 +40,9 @@ export const runHistogramQuery = createHandler(
       async function getPoolRange() {
         const queryText = `from ${poolId} | min(${timeField}), max(${timeField})`
         const resp = await query(queryText, {signal})
-        const [{min, max}] = await resp.js()
+        const data = await resp.js()
+        if (data.length == 0) return null
+        const [{min, max}] = data
         if (!(min instanceof Date && max instanceof Date)) return null
         return [min, max] as [Date, Date]
       }

--- a/apps/zui/src/views/results-pane/errors/missing-pool-error.tsx
+++ b/apps/zui/src/views/results-pane/errors/missing-pool-error.tsx
@@ -44,7 +44,7 @@ const Card = styled.section`
 `
 
 export function isMissingPoolError(e: unknown) {
-  return e === "no pool name given"
+  return typeof e === "string" && /no pool name given/.test(e)
 }
 
 function PoolsList({pools}: {pools: Pool[]}) {

--- a/apps/zui/src/views/session-page/handler.ts
+++ b/apps/zui/src/views/session-page/handler.ts
@@ -70,6 +70,7 @@ export class SessionPageHandler extends ViewHandler {
       const poolName = this.select(QueryInfo.getPoolName)
       this.invoke("updatePluginSessionOp", {poolName, program})
       const pool = this.select(Pools.getByName(lakeId, poolName))
+
       if (pool && !pool.hasSpan()) {
         this.dispatch(syncPool(pool.id, lakeId))
       }

--- a/apps/zui/src/views/session-page/handler.ts
+++ b/apps/zui/src/views/session-page/handler.ts
@@ -66,9 +66,6 @@ export class SessionPageHandler extends ViewHandler {
     const history = this.select(Current.getHistory)
 
     fetchQueryInfo(program).then((info) => {
-      if (info.error) {
-        return
-      }
       this.dispatch(QueryInfo.set({isParsed: true, ...info}))
       const poolName = this.select(QueryInfo.getPoolName)
       this.invoke("updatePluginSessionOp", {poolName, program})
@@ -77,7 +74,7 @@ export class SessionPageHandler extends ViewHandler {
         this.dispatch(syncPool(pool.id, lakeId))
       }
 
-      if (history.action === "PUSH") {
+      if (!info.error && history.action === "PUSH") {
         session.pushHistory()
       }
     })


### PR DESCRIPTION
fixes #3081 by not showing the histogram if there is a parse error

- Handle Error Case Differently
- Handle missing properties in query info
- Do not show the histogram if there is a parse error
- Loosen missing pool error detection

Here are the screenshots of the various "pool missing" stats. I also improved the error message of the histogram when the pool has no data in it.



## With no pools

![CleanShot 2024-06-07 at 15 49 08@2x](https://github.com/brimdata/zui/assets/3460638/7830c74e-8b12-411b-8bbd-93248eafa374)

## With a pool

![CleanShot 2024-06-07 at 15 48 57@2x](https://github.com/brimdata/zui/assets/3460638/335bc812-f487-49a7-b95a-02d0ee8b8a21)

## When there is no data in the pool

![CleanShot 2024-06-07 at 16 06 15@2x](https://github.com/brimdata/zui/assets/3460638/584dce25-d4c2-4061-ab6d-bcffe043c0b7)
