### PR TITLE
Handle zed.Union types in format.ts

### DIFF
--- a/apps/zui/src/components/format.ts
+++ b/apps/zui/src/components/format.ts
@@ -65,6 +65,9 @@ export function formatValue(
   if (data instanceof zed.Map) {
     return `|{...${data.value.size}}|`
   }
+  if (data instanceof zed.Union) {
+    return formatValue(data.value, config)
+  }
   return null
 }
 

--- a/apps/zui/src/views/detail-pane/Fields.tsx
+++ b/apps/zui/src/views/detail-pane/Fields.tsx
@@ -26,9 +26,7 @@ const DataPanel = React.memo<DTProps>(function DataTable({
         <Data key={index}>
           <Name>{field.path.join(" ‣ ")}</Name>
           <Value className={zedTypeClassName(field.data)}>
-            {field.data instanceof zed.Union
-              ? format(field.data.value as zed.Primitive)
-              : format(field.data as zed.Primitive)}
+            {format(field.data as zed.Primitive)}
           </Value>
         </Data>
       ))}


### PR DESCRIPTION
The changes in #3103 made it possible to smuggle a `null` union value into the Detail output formatter that was not prepared to handle them. After walking the code with @jameskerr, his suggestion was to back out the change from #3103 and instead add code in the Detail output formatter to handle unions in a way that's tolerant of `null` values. The attached video shows the fix working as intended with this PR's branch at commit 7807deb.

https://github.com/brimdata/zui/assets/5934157/a3353339-552c-4036-aa7d-f54843624667

As it turns out, @jameskerr already had work underway to sunset this particular code in the Detail view in favor of what we do with Inspector, and he's already confirmed that new code is immune to this problem. However, since we took the time to fully understand what's wrong here, I figure it doesn't hurt to fix it so we're leaving the code in better shape as we lay it to rest, plus it'll let the #3117 community user work off a Zui Insiders release with the fix in the days leading up to the next GA Zui release.

Fixes #3117