### PR TITLE
Show Table Header Menu Icons

### DIFF
--- a/apps/zui/src/css/_zed-table.scss
+++ b/apps/zui/src/css/_zed-table.scss
@@ -140,6 +140,7 @@
   justify-content: center;
   height: 20px;
   width: 20px;
+  padding: 0;
   border-radius: 6px;
   border: none;
   z-index: 1;


### PR DESCRIPTION
![CleanShot 2024-06-21 at 14 43 35@2x](https://github.com/brimdata/zui/assets/3460638/36734315-e989-45c9-b2f3-d4e2a1778887)

The padding added in the blamed PR caused the icons to be pushed off the buttons.]

Fixes #3108
