### PR TITLE
Upgrade Node 16 actions in .github/workflows

### DIFF
--- a/.github/actions/build-zui/action.yml
+++ b/.github/actions/build-zui/action.yml
@@ -53,7 +53,7 @@ runs:
 
     - name: Checkout esigner-codesign repository
       if: runner.os == 'Windows'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: 'SSLcom/esigner-codesign'
         path: esigner-codesign

--- a/.github/actions/setup-zui/action.yml
+++ b/.github/actions/setup-zui/action.yml
@@ -4,12 +4,12 @@ runs:
   using: 'composite'
   steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: '1.21'
 
     - name: Install Node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         # Caching is disabled because it resulted in getting amd64 Zed binaries
         # on arm64 builds. See https://github.com/actions/setup-node/issues/1008.

--- a/.github/actions/upload-build-artifacts/action.yml
+++ b/.github/actions/upload-build-artifacts/action.yml
@@ -7,7 +7,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: Mac Artifact (${{ runner.arch }})
         path: dist/apps/zui/*.dmg
@@ -20,17 +20,17 @@ runs:
         GH_TOKEN: ${{ inputs.gh_token }}
       shell: bash
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: Windows Artifact
         path: dist/apps/zui/*.exe
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: Debian Artifact
         path: dist/apps/zui/*.deb
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: RPM Artifact
         path: dist/apps/zui/*.rpm

--- a/.github/workflows/advance-zed.yml
+++ b/.github/workflows/advance-zed.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # ref defaults to github.sha, which is fixed at the time a run
           # is triggered. Using github.ref ensures a run that waits for

--- a/.github/workflows/build-insiders.yml
+++ b/.github/workflows/build-insiders.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout Zui
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.zui-branch }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout Zui
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Zui
         uses: ./.github/actions/setup-zui

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         os: [macos-12, macos-14, ubuntu-20.04, windows-2019]
     steps:
       - run: git config --global core.autocrlf false
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-zui
       - run: yarn lint
       - run: yarn test

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Output inputs
         run: echo "${{ toJSON(inputs) }}"
         shell: sh
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-zui
       - name: Install dependencies (Linux)
         if: startsWith(matrix.os, 'ubuntu-')

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -12,7 +12,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Extract branch name
       run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
       id: extract_branch

--- a/.github/workflows/release-insiders.yml
+++ b/.github/workflows/release-insiders.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout Zui
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Zui
         uses: ./.github/actions/setup-zui

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout Zui
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Zui
         uses: ./.github/actions/setup-zui


### PR DESCRIPTION
Node 16 actions are deprecated so upgrade to the Node 20 versions.