### PR TITLE
Output union values in Detail panel/window

### DIFF
--- a/apps/zui/src/views/detail-pane/Fields.tsx
+++ b/apps/zui/src/views/detail-pane/Fields.tsx
@@ -26,7 +26,9 @@ const DataPanel = React.memo<DTProps>(function DataTable({
         <Data key={index}>
           <Name>{field.path.join(" ‣ ")}</Name>
           <Value className={zedTypeClassName(field.data)}>
-            {format(field.data as zed.Primitive)}
+            {field.data instanceof zed.Union
+              ? format(field.data.value as zed.Primitive)
+              : format(field.data as zed.Primitive)}
           </Value>
         </Data>
       ))}


### PR DESCRIPTION
Since my approach in #3099 passed muster, that made me recall another open, union-centric issue #2938. Sure enough, as shown in the attached video, it seems a similar small change allows these union values to start being output where they weren't before.

https://github.com/brimdata/zui/assets/5934157/9e6ea525-51d7-46b0-bf68-1e30a0a37f23

Fixes #2938