### PR TITLE
Set process.resourcesPath to quiet electron-updater during Linux tests

### DIFF
--- a/apps/zui/src/test/unit/setup/after-env.ts
+++ b/apps/zui/src/test/unit/setup/after-env.ts
@@ -16,5 +16,5 @@ if (env.isCI) {
   configure({asyncUtilTimeout: 5000})
 }
 
-// @ts-ignore Quiets electron-updater during tests on Linux
+// @ts-ignore Quiets electron-updater during tests on Linux (see https://github.com/brimdata/zui/pull/3097)
 process.resourcesPath = "DoesNotExist"

--- a/apps/zui/src/test/unit/setup/after-env.ts
+++ b/apps/zui/src/test/unit/setup/after-env.ts
@@ -15,3 +15,6 @@ global.zui = preloadApi()
 if (env.isCI) {
   configure({asyncUtilTimeout: 5000})
 }
+
+// @ts-ignore Quiets electron-updater during tests on Linux
+process.resourcesPath = "DoesNotExist"


### PR DESCRIPTION
Since the merge of #3084, I've noticed that in the "Zui CI" Actions workflow on the Ubuntu runner there's warnings in the `yarn test` step, such as those in [this recent run](https://github.com/brimdata/zui/actions/runs/9523130204):

```
PASS apps/zui/src/electron/start.test.ts
  ● Console

    console.warn
      Unable to detect 'package-type' for autoUpdater (beta rpm/deb support). If you'd like to expand support, please consider contributing to electron-builder The "path" argument must be of type string. Received undefined

       7 | import pkg from "src/electron/pkg"
       8 |
    >  9 | autoUpdater.autoDownload = false
         |            ^
      10 | autoUpdater.autoInstallOnAppQuit = false
      11 | autoUpdater.forceDevUpdateConfig = true
      12 |

      at doLoadAutoUpdater (../../node_modules/electron-updater/src/main.ts:52:15)
      at Object.get [as autoUpdater] (../../node_modules/electron-updater/src/main.ts:64:28)
      at Object.<anonymous> (src/domain/updates/linux-updater.ts:9:12)
      at Object.<anonymous> (src/domain/updates/updater.ts:2:45)
      at Object.<anonymous> (src/domain/updates/operations.ts:2:34)
      at Object.<anonymous> (src/initializers/auto-update.ts:5:52)
      at Object.<anonymous> (src/initializers/index.ts:1:23)
      at Object.<anonymous> (src/electron/run-main/run-initializers.ts:3:25)
      at Object.<anonymous> (src/electron/run-main/boot.ts:4:51)
      at Object.<anonymous> (src/electron/run-main/run-main.ts:4:28)
      at Object.<anonymous> (src/electron/start.test.ts:5:41)
```

I dug into this and found the root cause to be [this line](https://github.com/electron-userland/electron-builder/blob/62d1991a7f1a26476100349733588763500ef16a/packages/electron-updater/src/main.ts#L34) from the "beta" support for Linux auto-update added in https://github.com/electron-userland/electron-builder/pull/7060. It looks for this `package-type` file that normally appears in a location like `/opt/Zui/resources/package-type` when running a packaged version of the app, but the `process.resourcesPath` that's used to build that path has been `undefined` when running our Jest tests. Just the act of importing `autoUpdater` and making those config settings shown above is enough to trigger this code that looks for the `package-type` file, hence why it it lands in the `catch` block and prints the warning.

A clean fix might be to make `electron-updater` smarter about bailing early when `process.resourcesPath` is `undefined`. However, I had challenges when trying to test with a modified `electron-updater` in a fork repo, so @jameskerr suggested we just make it happy by supplying this dummy value so `electron-updater` will bail cleanly when it finds the path does not exist on the [next line](https://github.com/electron-userland/electron-builder/blob/62d1991a7f1a26476100349733588763500ef16a/packages/electron-updater/src/main.ts#L35).