### PR TITLE
Zed lake service should listen only on localhost by default

### DIFF
--- a/packages/zed-node/src/lake.ts
+++ b/packages/zed-node/src/lake.ts
@@ -38,7 +38,7 @@ export class Lake {
     const args = [
       'serve',
       '-l',
-      ':' + this.port,
+      this.addr(),
       '-lake',
       this.root,
       '-manage=5m',


### PR DESCRIPTION
Fixes #3056, which has lots of background.

Now that the changes in #3069 have brought us to the the "use Electron's `net.fetch()`" state foretold in https://github.com/brimdata/zui/issues/3056#issuecomment-2086492607, here I'm restoring the prior behavior where the Zed service launched by Zui listens only on `localhost:9867` and therefore will no longer be open to connections from remote hosts.

```
$ ps auxww | grep -i zed
phil             52388   0.0  0.1 35563004  21380 s000  S+    6:17PM   0:00.05 /Users/phil/work/zui/apps/zui/zdeps/zed serve -l localhost:9867 -lake /Users/phil/work/zui/apps/zui/run/lake -manage=5m -log.level=info -log.filemode=rotate -log.path /Users/phil/work/zui/apps/zui/run/logs/zlake.log --cors.origin=* -brimfd=3
```

At some point after this merges, I'll introduce something in **Settings** so a user could open this back up if that's actually their preference (#1105).