### PR TITLE
Show an error message when pcap slices can't be opened

### DIFF
--- a/apps/zui/src/plugins/brimcap/packets/download.ts
+++ b/apps/zui/src/plugins/brimcap/packets/download.ts
@@ -43,8 +43,14 @@ export async function downloadPackets(root: string, pool: string, uid: string) {
       const msg = JSON.parse(err)?.error || `brimcap search failed: ${err}`
       window.showErrorMessage(msg)
     } else {
-      shell.openPath(dest)
-      window.showSuccessMessage("Packets extracted. Opening...")
+      const msg = await shell.openPath(dest)
+      if (msg) {
+        window.showErrorMessage(
+          "Could not open extracted pcap. Is Wireshark installed?"
+        )
+      } else {
+        window.showSuccessMessage("Packets extracted. Opening...")
+      }
     }
   }
 }


### PR DESCRIPTION
## tl;dr

Per #1379, we've had problems on some platforms when a user clicks **Download Packets** and there's no application installed to open the extracted slice, e.g., Wireshark. Though we've merged some changes over time that have helped us improve in this area, this change covers us for Linux where the problem is still significant.

Fixes #1379

## Details

As of the most recent update in https://github.com/brimdata/zui/issues/1379#issuecomment-2187902520, Zui actually gets decent help here from the OS on both macOS and Windows since in those cases the OS pops up a notification about the lack of a helper app for pcaps. However, on Linux the user would still see just the **Packets extracted. Opening...** message from Zui, no launched pcap app, and no other guidance, so there was still room for improvement there.

I pursued an angle advocated in https://github.com/brimdata/zui/issues/1379#issuecomment-769232791 of researching what's returned by the function call to open the pcap helper app, which is currently Electron's [`shell.openPath()`](https://www.electronjs.org/docs/latest/api/shell#shellopenpathpath). What I found is that it _does_ sometimes return an error message in the absence of a helper app, though it's not the most helpful. Specifically:

|**OS**|**Message**|
|-|-|
|macOS|"Failed to open path"|
|Linux|"The action failed"|
|Windows|(no message returned)|

Because these messages are pretty vague, in the branch for this PR I'm instead opting to display the more explicit error message **Could not open extracted pcap. Is Wireshark installed?** Granted, in theory a user could install a different pcap helper app instead of Wireshark, but it seems like 99% of our users think of Wireshark here, and if a user is advanced enough to be seeking alternate helper app I imagine they'll get the essence of what the message is implying and install the app of their choosing.

The fact there's no message returned at all on Windows is annoying, but since we have the OS pop-up to cover us there, I'm not inclined to get obsessed.

## Tests

Using a [Dev build](https://github.com/brimdata/zui/actions/runs/9656295221) generated from this branch, here's video on each OS showing evidence of the failure case (no Wireshark installed) and success case (just to confirm we've not disturbed what was already working ok).

### Linux

**Failure**

This is the main benefit we're getting here, since the user now sees our error message instead of the silence from before.

https://github.com/brimdata/zui/assets/5934157/6a136d4d-6b24-4c38-bb6a-1bce88121607

**Success**

https://github.com/brimdata/zui/assets/5934157/4dbc97dd-b54e-4d59-a931-95f4c5cffe3d

### Windows

**Failure**

Because `shell.openPath()` returns no error message here, we rely on the OS to inform the user.

https://github.com/brimdata/zui/assets/5934157/ec6eb498-ea86-453b-bc9b-7e94c8438ce8

**Success**

https://github.com/brimdata/zui/assets/5934157/5af61f13-a985-4c1c-b7f0-6fe43442b231

### macOS

**Failure**

Here we get the "belt & suspenders" benefit of both the error message from Zui and the pop-up from the OS.

https://github.com/brimdata/zui/assets/5934157/26b00c36-d2e3-49a4-8ecc-4f9be271295a

**Success**

https://github.com/brimdata/zui/assets/5934157/82ee7b38-903f-48f5-a1d0-cef7410baba0



