### PR TITLE
Update zed to v1.16.0, Brimcap to v1.8.0, and prep Zui v1.8.0

### DIFF
--- a/apps/zui/CHANGELOG.md
+++ b/apps/zui/CHANGELOG.md
@@ -1,3 +1,21 @@
+## v1.8.0
+- Update Zed to [v1.16.0](https://github.com/brimdata/zed/releases/tag/v1.16.0)
+- Update Brimcap to [v1.8.0](https://github.com/brimdata/brimcap/releases/tag/v1.8.0), which includes a new Zeek [v6.2.0-brim2](https://github.com/brimdata/build-zeek/releases/tag/v6.2.0-brim2)
+- Zui macOS installers are now available for [Apple silicon](https://zui.brimdata.io/docs/Installation#macos-details) (ARM64) hardware (#3077, #3102)
+- A new Windows code signing certificate is now in use, which will likely result in a period of [Microsoft Defender SmartScreen warnings](https://zui.brimdata.io/docs/support/Troubleshooting#microsoft-defender-smartscreen-has-flagged-the-zui-installer-as-an-unrecognized-app) (#3050, #3055, #3057)
+- The title of the section in **Settings** formerly called **Brimcap Settings** is now called **Packet Captures** (#3054)
+- Zed queries are now parsed via a lake service endpoint, which adds red squiggly lines with tooltip details in the editor when errors are detected (#3076, #3085, #3087, #3094, #3104)
+- Fix an issue where the Zed lake service launched by Zui was incorrectly open to remote connections (#3061, #3069, #3091, #3106)
+- Add an option in **Settings** to point at local sets of [additional Suricata rules](https://zui.brimdata.io/docs/features/Packet-Captures#local-suricata-rules-folder) (#3049)
+- Add an option in **Settings** to specify a [folder for storing extracted pcap slices](https://zui.brimdata.io/docs/features/Packet-Captures#folder-for-extracted-pcaps) (#3053)
+- Add updated docs and a video for [Packet Capture functionality](https://zui.brimdata.io/docs/features/Packet-Captures) (#3060)
+- Fix an issue where populating the [**Brimcap YAML Config File**](https://zui.brimdata.io/docs/features/Packet-Captures#brimcap-yaml-config-file) option in **Settings** could cause a crash (#3044)
+- Fix an issue where a parsing error displayed incorrect Zed code (#3065)
+- Fix an issue where maximizing the Zui window could cause a crash on Linux (#3090)
+- Fix an issue where [Zui Insiders](https://github.com/brimdata/zui-insiders) on Linux was not correctly detecting the availability of newer releases (#3084)
+- Fix an issue where right-click **Pivot to Values** failed when clicking a Zed [union](https://zed.brimdata.io/docs/formats/zed#25-union) value (#3099)
+- Fix an issue where Zed [union](https://zed.brimdata.io/docs/formats/zed#25-union) values were rendered blank in the **Detail** pane/window (#3103)
+
 ## v1.7.0
 - Update Zed to [v1.15.0](https://github.com/brimdata/zed/releases/tag/v1.15.0)
 - Update Brimcap to [v1.7.0](https://github.com/brimdata/brimcap/releases/tag/v1.7.0), which includes a new Zeek [v6.2.0-brim1](https://github.com/brimdata/build-zeek/releases/tag/v6.2.0-brim1)

--- a/apps/zui/package.json
+++ b/apps/zui/package.json
@@ -73,7 +73,7 @@
     "acorn": "^7.4.1",
     "ajv": "^6.9.1",
     "animejs": "^3.2.0",
-    "brimcap": "brimdata/brimcap#65795e31ef4147d2356df4912f6f3bb4a40c28e1",
+    "brimcap": "brimdata/brimcap#v1.8.0",
     "chalk": "^4.1.0",
     "chevrotain": "^10.5.0",
     "chrono-node": "^2.5.0",
@@ -158,7 +158,7 @@
     "utopia-core-scss": "^1.0.1",
     "web-file-polyfill": "^1.0.4",
     "web-streams-polyfill": "^3.2.0",
-    "zed": "brimdata/zed#eff539fbfcfd10f136038de1a52192819137b2c1",
+    "zed": "brimdata/zed#v1.16.0",
     "zui-test-data": "workspace:*"
   },
   "peerDependencies": {

--- a/apps/zui/package.json
+++ b/apps/zui/package.json
@@ -5,7 +5,7 @@
   "description": "Zed User Interface",
   "repository": "https://github.com/brimdata/zui",
   "license": "BSD-3-Clause",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "main": "dist/main.js",
   "author": "Brim Data <support@brimdata.io> (http://www.brimdata.io)",
   "lake": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6661,12 +6661,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brimcap@brimdata/brimcap#65795e31ef4147d2356df4912f6f3bb4a40c28e1":
+"brimcap@brimdata/brimcap#v1.8.0":
   version: 1.1.2
-  resolution: "brimcap@https://github.com/brimdata/brimcap.git#commit=65795e31ef4147d2356df4912f6f3bb4a40c28e1"
+  resolution: "brimcap@https://github.com/brimdata/brimcap.git#commit=e1242c7029d8207d5e69ec3a13e531b57b65b046"
   bin:
     brimcap: build/dist/brimcap
-  checksum: 5da28423c1e13a5f4e31ae21bc0016ced8f63e8856b4c82a8fbd310501f84091332bd4ea43b2b51ab69fe3924af85bc1ef91c6903b53c1c6e1fa3cdfe5b36174
+  checksum: 42f050137fae0f4d9b3dfd898e2d9c58be359e11307d46256836ed6fc9e38eee2ec0b7d95c136f5cc99dd3eae6fe854d7b5e6fab795fb072f6dd8841187c0675
   languageName: node
   linkType: hard
 
@@ -18200,10 +18200,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zed@brimdata/zed#eff539fbfcfd10f136038de1a52192819137b2c1":
+"zed@brimdata/zed#v1.16.0":
   version: 0.33.0-dev
-  resolution: "zed@https://github.com/brimdata/zed.git#commit=eff539fbfcfd10f136038de1a52192819137b2c1"
-  checksum: 903fe8eb1b87ba0b626b4e8834185928762baa0c34ffee310d928a520ccee87ad9f2ac0a8364bb5138c756e13ede9b6213c6767a1bb9359efe8821a5d5d4c7bc
+  resolution: "zed@https://github.com/brimdata/zed.git#commit=43d684043e312b2b4e7c9d20df85462332682a72"
+  checksum: 95eb7afbab30c91a005d28692f3865daba1d6da6950236fdae0769701b5742d274f7952bcdbb0c49299443a6394526911eed29ddc970013dfc0c6cbf86a0f798
   languageName: node
   linkType: hard
 
@@ -18314,7 +18314,7 @@ __metadata:
     acorn: ^7.4.1
     ajv: ^6.9.1
     animejs: ^3.2.0
-    brimcap: "brimdata/brimcap#65795e31ef4147d2356df4912f6f3bb4a40c28e1"
+    brimcap: "brimdata/brimcap#v1.8.0"
     chalk: ^4.1.0
     chevrotain: ^10.5.0
     chrono-node: ^2.5.0
@@ -18401,7 +18401,7 @@ __metadata:
     utopia-core-scss: ^1.0.1
     web-file-polyfill: ^1.0.4
     web-streams-polyfill: ^3.2.0
-    zed: "brimdata/zed#eff539fbfcfd10f136038de1a52192819137b2c1"
+    zed: "brimdata/zed#v1.16.0"
     zui-test-data: "workspace:*"
   peerDependencies:
     react: ^18.0.0


### PR DESCRIPTION
https://github.com/brimdata/zui/compare/v1.7.0...b5987c1

The link checker failure in CI is expected because there's a forward-looking link in one of the docs to the `v1.8.0` release that I plan to tag once this PR gets approved.