### PR TITLE
Parquet export

### DIFF
--- a/apps/zui/src/domain/results/handlers/export.ts
+++ b/apps/zui/src/domain/results/handlers/export.ts
@@ -69,7 +69,7 @@ export const exportToClipboard = createHandler(
 )
 
 export const getExportQuery = createHandler((ctx, format: ResponseFormat) => {
-  const formatNeedsFuse = ["csv", "tsv", "arrows"]
+  const formatNeedsFuse = ["arrows", "csv", "parquet", "tsv"]
   const query = ctx.select(Results.getQuery(RESULTS_QUERY))
   const isTable = ctx.select(Layout.getEffectiveResultsView) == "TABLE"
   const hiddenColCount = ctx.select(Table.getHiddenColumnCount)

--- a/apps/zui/src/views/format-select/options.ts
+++ b/apps/zui/src/views/format-select/options.ts
@@ -3,6 +3,7 @@ export const FORMAT_OPTIONS = [
   {value: "csv", label: "CSV"},
   {value: "json", label: "JSON"},
   {value: "ndjson", label: "NDJSON"},
+  {value: "parquet", label: "Parquet"},
   {value: "tsv", label: "TSV"},
   {value: "vng", label: "VNG"},
   {value: "zeek", label: "Zeek"},

--- a/packages/zed-js/src/client/types.ts
+++ b/packages/zed-js/src/client/types.ts
@@ -19,6 +19,7 @@ export type ResponseFormat =
   | 'csv'
   | 'json'
   | 'ndjson'
+  | 'parquet'
   | 'tsv'
   | 'vng'
   | 'zeek'

--- a/packages/zed-js/src/client/utils.ts
+++ b/packages/zed-js/src/client/utils.ts
@@ -36,6 +36,7 @@ export function accept(format: ResponseFormat) {
     csv: 'text/csv',
     json: 'application/json',
     ndjson: 'application/x-ndjson',
+    parquet: 'application/x-parquet',
     tsv: 'text/tab-separated-values',
     vng: 'application/x-vng',
     zeek: 'application/x-zeek',

--- a/packages/zui-player/tests/export.spec.ts
+++ b/packages/zui-player/tests/export.spec.ts
@@ -39,22 +39,7 @@ test.describe('Export tests', () => {
 
   formats.forEach(({ label, expectedSize }) => {
     test(`Exporting in ${label} format succeeds`, async () => {
-      const file = path.join(tempDir, `results.${label}`);
-      app.mockSaveDialog({ canceled: false, filePath: file });
-      await app.click('button', 'Export Results');
-      await app.attached('dialog');
-      const dialog = app.mainWin.getByRole('dialog');
-      await app.select('Format', label);
-      await dialog
-        .getByRole('button')
-        .filter({ hasText: 'Export To File' })
-        .click();
-      await app.detached('dialog');
-      await app.mainWin
-        .getByText(new RegExp('Export Completed: .*results\\.' + label))
-        .waitFor();
-
-      expect(fsExtra.statSync(file).size).toBe(expectedSize);
+      await app.exportAsFormat(label, expectedSize, tempDir);
     });
   });
 
@@ -98,22 +83,7 @@ test.describe('Export tests', () => {
   test(`Exporting in Parquet format succeeds`, async () => {
     await app.createPool([getPath('cities.json')]);
     await app.click('button', 'Query Pool');
-    const file = path.join(tempDir, `results.Parquet]`);
-    app.mockSaveDialog({ canceled: false, filePath: file });
-    await app.click('button', 'Export Results');
-    await app.attached('dialog');
-    const dialog = app.mainWin.getByRole('dialog');
-    await app.select('Format', 'Parquet');
-    await dialog
-      .getByRole('button')
-      .filter({ hasText: 'Export To File' })
-      .click();
-    await app.detached('dialog');
-    await app.mainWin
-      .getByText(new RegExp('Export Completed: .*results\\.Parquet'))
-      .waitFor();
-
-    expect(fsExtra.statSync(file).size).toBe(851913);
+    await app.exportAsFormat('Parquet', 851913, tempDir);
   });
 
 });

--- a/packages/zui-player/tests/export.spec.ts
+++ b/packages/zui-player/tests/export.spec.ts
@@ -94,4 +94,26 @@ test.describe('Export tests', () => {
     await app.attached(/Error: CSV output encountered non-record value/);
     await expect(fsExtra.stat(filePath)).rejects.toThrowError('no such file');
   });
+
+  test(`Exporting in Parquet format succeeds`, async () => {
+    await app.createPool([getPath('cities.json')]);
+    await app.click('button', 'Query Pool');
+    const file = path.join(tempDir, `results.Parquet]`);
+    app.mockSaveDialog({ canceled: false, filePath: file });
+    await app.click('button', 'Export Results');
+    await app.attached('dialog');
+    const dialog = app.mainWin.getByRole('dialog');
+    await app.select('Format', 'Parquet');
+    await dialog
+      .getByRole('button')
+      .filter({ hasText: 'Export To File' })
+      .click();
+    await app.detached('dialog');
+    await app.mainWin
+      .getByText(new RegExp('Export Completed: .*results\\.Parquet'))
+      .waitFor();
+
+    expect(fsExtra.statSync(file).size).toBe(851913);
+  });
+
 });


### PR DESCRIPTION
I've been holding off on adding Parquet as an Export format in Zui until #2751 was fixed, since there's so many Parquet limitations that can prevent the export from succeeding (e.g., lack of support for multiple types, lack of duration support, poor union support, etc.) But now that #2751 has been fixed and users will see the errors when exports fail, here I'm adding support for Parquet as an Export format.

Due to those same Parquet limitations, I could not just extend the existing loop-through-all-formats approach in the existing Export e2e test because an attempted export of that same test data file would fail. I saw a few ways this could be addressed:

1. I could rework the existing test to use a different, Parquet-eligible test data file for export in all formats and change all the expected byte counts to match. I chose not to pursue this since it didn't seem appropriate to "dumb down" to the lowest common denominator.

2. I could add an additional test just for Parquet that imports its own Parquet-eligible test data file. I took this approach in the first commit on this branch. However, I had to duplicate some code from the existing test.

3. Same as the prior, but I could break out the common code to a helper function that could be called by both the prior loop-through-all-formats approach as well as the new test for just Parquet. I took this approach in the second commit on this branch.

Of course, there's surely other variations, so I'm open to other adjustments.

Closes #2591 
