### PR TITLE
Tiny Duration Fix

### DIFF
--- a/apps/zui/src/ppl/detail/models/ZeekEvent.ts
+++ b/apps/zui/src/ppl/detail/models/ZeekEvent.ts
@@ -1,5 +1,6 @@
 import * as zed from "@brimdata/zed-js"
 import {SecurityEventInterface} from "./security-event"
+import {isNumber} from "lodash"
 
 export class ZeekEvent implements SecurityEventInterface {
   constructor(private r: zed.Record) {}
@@ -14,10 +15,10 @@ export class ZeekEvent implements SecurityEventInterface {
 
   getEndTime() {
     if (this.r.get("_path").toString() !== "conn") return null
-    const dur = this.r.get<zed.Duration>("duration").asSeconds()
-    if (!dur) return
+    const dur = this.r.get<zed.Duration>("duration").asMs()
+    if (!isNumber(dur)) return
     const ts = this.r.get<zed.Time>("ts").toDate()
-    return new Date(ts.getTime() + dur * 1000)
+    return new Date(ts.getTime() + dur)
   }
 
   getType() {

--- a/apps/zui/src/ppl/detail/util/formatDur.test.ts
+++ b/apps/zui/src/ppl/detail/util/formatDur.test.ts
@@ -14,7 +14,7 @@ test("No end", () => {
 })
 
 test("500 ms", () => {
-  expect(formatDur(new Date(0), new Date(500))).toBe("0.5 seconds")
+  expect(formatDur(new Date(0), new Date(500))).toBe("500 milliseconds")
 })
 
 test("10 seconds", () => {

--- a/apps/zui/src/ppl/detail/util/formatDur.ts
+++ b/apps/zui/src/ppl/detail/util/formatDur.ts
@@ -14,7 +14,11 @@ export default function formatDir(start, end) {
     parts.push(formatPart(obj[unit], unit))
   }
   if (allZero) {
-    parts.push(formatPart((end.getTime() - start.getTime()) / 1000, "seconds"))
+    if (end.getTime() === start.getTime()) {
+      return "less than 1 millisecond"
+    } else {
+      parts.push(formatPart(end.getTime() - start.getTime(), "milliseconds"))
+    }
   }
   return firstTwo(parts).join(" ")
 }


### PR DESCRIPTION
Fixes #3101 


With this fix:

If the duration is less than 1 second, it will display "xxxmilliseconds"
If it is less than 1 millisecond, it will display "less than one millisecond"

![CleanShot 2024-07-01 at 11 34 24@2x](https://github.com/brimdata/zui/assets/3460638/b28656d9-e347-44a3-893e-27a8f7d620d2)
