### PR TITLE
Handle unions in toZedScript

### DIFF
--- a/apps/zui/src/js/zed-script/toZedScript.ts
+++ b/apps/zui/src/js/zed-script/toZedScript.ts
@@ -25,6 +25,7 @@ export const toFieldPath = (arg: string | string[] | zed.Field) => {
 export function toZedScript(object: unknown): string {
   if (object instanceof zed.Field) return toFieldPath(object)
   if (object instanceof zed.Primitive) return toZedScriptPrimitive(object)
+  if (object instanceof zed.Union) return toZedScript(object.value)
   if (isString(object)) return toZedScriptString(object)
   if (object instanceof Date) return toZedScriptDate(object)
   if (typeof object === "boolean") return toZedScriptBool(object)


### PR DESCRIPTION
Fixes #3098, which has more background.

The video below shows the change having the intended benefit on the original repro shown in #3098, and also with this simpler input file `foo.ndjson`:

```
{"_path": "http", "foo": "bar"}
{"_path": 1, "foo": "baz"}
{"_path": true, "foo": "bonk"}
```

https://github.com/brimdata/zui/assets/5934157/651cffc8-13e4-48ed-9582-c0d16e1ca24f
