### PR TITLE
Split Correlations and Detail Panes

### DIFF
--- a/apps/zui/pages/detail.tsx
+++ b/apps/zui/pages/detail.tsx
@@ -8,7 +8,7 @@ import initialize from "src/js/initializers/initialize"
 import TabHistories from "src/js/state/TabHistories"
 import Tabs from "src/js/state/Tabs"
 import {getPersistedWindowState} from "src/js/state/stores/get-persistable"
-import {DetailsWindow} from "src/views/details-window"
+import DetailPane from "src/views/detail-pane/Pane"
 
 export default function DetailPage() {
   const [app, setApp] = useState(null)
@@ -34,7 +34,7 @@ export default function DetailPage() {
   return (
     <AppProvider store={app.store} api={app.api}>
       <AppWindowRouter>
-        <DetailsWindow />
+        <DetailPane />
         <Modals />
         <Tooltip />
       </AppWindowRouter>

--- a/apps/zui/pages/detail.tsx
+++ b/apps/zui/pages/detail.tsx
@@ -34,7 +34,9 @@ export default function DetailPage() {
   return (
     <AppProvider store={app.store} api={app.api}>
       <AppWindowRouter>
-        <DetailPane />
+        <div className="scroll-y">
+          <DetailPane />
+        </div>
         <Modals />
         <Tooltip />
       </AppWindowRouter>

--- a/apps/zui/src/app/routes/app-wrapper/app-grid.tsx
+++ b/apps/zui/src/app/routes/app-wrapper/app-grid.tsx
@@ -26,7 +26,7 @@ export function AppGrid({children}) {
   const width = sidebarIsOpen ? sidebarWidth : 0
   const width2 = secondarySidebarIsOpen ? secondarySidebarWidth : 0
   const rows = ["40px", "1fr"]
-  const columns = [`min(${width}px, 70vw)`, "1fr", `min(${width2}px, 30vw)`]
+  const columns = [`min(${width}px, 50vw)`, "1fr", `min(${width2}px, 50vw)`]
   const style = {
     gridTemplateAreas: areas,
     gridTemplateRows: rows.join(" "),

--- a/apps/zui/src/components/data.tsx
+++ b/apps/zui/src/components/data.tsx
@@ -8,7 +8,7 @@ export const Data = styled.dl`
   position: relative;
   margin: 0;
   cursor: default;
-  min-height: 26px;
+  line-height: 1.7;
 `
 
 export const Name = styled.dt`

--- a/apps/zui/src/components/section-tabs.tsx
+++ b/apps/zui/src/components/section-tabs.tsx
@@ -1,70 +1,7 @@
 import React, {useLayoutEffect, useRef, useState} from "react"
 import {MenuItem} from "src/core/menu"
-import styled from "styled-components"
 import {MoreItemsButton} from "./more-items-button"
 import {useResponsiveMenu} from "src/js/components/hooks/use-responsive-menu"
-
-const BG = styled.div`
-  display: flex;
-  min-width: 0;
-  align-items: center;
-  height: 100%;
-  position: relative;
-  overflow: hidden;
-`
-
-const Nav = styled.nav`
-  display: flex;
-  align-items: center;
-  min-width: 0;
-  flex: 1;
-
-  button {
-    background: none;
-    border: none;
-
-    display: flex;
-    align-items: center;
-
-    border-radius: 6px;
-    padding: 6px 6px;
-
-    text-transform: uppercase;
-    font-weight: 500;
-    font-size: 12px;
-    opacity: 0.5;
-
-    &:hover:not([aria-pressed="true"]) {
-      opacity: 0.7;
-      transition: opacity 0.2s;
-      background: var(--sidebar-item-hover);
-    }
-
-    &:active:not([aria-pressed="true"]) {
-      opacity: 0.8;
-      background: var(--sidebar-item-active);
-      box-shadow: var(--sidebar-item-active-shadow);
-    }
-
-    &[aria-pressed="true"] {
-      opacity: 1;
-    }
-
-    span {
-      padding: 0 2px;
-      display: block;
-    }
-  }
-`
-
-const Underline = styled.div`
-  height: 2px;
-  background: var(--primary-color);
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  border-radius: 1px;
-`
 
 export function SectionTabs(props: {options: MenuItem[]}) {
   const changeCount = useRef(0)
@@ -87,10 +24,11 @@ export function SectionTabs(props: {options: MenuItem[]}) {
   }, [pressedIndex, menu])
 
   return (
-    <BG ref={menu.containerRef}>
-      <Nav>
+    <div ref={menu.containerRef} className="flex items-center h-full relative">
+      <nav className="flex">
         {menu.items.map((item, index) => (
           <button
+            className="section-tab-button"
             key={item.id ?? index}
             onClick={() => {
               changeCount.current += 1
@@ -109,8 +47,9 @@ export function SectionTabs(props: {options: MenuItem[]}) {
         {menu.hasHiddenItems ? (
           <MoreItemsButton items={menu.hiddenItems} ref={menu.moreRef} />
         ) : null}
-      </Nav>
-      <Underline
+      </nav>
+      <div
+        className="section-tab-button-underline"
         style={{
           transform: `translateX(${pos.x}px)`,
           width: pos.width,
@@ -119,6 +58,6 @@ export function SectionTabs(props: {options: MenuItem[]}) {
           visibility: menu.isHidden(pressedIndex) ? "hidden" : "visible",
         }}
       />
-    </BG>
+    </div>
   )
 }

--- a/apps/zui/src/components/section-tabs.tsx
+++ b/apps/zui/src/components/section-tabs.tsx
@@ -1,34 +1,30 @@
-import React, {useLayoutEffect, useRef, useState} from "react"
+import React, {useRef} from "react"
 import {MenuItem} from "src/core/menu"
 import {MoreItemsButton} from "./more-items-button"
 import {useResponsiveMenu} from "src/js/components/hooks/use-responsive-menu"
+import classNames from "classnames"
 
-export function SectionTabs(props: {options: MenuItem[]}) {
+export function SectionTabs(props: {
+  options: MenuItem[]
+  className?: string
+  style?: any
+}) {
   const changeCount = useRef(0)
-  const [pos, setPos] = useState({x: 0, width: 10})
-  const pressedIndex = props.options.findIndex((opt) => opt.checked)
   const menu = useResponsiveMenu(props.options)
 
-  useLayoutEffect(() => {
-    const el = menu.containerRef.current
-    if (el) {
-      const parent = el.getBoundingClientRect()
-      const pressed = el.querySelector(`[aria-pressed="true"] span`)
-      if (pressed) {
-        const button = pressed.getBoundingClientRect()
-        const x = button.x - parent.x
-        const width = button.width
-        setPos({x, width})
-      }
-    }
-  }, [pressedIndex, menu])
-
   return (
-    <div ref={menu.containerRef} className="flex items-center h-full relative">
-      <nav className="flex">
+    <div
+      ref={menu.containerRef}
+      style={props.style}
+      className={classNames(
+        props.className,
+        "flex items-center h-full relative w-full overflow-hidden"
+      )}
+    >
+      <nav className="flex h-full items-center">
         {menu.items.map((item, index) => (
           <button
-            className="section-tab-button"
+            className="section-tab-button h-full"
             key={item.id ?? index}
             onClick={() => {
               changeCount.current += 1
@@ -48,16 +44,6 @@ export function SectionTabs(props: {options: MenuItem[]}) {
           <MoreItemsButton items={menu.hiddenItems} ref={menu.moreRef} />
         ) : null}
       </nav>
-      <div
-        className="section-tab-button-underline"
-        style={{
-          transform: `translateX(${pos.x}px)`,
-          width: pos.width,
-          transition:
-            changeCount.current === 0 ? "none" : "width 200ms, transform 200ms",
-          visibility: menu.isHidden(pressedIndex) ? "hidden" : "visible",
-        }}
-      />
     </div>
   )
 }

--- a/apps/zui/src/css/_conn-versation.scss
+++ b/apps/zui/src/css/_conn-versation.scss
@@ -1,8 +1,4 @@
 .conn-versation {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-3xs);
-  justify-content: flex-start;
   user-select: none;
   font-size: var(--step--1);
 
@@ -13,6 +9,8 @@
   }
 
   .host {
+    margin-inline: auto;
+    max-inline-size: fit-content;
     border: 1px solid var(--border-color);
   }
 

--- a/apps/zui/src/css/_conn-versation.scss
+++ b/apps/zui/src/css/_conn-versation.scss
@@ -1,7 +1,9 @@
 .conn-versation {
   margin-bottom: $space-s;
   display: flex;
-  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--space-s);
+  justify-content: flex-start;
   user-select: none;
 
   td,
@@ -25,15 +27,13 @@
     margin: 0;
     color: white;
     background: var(--primary-color);
-    font-size: 12px;
     text-align: center;
-    line-height: 20px;
     font-family: var(--mono-font);
     user-select: all;
   }
 
   .ip.small {
-    font-size: 8px;
+    font-size: var(--step--2);
   }
 
   .port {
@@ -84,11 +84,11 @@
   }
 
   .history-packet.arrow-right {
-    padding-right: $space-s*0.5;
+    padding-right: $space-s * 0.5;
   }
 
   .history-packet.arrow-left {
-    padding-left: $space-s*0.5;
+    padding-left: $space-s * 0.5;
 
     .triangle {
       order: 1;

--- a/apps/zui/src/css/_conn-versation.scss
+++ b/apps/zui/src/css/_conn-versation.scss
@@ -1,10 +1,10 @@
 .conn-versation {
-  margin-bottom: $space-s;
   display: flex;
   flex-wrap: wrap;
-  gap: var(--space-s);
+  gap: var(--space-3xs);
   justify-content: flex-start;
   user-select: none;
+  font-size: var(--step--1);
 
   td,
   th {
@@ -13,13 +13,12 @@
   }
 
   .host {
-    border: 1px solid var(--fg-color-less);
-    border-radius: 3px;
+    border: 1px solid var(--border-color);
   }
 
   .fieldset {
     text-align: center;
-    padding: 6px 3px;
+    padding: var(--space-3xs);
   }
 
   .ip,
@@ -53,7 +52,6 @@
   .history {
     align-self: center;
     flex: 1;
-    padding: $space-s;
   }
 
   .history-packet {
@@ -72,13 +70,13 @@
     hr {
       flex: 1;
       border: none;
-      border-bottom: 1px solid var(--yellow);
+      border-bottom: 1px solid var(--fg-color-less);
       margin: 0;
     }
 
     .triangle {
-      fill: var(--yellow);
-      stroke: var(--yellow);
+      fill: var(--fg-color-less);
+      stroke: var(--fg-color-less);
       width: 10px;
     }
   }

--- a/apps/zui/src/css/_global.scss
+++ b/apps/zui/src/css/_global.scss
@@ -75,10 +75,6 @@ button {
   background-color: var(--emphasis-bg-less);
 }
 
-dt {
-  font-weight: bold;
-}
-
 dd {
   font-family: var(--mono-font);
 }

--- a/apps/zui/src/css/_hash-correlation.scss
+++ b/apps/zui/src/css/_hash-correlation.scss
@@ -3,6 +3,7 @@
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
+    flex-wrap: wrap;
     & > * {
       flex-basis: 45%;
     }

--- a/apps/zui/src/css/_log-detail-window.scss
+++ b/apps/zui/src/css/_log-detail-window.scss
@@ -2,25 +2,3 @@
   height: 100%;
   width: 100%;
 }
-
-.log-detail-window {
-  display: flex;
-  width: 100%;
-  height: 100%;
-  flex-direction: column;
-
-  .pane-header {
-    background: var(--chrome-color);
-    border-bottom: 1px solid #dbdbdb;
-  }
-
-  .detail-pane-content {
-    display: flex;
-    justify-content: space-between;
-
-    .column {
-      width: 50%;
-      margin: 12px;
-    }
-  }
-}

--- a/apps/zui/src/css/_tab.scss
+++ b/apps/zui/src/css/_tab.scss
@@ -31,10 +31,7 @@
   // Title
   .title {
     font-family: system-ui;
-    font-size: 14px;
-    line-height: 16px;
     margin: 0;
-    font-weight: 400;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -51,7 +48,7 @@
     }
 
     .close-button {
-      opacity: 1
+      opacity: 1;
     }
 
     .tab-content {

--- a/apps/zui/src/css/_table.scss
+++ b/apps/zui/src/css/_table.scss
@@ -18,8 +18,8 @@
 
   th {
     text-align: left;
-    font-size: 9px;
     font-weight: bold;
+    font-size: var(--step--1);
   }
 
   td {
@@ -38,7 +38,6 @@
 }
 
 .vertical-table {
-
   th,
   td {
     word-break: break-word;

--- a/apps/zui/src/css/_utilities.scss
+++ b/apps/zui/src/css/_utilities.scss
@@ -10,6 +10,10 @@
   justify-content: space-between;
 }
 
+.justify-center {
+  justify-content: center;
+}
+
 .align\:center {
   align-items: center;
 }
@@ -217,4 +221,24 @@
 
 .flex-nowrap {
   flex-wrap: nowrap;
+}
+
+.relative {
+  position: relative;
+}
+
+.border-b-solid {
+  border-bottom-style: solid;
+}
+
+.border-more {
+  border-color: var(--border-color-more);
+}
+
+.h-toolbar {
+  height: var(--toolbar-height);
+}
+
+.w-full {
+  width: 100%;
 }

--- a/apps/zui/src/css/_utilities.scss
+++ b/apps/zui/src/css/_utilities.scss
@@ -232,7 +232,7 @@
 }
 
 .border-more {
-  border-color: var(--border-color-more);
+  --border-color: var(--border-color-more);
 }
 
 .h-toolbar {

--- a/apps/zui/src/css/_utilities.scss
+++ b/apps/zui/src/css/_utilities.scss
@@ -242,3 +242,7 @@
 .w-full {
   width: 100%;
 }
+
+.h-full {
+  height: 100%;
+}

--- a/apps/zui/src/css/blocks/_cards.scss
+++ b/apps/zui/src/css/blocks/_cards.scss
@@ -1,5 +1,5 @@
 .data-card {
-  background: var(--chrome-color);
+  background: var(--bg-color);
   border-radius: var(--radius-m);
   border-style: solid;
 }

--- a/apps/zui/src/css/blocks/_cards.scss
+++ b/apps/zui/src/css/blocks/_cards.scss
@@ -1,4 +1,4 @@
-.data-card {
+.sidebar-card {
   background: var(--bg-color);
   border-radius: var(--radius-m);
   border-style: solid;

--- a/apps/zui/src/css/blocks/_cards.scss
+++ b/apps/zui/src/css/blocks/_cards.scss
@@ -1,0 +1,5 @@
+.data-card {
+  background: var(--chrome-color);
+  border-radius: var(--radius-m);
+  border-style: solid;
+}

--- a/apps/zui/src/css/blocks/_section-tabs.scss
+++ b/apps/zui/src/css/blocks/_section-tabs.scss
@@ -1,14 +1,14 @@
 .section-tab-button {
   background: none;
-  opacity: 0.75;
   padding: 0;
   border-radius: 0;
   border-top: 2px solid transparent;
   border-bottom: 2px solid transparent;
+  color: var(--fg-color-less);
 
   &[aria-pressed="true"] {
     opacity: 1;
-    color: var(--primary-color-darker);
+    color: var(--text-active);
     border-bottom: 2px solid var(--primary-color);
   }
 

--- a/apps/zui/src/css/blocks/_section-tabs.scss
+++ b/apps/zui/src/css/blocks/_section-tabs.scss
@@ -1,0 +1,24 @@
+.section-tab-button {
+  background: none;
+  opacity: 0.75;
+  padding: 0;
+
+  &[aria-pressed="true"] {
+    opacity: 1;
+    color: var(--primary-color-darker);
+  }
+
+  span {
+    padding: 0 var(--half-gutter);
+    display: block;
+  }
+}
+
+.section-tab-button-underline {
+  height: 2px;
+  border-radius: 2px;
+  background: var(--primary-color);
+  position: absolute;
+  bottom: 0;
+  left: 0;
+}

--- a/apps/zui/src/css/blocks/_section-tabs.scss
+++ b/apps/zui/src/css/blocks/_section-tabs.scss
@@ -2,10 +2,18 @@
   background: none;
   opacity: 0.75;
   padding: 0;
+  border-radius: 0;
+  border-top: 2px solid transparent;
+  border-bottom: 2px solid transparent;
 
   &[aria-pressed="true"] {
     opacity: 1;
     color: var(--primary-color-darker);
+    border-bottom: 2px solid var(--primary-color);
+  }
+
+  &:hover {
+    background: var(--emphasis-bg-less);
   }
 
   span {

--- a/apps/zui/src/css/blocks/_vertical-rule.scss
+++ b/apps/zui/src/css/blocks/_vertical-rule.scss
@@ -1,0 +1,4 @@
+.vertical-rule {
+  width: 0px;
+  border-left-style: solid;
+}

--- a/apps/zui/src/css/compositions/_box.scss
+++ b/apps/zui/src/css/compositions/_box.scss
@@ -1,3 +1,11 @@
 .box {
   padding: var(--gutter-space);
 }
+
+.gutter {
+  padding-inline: var(--gutter-space);
+}
+
+.gutter-block {
+  padding-block: var(--gutter-space);
+}

--- a/apps/zui/src/css/compositions/_box.scss
+++ b/apps/zui/src/css/compositions/_box.scss
@@ -9,3 +9,11 @@
 .gutter-block {
   padding-block: var(--gutter-space);
 }
+
+.half-gutter {
+  --gutter-space: var(--half-gutter);
+}
+
+.gutter-inline-end {
+  padding-inline-end: var(--gutter);
+}

--- a/apps/zui/src/css/compositions/_flex-stack.scss
+++ b/apps/zui/src/css/compositions/_flex-stack.scss
@@ -1,0 +1,4 @@
+.flex-stack {
+  display: flex;
+  flex-direction: column;
+}

--- a/apps/zui/src/css/compositions/_stack.scss
+++ b/apps/zui/src/css/compositions/_stack.scss
@@ -1,4 +1,4 @@
-.flex-stack {
+.stack {
   display: flex;
   flex-direction: column;
 }

--- a/apps/zui/src/css/compositions/_switcher.scss
+++ b/apps/zui/src/css/compositions/_switcher.scss
@@ -1,0 +1,10 @@
+.switcher {
+  display: flex;
+  flex-wrap: wrap;
+  --threshold: 40rem;
+}
+
+.switcher > * {
+  flex-grow: 1;
+  flex-basis: calc((var(--threshold) - 100%) * 999);
+}

--- a/apps/zui/src/css/main.scss
+++ b/apps/zui/src/css/main.scss
@@ -32,6 +32,7 @@
 @import "compositions/region";
 @import "compositions/repel";
 @import "compositions/stack";
+@import "compositions/switcher";
 
 /* Blocks */
 @import "buttons";

--- a/apps/zui/src/css/main.scss
+++ b/apps/zui/src/css/main.scss
@@ -95,6 +95,7 @@
 @import "blocks/sidebar-item";
 @import "blocks/settings-modal";
 @import "blocks/vertical-rule";
+@import "blocks/section-tabs";
 
 /* Utilities */
 @import "utilities";

--- a/apps/zui/src/css/main.scss
+++ b/apps/zui/src/css/main.scss
@@ -31,6 +31,7 @@
 @import "compositions/sidebar";
 @import "compositions/region";
 @import "compositions/repel";
+@import "compositions/stack";
 
 /* Blocks */
 @import "buttons";
@@ -101,3 +102,5 @@
 @import "utilities";
 @import "utilities/spacing";
 @import "utilities/flex";
+@import "utilities/surfaces";
+@import "utilities/radius";

--- a/apps/zui/src/css/main.scss
+++ b/apps/zui/src/css/main.scss
@@ -97,6 +97,7 @@
 @import "blocks/settings-modal";
 @import "blocks/vertical-rule";
 @import "blocks/section-tabs";
+@import "blocks/cards";
 
 /* Utilities */
 @import "utilities";

--- a/apps/zui/src/css/main.scss
+++ b/apps/zui/src/css/main.scss
@@ -94,6 +94,7 @@
 
 @import "blocks/sidebar-item";
 @import "blocks/settings-modal";
+@import "blocks/vertical-rule";
 
 /* Utilities */
 @import "utilities";

--- a/apps/zui/src/css/settings/_colors.scss
+++ b/apps/zui/src/css/settings/_colors.scss
@@ -148,7 +148,7 @@
  */
 :root {
   --border-color: hsl(216, 10%, 87%);
-  --border-color-more: hsl(216, 10%, 75%);
+  --border-color-more: hsl(216, 10%, 70%);
 
   @media (prefers-color-scheme: dark) {
     --border-color: #393939;

--- a/apps/zui/src/css/settings/_colors.scss
+++ b/apps/zui/src/css/settings/_colors.scss
@@ -9,6 +9,12 @@
   --yellow: #ffc933;
   --blue: hsl(212, 72%, 59%);
 
+  --primary-color-lighter: hsl(212, 89%, 82%);
+  --primary-color-light: hsl(212, 72%, 69%);
+  --primary-color: hsl(212, 72%, 59%);
+  --primary-color-dark: hsl(212, 78%, 50%);
+  --primary-color-darker: hsl(212, 88%, 35%);
+
   /* Forms */
   --form-border-radius: 4px;
 
@@ -102,6 +108,17 @@
   }
 }
 
+/** 
+ * Text Colors
+ */
+:root {
+  --text-active: var(--primary-color-darker);
+
+  @media (prefers-color-scheme: dark) {
+    --text-active: var(--primary-color-lighter);
+  }
+}
+
 /**
  * Chrome / Grays
  */
@@ -113,17 +130,6 @@
     --chrome-color: hsl(0deg 0% 16.02%);
     --chrome-color-more: hsl(0deg 0% 46.02%);
   }
-}
-
-/**
- * Primary Color Variations
- */
-:root {
-  --primary-color-lighter: hsl(212, 89%, 82%);
-  --primary-color-light: hsl(212, 72%, 69%);
-  --primary-color: hsl(212, 72%, 59%);
-  --primary-color-dark: hsl(212, 78%, 50%);
-  --primary-color-darker: hsl(212, 88%, 35%);
 }
 
 /**
@@ -152,7 +158,7 @@
 
   @media (prefers-color-scheme: dark) {
     --border-color: #393939;
-    --border-color-more: rgba(255, 255, 255, 0.5);
+    --border-color-more: rgba(255, 255, 255, 0.25);
   }
 }
 

--- a/apps/zui/src/css/settings/_colors.scss
+++ b/apps/zui/src/css/settings/_colors.scss
@@ -148,7 +148,7 @@
  */
 :root {
   --border-color: hsl(216, 10%, 87%);
-  --border-color-more: hsl(216, 10%, 80%);
+  --border-color-more: hsl(216, 10%, 75%);
 
   @media (prefers-color-scheme: dark) {
     --border-color: #393939;

--- a/apps/zui/src/css/settings/_variables.scss
+++ b/apps/zui/src/css/settings/_variables.scss
@@ -36,9 +36,10 @@
 }
 
 :root {
-  
   --gutter-space: var(--space-s);
+  --half-gutter: calc(var(--gutter-space) / 2);
   --hover-duration: 75ms;
+  --toolbar-height: 40px;
 
   /* Hover and Active Filters */
   --hover-filter: brightness(95%);

--- a/apps/zui/src/css/shared/_typography.scss
+++ b/apps/zui/src/css/shared/_typography.scss
@@ -65,10 +65,6 @@
 
 .mono {
   font-family: var(--mono-font);
-  font-weight: normal;
-  font-size: 12px;
-  line-height: 16px;
-  margin: 0;
 }
 
 .code {

--- a/apps/zui/src/css/utilities/_flex.scss
+++ b/apps/zui/src/css/utilities/_flex.scss
@@ -17,3 +17,8 @@
 .flex-shrink-0 {
   flex-shrink: 0;
 }
+
+.flex-fixed {
+  flex-shrink: 0;
+  flex-grow: 0;
+}

--- a/apps/zui/src/css/utilities/_flex.scss
+++ b/apps/zui/src/css/utilities/_flex.scss
@@ -1,3 +1,7 @@
+.justify-end {
+  justify-content: flex-end;
+}
+
 .justify-between {
   justify-content: space-between;
 }
@@ -8,4 +12,8 @@
 
 .items-center {
   align-items: center;
+}
+
+.flex-shrink-0 {
+  flex-shrink: 0;
 }

--- a/apps/zui/src/css/utilities/_radius.scss
+++ b/apps/zui/src/css/utilities/_radius.scss
@@ -1,0 +1,11 @@
+.radius-s {
+  border-radius: var(--radius-s);
+}
+
+.radius-m {
+  border-radius: var(--radius-m);
+}
+
+.radius-l {
+  border-radius: var(--radius-l);
+}

--- a/apps/zui/src/css/utilities/_surfaces.scss
+++ b/apps/zui/src/css/utilities/_surfaces.scss
@@ -1,0 +1,3 @@
+.surface-1 {
+  background: var(--emphasis-bg);
+}

--- a/apps/zui/src/electron/windows/detail-window.ts
+++ b/apps/zui/src/electron/windows/detail-window.ts
@@ -7,9 +7,9 @@ export class DetailWindow extends ZuiWindow {
   persistable = false
   options = {
     resizable: true,
-    width: 680,
-    height: 480,
-    minWidth: 500,
+    width: 480,
+    height: 680,
+    minWidth: 300,
   }
 
   beforeLoad() {

--- a/apps/zui/src/electron/windows/search/search-window.ts
+++ b/apps/zui/src/electron/windows/search/search-window.ts
@@ -16,8 +16,8 @@ export class SearchWindow extends ZuiWindow {
     resizable: true,
     minWidth: 480,
     minHeight: 100,
-    width: 1250,
-    height: 750,
+    width: 1470,
+    height: 900,
   }
   loadsInProgress = 0
 

--- a/apps/zui/src/js/components/ConnVersation.tsx
+++ b/apps/zui/src/js/components/ConnVersation.tsx
@@ -75,7 +75,7 @@ const Host = ({className, title, ip, port, record}: HostProps) => {
   if (!port) return null
 
   return (
-    <div className={`host ${className} data-card`}>
+    <div className={`host ${className} sidebar-card`}>
       <Fieldset>{title}</Fieldset>
       <p className={`ip ${ip.data.toString().length > 16 ? "small" : ""}`}>
         {ip.data.toString()}

--- a/apps/zui/src/js/components/ConnVersation.tsx
+++ b/apps/zui/src/js/components/ConnVersation.tsx
@@ -75,7 +75,7 @@ const Host = ({className, title, ip, port, record}: HostProps) => {
   if (!port) return null
 
   return (
-    <div className={`host ${className}`}>
+    <div className={`host ${className} data-card`}>
       <Fieldset>{title}</Fieldset>
       <p className={`ip ${ip.data.toString().length > 16 ? "small" : ""}`}>
         {ip.data.toString()}

--- a/apps/zui/src/js/components/ConnVersation.tsx
+++ b/apps/zui/src/js/components/ConnVersation.tsx
@@ -28,22 +28,29 @@ function filter(record: zed.Record, names: string[]) {
 
 const ConnVersation = ({record}: Props) => {
   return (
-    <div className="conn-versation">
-      <Host
-        title="Originator"
-        className="originator"
-        record={filter(record, ORIG_FIELDS)}
-        ip={record.getField(["id", "orig_h"])}
-        port={record.getField(["id", "orig_p"])}
-      />
+    <div
+      className="conn-versation switcher gap-s"
+      style={{"--threshold": "390px"} as any}
+    >
+      <div>
+        <Host
+          title="Originator"
+          className="originator"
+          record={filter(record, ORIG_FIELDS)}
+          ip={record.getField(["id", "orig_h"])}
+          port={record.getField(["id", "orig_p"])}
+        />
+      </div>
       <ConnHistory history={record.get("history").toString()} />
-      <Host
-        title="Responder"
-        className="responder"
-        record={filter(record, RESP_FIELDS)}
-        ip={record.getField(["id", "resp_h"])}
-        port={record.getField(["id", "resp_p"])}
-      />
+      <div>
+        <Host
+          title="Responder"
+          className="responder"
+          record={filter(record, RESP_FIELDS)}
+          ip={record.getField(["id", "resp_h"])}
+          port={record.getField(["id", "resp_p"])}
+        />
+      </div>
     </div>
   )
 }

--- a/apps/zui/src/js/components/LogDetails/ConnPanel.tsx
+++ b/apps/zui/src/js/components/LogDetails/ConnPanel.tsx
@@ -10,7 +10,7 @@ type Props = {
 const ConnPanel = ({record}: Props) => {
   if (!ConnVersation.shouldShow(record)) return null
   return (
-    <section className="conn-versation-panel detail-panel">
+    <section>
       <PanelHeading>Conn History</PanelHeading>
       <ConnVersation record={record} />
     </section>

--- a/apps/zui/src/js/components/LogDetails/Md5Panel.tsx
+++ b/apps/zui/src/js/components/LogDetails/Md5Panel.tsx
@@ -14,7 +14,7 @@ import {
 
 export const Md5Panel = () => {
   return (
-    <section className="hash-correlation detail-panel">
+    <section className="hash-correlation data-card box">
       <PanelHeading isLoading={false}>Md5 Correlation</PanelHeading>
       <AsyncTable resultId={MD5_CORRELATION} expect={1} />
       <AsyncTable resultId={FILENAME_CORRELATION} expect={1} />

--- a/apps/zui/src/js/components/LogDetails/Md5Panel.tsx
+++ b/apps/zui/src/js/components/LogDetails/Md5Panel.tsx
@@ -14,7 +14,7 @@ import {
 
 export const Md5Panel = () => {
   return (
-    <section className="hash-correlation data-card box">
+    <section className="hash-correlation sidebar-card box">
       <PanelHeading isLoading={false}>Md5 Correlation</PanelHeading>
       <AsyncTable resultId={MD5_CORRELATION} expect={1} />
       <AsyncTable resultId={FILENAME_CORRELATION} expect={1} />

--- a/apps/zui/src/js/components/TabBar/TabBar.tsx
+++ b/apps/zui/src/js/components/TabBar/TabBar.tsx
@@ -21,6 +21,7 @@ import {
 import tab from "src/js/models/tab"
 import useLakeId from "src/app/router/hooks/use-lake-id"
 import {bounded} from "src/util/bounded"
+import {Show} from "src/components/show"
 
 const AnimatedSearchTab = animated(SearchTab)
 const MAX_WIDTH = 200
@@ -113,7 +114,9 @@ export default function TabBar() {
         })}
         <AddTab onClick={ctl.onAddClick} left={width * count} />
       </Container>
-      <RightSidebarToggleButton />
+      <Show when={rightbarCollapse}>
+        <RightSidebarToggleButton />
+      </Show>
     </BG>
   )
 }

--- a/apps/zui/src/js/components/draggable-pane.tsx
+++ b/apps/zui/src/js/components/draggable-pane.tsx
@@ -1,22 +1,25 @@
 import React, {ReactNode} from "react"
-import styled from "styled-components"
 import DragAnchor from "src/components/drag-anchor"
+import classNames from "classnames"
 
 type Props = {
   onDrag: (e: MouseEvent, args: {dx: number; dy: number}) => void
   dragAnchor: "right" | "left" | "top" | "bottom"
   children: ReactNode
-}
+  className?: string
+} & React.HTMLAttributes<any>
 
-const Pane = styled.div<any>`
-  position: relative;
-`
-
-export function DraggablePane({onDrag, dragAnchor, children, ...props}: Props) {
+export function DraggablePane({
+  onDrag,
+  dragAnchor,
+  children,
+  className,
+  ...props
+}: Props) {
   return (
-    <Pane {...props}>
+    <div className={classNames("relative", className)} {...props}>
       {children}
       <DragAnchor onDrag={onDrag} position={dragAnchor} />
-    </Pane>
+    </div>
   )
 }

--- a/apps/zui/src/js/state/Appearance/index.ts
+++ b/apps/zui/src/js/state/Appearance/index.ts
@@ -6,7 +6,7 @@ const init = () => ({
   sidebarIsOpen: true,
   sidebarWidth: 250,
   secondarySidebarIsOpen: true,
-  secondarySidebarWidth: 370,
+  secondarySidebarWidth: 400,
   currentSectionName: "pools" as SectionName,
   historyView: "linear" as HistoryView,
   poolsOpenState: {} as OpenMap,

--- a/apps/zui/src/js/state/Appearance/index.ts
+++ b/apps/zui/src/js/state/Appearance/index.ts
@@ -6,7 +6,7 @@ const init = () => ({
   sidebarIsOpen: true,
   sidebarWidth: 250,
   secondarySidebarIsOpen: true,
-  secondarySidebarWidth: 250,
+  secondarySidebarWidth: 370,
   currentSectionName: "pools" as SectionName,
   historyView: "linear" as HistoryView,
   poolsOpenState: {} as OpenMap,

--- a/apps/zui/src/js/state/Layout/types.ts
+++ b/apps/zui/src/js/state/Layout/types.ts
@@ -1,3 +1,8 @@
 export type ResultsView = "INSPECTOR" | "TABLE" | "CHART"
 export type ColumnHeadersViewState = "AUTO" | "ON" | "OFF"
-export type PaneName = "detail" | "versions" | "history" | "columns"
+export type PaneName =
+  | "detail"
+  | "versions"
+  | "history"
+  | "columns"
+  | "correlations"

--- a/apps/zui/src/ppl/detail/EventTimeline.tsx
+++ b/apps/zui/src/ppl/detail/EventTimeline.tsx
@@ -112,7 +112,7 @@ export default memo(function EventTimeline({events, current}: Props) {
     i === events.length - 1 && events.length > 1 ? lastItemRef : undefined
 
   return (
-    <div ref={resizeRef}>
+    <div ref={resizeRef} className="border-more">
       {events.map((e, i) => (
         <Lane key={i}>
           <Layer>

--- a/apps/zui/src/ppl/detail/RelatedAlerts.tsx
+++ b/apps/zui/src/ppl/detail/RelatedAlerts.tsx
@@ -43,7 +43,7 @@ export default memo(function RelatedAlerts({record}: Props) {
   }, [])
 
   return (
-    <section>
+    <section className="data-card box">
       <PanelHeading isLoading={isFetching}>Related Alerts</PanelHeading>
       <Panel>
         <div>

--- a/apps/zui/src/ppl/detail/RelatedAlerts.tsx
+++ b/apps/zui/src/ppl/detail/RelatedAlerts.tsx
@@ -1,7 +1,7 @@
 import {Data, Name, Value} from "src/components/data"
 import Panel from "src/views/detail-pane/Panel"
 import PanelHeading from "src/views/detail-pane/PanelHeading"
-import {Caption, ChartWrap, TableWrap} from "src/views/detail-pane/Shared"
+import {Caption, TableWrap} from "src/views/detail-pane/Shared"
 import {isEqual} from "lodash"
 import {SecurityEvent} from "src/ppl/detail/models/security-event"
 import React, {memo, useCallback, useMemo} from "react"
@@ -46,10 +46,10 @@ export default memo(function RelatedAlerts({record}: Props) {
     <section>
       <PanelHeading isLoading={isFetching}>Related Alerts</PanelHeading>
       <Panel>
-        <ChartWrap>
+        <div>
           <EventTimeline events={events} current={current}></EventTimeline>
           <EventLimit count={events.length} query={query} limit={perPage} />
-        </ChartWrap>
+        </div>
         <TableWrap>
           {data.map(([name, value]) => (
             <Data key={name}>

--- a/apps/zui/src/ppl/detail/RelatedAlerts.tsx
+++ b/apps/zui/src/ppl/detail/RelatedAlerts.tsx
@@ -43,7 +43,7 @@ export default memo(function RelatedAlerts({record}: Props) {
   }, [])
 
   return (
-    <section className="data-card box">
+    <section className="sidebar-card box">
       <PanelHeading isLoading={isFetching}>Related Alerts</PanelHeading>
       <Panel>
         <div>

--- a/apps/zui/src/ppl/detail/RelatedConns.tsx
+++ b/apps/zui/src/ppl/detail/RelatedConns.tsx
@@ -38,7 +38,7 @@ export default memo(function RelatedConns() {
   }, [])
 
   return (
-    <section>
+    <section className="data-card box">
       <PanelHeading isLoading={isFetching}>Related Connections</PanelHeading>
       <Panel>
         <div>

--- a/apps/zui/src/ppl/detail/RelatedConns.tsx
+++ b/apps/zui/src/ppl/detail/RelatedConns.tsx
@@ -1,7 +1,7 @@
 import {Data, Name, Value} from "src/components/data"
 import Panel from "src/views/detail-pane/Panel"
 import PanelHeading from "src/views/detail-pane/PanelHeading"
-import {Caption, ChartWrap, TableWrap} from "src/views/detail-pane/Shared"
+import {Caption, TableWrap} from "src/views/detail-pane/Shared"
 import {
   SecurityEvent,
   SecurityEventInterface,
@@ -41,10 +41,10 @@ export default memo(function RelatedConns() {
     <section>
       <PanelHeading isLoading={isFetching}>Related Connections</PanelHeading>
       <Panel>
-        <ChartWrap>
+        <div>
           <EventTimeline events={events} />
           <EventLimit query={query} count={events.length} limit={perPage} />
-        </ChartWrap>
+        </div>
         <TableWrap>
           {data.map(([name, value]) => (
             <Data key={name}>

--- a/apps/zui/src/ppl/detail/RelatedConns.tsx
+++ b/apps/zui/src/ppl/detail/RelatedConns.tsx
@@ -38,7 +38,7 @@ export default memo(function RelatedConns() {
   }, [])
 
   return (
-    <section className="data-card box">
+    <section className="sidebar-card box">
       <PanelHeading isLoading={isFetching}>Related Connections</PanelHeading>
       <Panel>
         <div>

--- a/apps/zui/src/ppl/detail/UidPanel.tsx
+++ b/apps/zui/src/ppl/detail/UidPanel.tsx
@@ -41,7 +41,7 @@ export default memo(function UidPanel({record}: {record: zed.Record}) {
   }, [])
 
   return (
-    <section>
+    <section className="data-card box">
       <PanelHeading isLoading={isLoading}>Correlation</PanelHeading>
       <Panel isLoading={isLoading && events.length === 0}>
         <div>

--- a/apps/zui/src/ppl/detail/UidPanel.tsx
+++ b/apps/zui/src/ppl/detail/UidPanel.tsx
@@ -1,7 +1,7 @@
 import {useSelector} from "react-redux"
 import React, {memo, useCallback, useMemo} from "react"
 
-import {Caption, ChartWrap, TableWrap} from "src/views/detail-pane/Shared"
+import {Caption, TableWrap} from "src/views/detail-pane/Shared"
 import PanelHeading from "src/views/detail-pane/PanelHeading"
 import EventTimeline from "src/ppl/detail/EventTimeline"
 import {SecurityEvent} from "src/ppl/detail/models/security-event"
@@ -44,10 +44,10 @@ export default memo(function UidPanel({record}: {record: zed.Record}) {
     <section>
       <PanelHeading isLoading={isLoading}>Correlation</PanelHeading>
       <Panel isLoading={isLoading && events.length === 0}>
-        <ChartWrap>
+        <div>
           <EventTimeline events={events} current={index} />
           <EventLimit query={query} count={events.length} limit={perPage} />
-        </ChartWrap>
+        </div>
         <TableWrap>
           <Data>
             <Name>Duration</Name>

--- a/apps/zui/src/ppl/detail/UidPanel.tsx
+++ b/apps/zui/src/ppl/detail/UidPanel.tsx
@@ -41,7 +41,7 @@ export default memo(function UidPanel({record}: {record: zed.Record}) {
   }, [])
 
   return (
-    <section className="data-card box">
+    <section className="sidebar-card box">
       <PanelHeading isLoading={isLoading}>Correlation</PanelHeading>
       <Panel isLoading={isLoading && events.length === 0}>
         <div>

--- a/apps/zui/src/views/columns-pane/columns-toolbar.tsx
+++ b/apps/zui/src/views/columns-pane/columns-toolbar.tsx
@@ -1,5 +1,4 @@
 import React from "react"
-import {Toolbar} from "src/components/toolbar"
 import {ButtonMenu} from "src/components/button-menu"
 import {columnsToolbarMenu} from "src/app/menus/columns-toolbar-menu"
 import Table from "src/js/state/Table"
@@ -14,11 +13,14 @@ export function ColumnsToolbar() {
 
   const items = columnsToolbarMenu()
   return (
-    <Toolbar>
+    <div
+      className="repel flex-nowrap overflow-hidden h-toolbar border-b-solid border-more"
+      style={{marginInline: "var(--gutter)"}}
+    >
       <ButtonMenu items={items} label={"Columns Toolbar Menu"} />
       <p style={{whiteSpace: "nowrap"}}>
         {columnCount} Columns / {hiddenCount} Hidden
       </p>
-    </Toolbar>
+    </div>
   )
 }

--- a/apps/zui/src/views/columns-pane/index.tsx
+++ b/apps/zui/src/views/columns-pane/index.tsx
@@ -1,22 +1,14 @@
 import {Scrollable} from "src/components/scrollable"
-import styled from "styled-components"
 import {ColumnsToolbar} from "./columns-toolbar"
 import {ColumnsTree} from "./columns-tree"
 
-const BG = styled.div`
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  overflow: hidden;
-`
-
 export function ColumnsPane() {
   return (
-    <BG>
+    <div className="stack h-full overflow-hidden">
       <ColumnsToolbar />
       <Scrollable>
         <ColumnsTree />
       </Scrollable>
-    </BG>
+    </div>
   )
 }

--- a/apps/zui/src/views/correlations-pane/index.tsx
+++ b/apps/zui/src/views/correlations-pane/index.tsx
@@ -1,0 +1,39 @@
+import {useMemo} from "react"
+import {useSelector} from "react-redux"
+import EmptyMessage from "src/js/components/EmptyMessage"
+import ConnPanel from "src/js/components/LogDetails/ConnPanel"
+import {Md5Panel} from "src/js/components/LogDetails/Md5Panel"
+import LogDetails from "src/js/state/LogDetails"
+import RelatedAlerts from "src/ppl/detail/RelatedAlerts"
+import RelatedConns from "src/ppl/detail/RelatedConns"
+import UidPanel from "src/ppl/detail/UidPanel"
+import {Correlation} from "src/ppl/detail/models/Correlation"
+import {SuricataEvent} from "src/ppl/detail/models/SuricataEvent"
+import {ZeekEvent} from "src/ppl/detail/models/ZeekEvent"
+import {SecurityEvent} from "src/ppl/detail/models/security-event"
+
+export function CorrelationsPane() {
+  const record = useSelector(LogDetails.build)
+  if (!record)
+    return (
+      <div>
+        <p>Select value in results to view correlations.</p>
+      </div>
+    )
+  // Move these files around
+  const event = useMemo(() => SecurityEvent.build(record), [record])
+  const isZeek = event instanceof ZeekEvent
+  const isSuricata = event instanceof SuricataEvent
+  const {uid, cid} = new Correlation(record).getIds()
+  const isConn = isZeek && record.try("_path")?.toString() === "conn"
+  const hasMd5 = isZeek && record.has("md5")
+  return (
+    <div className="box flow region region-space-l">
+      {isZeek && uid && <UidPanel record={record} />}
+      {isSuricata && cid && <RelatedAlerts record={record} />}
+      {isSuricata && cid && <RelatedConns />}
+      {isConn && <ConnPanel record={record} />}
+      {hasMd5 && <Md5Panel />}
+    </div>
+  )
+}

--- a/apps/zui/src/views/correlations-pane/index.tsx
+++ b/apps/zui/src/views/correlations-pane/index.tsx
@@ -31,7 +31,7 @@ function Correlations({record}) {
   const isConn = isZeek && record.try("_path")?.toString() === "conn"
   const hasMd5 = isZeek && record.has("md5")
   return (
-    <div className="box stack gap-xl region region-space-l">
+    <div className="box stack gap-xl region region-space-l scroll-y">
       {isZeek && uid && <UidPanel record={record} />}
       {isSuricata && cid && <RelatedAlerts record={record} />}
       {isSuricata && cid && <RelatedConns />}

--- a/apps/zui/src/views/correlations-pane/index.tsx
+++ b/apps/zui/src/views/correlations-pane/index.tsx
@@ -1,6 +1,5 @@
 import {useMemo} from "react"
 import {useSelector} from "react-redux"
-import EmptyMessage from "src/js/components/EmptyMessage"
 import ConnPanel from "src/js/components/LogDetails/ConnPanel"
 import {Md5Panel} from "src/js/components/LogDetails/Md5Panel"
 import LogDetails from "src/js/state/LogDetails"
@@ -11,16 +10,20 @@ import {Correlation} from "src/ppl/detail/models/Correlation"
 import {SuricataEvent} from "src/ppl/detail/models/SuricataEvent"
 import {ZeekEvent} from "src/ppl/detail/models/ZeekEvent"
 import {SecurityEvent} from "src/ppl/detail/models/security-event"
+import {EmptyText} from "../right-pane/common"
 
 export function CorrelationsPane() {
   const record = useSelector(LogDetails.build)
-  if (!record)
+  if (record) {
+    return <Correlations record={record} />
+  } else {
     return (
-      <div>
-        <p>Select value in results to view correlations.</p>
-      </div>
+      <EmptyText>Select a value in the results to run correlations.</EmptyText>
     )
-  // Move these files around
+  }
+}
+
+function Correlations({record}) {
   const event = useMemo(() => SecurityEvent.build(record), [record])
   const isZeek = event instanceof ZeekEvent
   const isSuricata = event instanceof SuricataEvent
@@ -28,7 +31,7 @@ export function CorrelationsPane() {
   const isConn = isZeek && record.try("_path")?.toString() === "conn"
   const hasMd5 = isZeek && record.has("md5")
   return (
-    <div className="box flow region region-space-l">
+    <div className="box stack gap-xl region region-space-l">
       {isZeek && uid && <UidPanel record={record} />}
       {isSuricata && cid && <RelatedAlerts record={record} />}
       {isSuricata && cid && <RelatedConns />}

--- a/apps/zui/src/views/detail-pane/Pane.tsx
+++ b/apps/zui/src/views/detail-pane/Pane.tsx
@@ -1,16 +1,9 @@
 import React, {useLayoutEffect, useRef} from "react"
 import {useSelector} from "react-redux"
 import LogDetails from "src/js/state/LogDetails"
-import styled from "styled-components"
 import Fields from "./Fields"
 import NoSelection from "./NoSelection"
 import * as zed from "@brimdata/zed-js"
-
-const Wrap = styled.div`
-  height: 100%;
-  overflow-x: hidden;
-  overflow-y: auto;
-`
 
 export default function Pane() {
   const record = useSelector(LogDetails.build)

--- a/apps/zui/src/views/detail-pane/Pane.tsx
+++ b/apps/zui/src/views/detail-pane/Pane.tsx
@@ -22,7 +22,7 @@ export default function Pane() {
   }, [record])
 
   return (
-    <Wrap ref={ref}>
+    <div ref={ref} className="gutter region">
       {record && record instanceof zed.Record ? (
         <div className="detail-pane-content">
           <Fields record={record} />
@@ -30,6 +30,6 @@ export default function Pane() {
       ) : (
         <NoSelection />
       )}
-    </Wrap>
+    </div>
   )
 }

--- a/apps/zui/src/views/detail-pane/Pane.tsx
+++ b/apps/zui/src/views/detail-pane/Pane.tsx
@@ -1,55 +1,10 @@
-import {SecurityEvent} from "src/ppl/detail/models/security-event"
-import {Correlation} from "src/ppl/detail/models/Correlation"
-import {SuricataEvent} from "src/ppl/detail/models/SuricataEvent"
-import {ZeekEvent} from "src/ppl/detail/models/ZeekEvent"
-import RelatedAlerts from "src/ppl/detail/RelatedAlerts"
-import RelatedConns from "src/ppl/detail/RelatedConns"
-import UidPanel from "src/ppl/detail/UidPanel"
-import React, {useLayoutEffect, memo, useMemo, useRef} from "react"
+import React, {useLayoutEffect, useRef} from "react"
 import {useSelector} from "react-redux"
-import ConnPanel from "src/js/components/LogDetails/ConnPanel"
-import {Md5Panel} from "src/js/components/LogDetails/Md5Panel"
 import LogDetails from "src/js/state/LogDetails"
 import styled from "styled-components"
 import Fields from "./Fields"
 import NoSelection from "./NoSelection"
 import * as zed from "@brimdata/zed-js"
-
-const BG = styled.div`
-  padding: 12px;
-
-  section {
-    margin-bottom: 24px;
-  }
-`
-
-type Props = {
-  record: zed.Record
-}
-
-const Content = memo<Props>(function Content({record}) {
-  const event = useMemo(() => SecurityEvent.build(record), [record])
-  const isZeek = event instanceof ZeekEvent
-  const isSuricata = event instanceof SuricataEvent
-  const {uid, cid} = new Correlation(record).getIds()
-  const isConn = isZeek && record.try("_path")?.toString() === "conn"
-  const hasMd5 = isZeek && record.has("md5")
-
-  return (
-    <BG className="detail-pane-content">
-      <div className="column">
-        <Fields record={record} />
-      </div>
-      <div className="column">
-        {isZeek && uid && <UidPanel record={record} />}
-        {isSuricata && cid && <RelatedAlerts record={record} />}
-        {isSuricata && cid && <RelatedConns />}
-        {isConn && <ConnPanel record={record} />}
-        {hasMd5 && <Md5Panel />}
-      </div>
-    </BG>
-  )
-})
 
 const Wrap = styled.div`
   height: 100%;
@@ -69,7 +24,9 @@ export default function Pane() {
   return (
     <Wrap ref={ref}>
       {record && record instanceof zed.Record ? (
-        <Content record={record} />
+        <div className="detail-pane-content">
+          <Fields record={record} />
+        </div>
       ) : (
         <NoSelection />
       )}

--- a/apps/zui/src/views/detail-pane/Panel.tsx
+++ b/apps/zui/src/views/detail-pane/Panel.tsx
@@ -1,30 +1,21 @@
 import React, {memo, ReactNode} from "react"
 import InlineTableLoading from "src/js/components/InlineTableLoading"
-import {ChartWrap} from "./Shared"
-import styled from "styled-components"
 
 type Props = {
   isLoading?: boolean
   children: ReactNode
 }
 
-const BG = styled.div`
-  background: var(--bg-color);
-  background: var(--emphasis-bg-less);
-  border-radius: 8px;
-  padding: 0.5rem 1rem;
-`
-
 export default memo<Props>(function Panel({isLoading, children}: Props) {
   return (
-    <BG>
+    <div>
       {isLoading ? (
-        <ChartWrap>
+        <div>
           <InlineTableLoading rows={3} />
-        </ChartWrap>
+        </div>
       ) : (
         children
       )}
-    </BG>
+    </div>
   )
 })

--- a/apps/zui/src/views/detail-pane/PanelHeading.tsx
+++ b/apps/zui/src/views/detail-pane/PanelHeading.tsx
@@ -17,7 +17,7 @@ type Props = {children: ReactNode; isLoading?: boolean}
 export default function PanelHeading({children, isLoading}: Props) {
   return (
     <BG className="flow">
-      <label>{children}</label>
+      <label role="heading">{children}</label>
       <LoadingBurst show={isLoading} />
     </BG>
   )

--- a/apps/zui/src/views/detail-pane/PanelHeading.tsx
+++ b/apps/zui/src/views/detail-pane/PanelHeading.tsx
@@ -4,15 +4,7 @@ import styled from "styled-components"
 
 const BG = styled.div`
   display: flex;
-  margin: 0 4px 12px 4px;
   user-select: none;
-
-  h4 {
-    margin: 0;
-    font-weight: bold;
-    font-size: 1rem;
-    padding-left: 0.5rem;
-  }
 
   .burst-1,
   .burst-2 {
@@ -24,8 +16,8 @@ type Props = {children: ReactNode; isLoading?: boolean}
 
 export default function PanelHeading({children, isLoading}: Props) {
   return (
-    <BG>
-      <h4>{children}</h4>
+    <BG className="flow">
+      <label>{children}</label>
       <LoadingBurst show={isLoading} />
     </BG>
   )

--- a/apps/zui/src/views/detail-pane/Shared.tsx
+++ b/apps/zui/src/views/detail-pane/Shared.tsx
@@ -1,9 +1,5 @@
 import styled from "styled-components"
 
-export const ChartWrap = styled.div`
-  padding: 12px;
-`
-
 export const TableWrap = styled.div`
   padding-bottom: 4px;
 `

--- a/apps/zui/src/views/details-window/index.tsx
+++ b/apps/zui/src/views/details-window/index.tsx
@@ -1,6 +1,0 @@
-import React from "react"
-import DetailPane from "src/views/detail-pane/Pane"
-
-export function DetailsWindow() {
-  return <DetailPane />
-}

--- a/apps/zui/src/views/details-window/index.tsx
+++ b/apps/zui/src/views/details-window/index.tsx
@@ -1,37 +1,6 @@
-import {useDispatch, useSelector} from "react-redux"
-import React, {HTMLProps} from "react"
-import LogDetails from "../../js/state/LogDetails"
+import React from "react"
 import DetailPane from "src/views/detail-pane/Pane"
-import classNames from "classnames"
-import {HistoryButtons} from "./history-buttons"
 
-type Pass = HTMLProps<any>
-
-const PaneHeader = (props: Pass) => (
-  <header {...props} className="pane-header" />
-)
-
-const Left = ({className, ...props}: Pass) => (
-  <div {...props} className={classNames("left", className)} />
-)
 export function DetailsWindow() {
-  const dispatch = useDispatch()
-  const prevExists = useSelector(LogDetails.getHistory).canGoBack()
-  const nextExists = useSelector(LogDetails.getHistory).canGoForward()
-
-  return (
-    <div className="log-detail-window">
-      <PaneHeader>
-        <Left>
-          <HistoryButtons
-            prevExists={prevExists}
-            nextExists={nextExists}
-            backFunc={() => dispatch(LogDetails.back())}
-            forwardFunc={() => dispatch(LogDetails.forward())}
-          />
-        </Left>
-      </PaneHeader>
-      <DetailPane />
-    </div>
-  )
+  return <DetailPane />
 }

--- a/apps/zui/src/views/right-pane/common.tsx
+++ b/apps/zui/src/views/right-pane/common.tsx
@@ -26,7 +26,7 @@ export const PaneHeader = styled.header`
 `
 
 export const EmptyText = styled.p`
-  padding: 24px;
+  padding: var(--gutter-space);
   opacity: 0.5;
   text-align: center;
   display: flex;

--- a/apps/zui/src/views/right-pane/header-handler.tsx
+++ b/apps/zui/src/views/right-pane/header-handler.tsx
@@ -1,0 +1,29 @@
+import {capitalize} from "lodash"
+import {ViewHandler} from "src/core/view-handler"
+import Layout from "src/js/state/Layout"
+import {PaneName} from "src/js/state/Layout/types"
+
+const SECTIONS: PaneName[] = ["history", "detail", "correlations", "columns"]
+
+export class HeaderHandler extends ViewHandler {
+  constructor(public name: PaneName) {
+    super()
+  }
+
+  get options() {
+    return SECTIONS.map((name) => this.createOption(name))
+  }
+
+  createOption(value: PaneName) {
+    return {
+      label: capitalize(value),
+      click: () => this.onChange(value),
+      checked: this.name === value,
+    }
+  }
+
+  onChange(name: PaneName) {
+    if (name === this.name) return
+    this.dispatch(Layout.setCurrentPaneName(name))
+  }
+}

--- a/apps/zui/src/views/right-pane/header.tsx
+++ b/apps/zui/src/views/right-pane/header.tsx
@@ -1,0 +1,21 @@
+import {SectionTabs} from "src/components/section-tabs"
+import {HeaderHandler} from "./header-handler"
+import {useSelector} from "react-redux"
+import Layout from "src/js/state/Layout"
+
+export function Header() {
+  const name = useSelector(Layout.getCurrentPaneName)
+  const handler = new HeaderHandler(name)
+
+  return (
+    <header className="h-toolbar flex">
+      <div
+        className="vertical-rule border-more"
+        style={{marginBlock: "var(--space-2xs)"}}
+      />
+      <div className="border-b-solid border-more w-full">
+        <SectionTabs options={handler.options} />
+      </div>
+    </header>
+  )
+}

--- a/apps/zui/src/views/right-pane/header.tsx
+++ b/apps/zui/src/views/right-pane/header.tsx
@@ -10,7 +10,7 @@ export function Header() {
 
   return (
     <header
-      className="flex border-more overflow-hidden"
+      className="flex flex-fixed border-more overflow-hidden"
       style={{
         blockSize: "calc(var(--toolbar-height) + 1px)",
       }}

--- a/apps/zui/src/views/right-pane/header.tsx
+++ b/apps/zui/src/views/right-pane/header.tsx
@@ -8,12 +8,15 @@ export function Header() {
   const handler = new HeaderHandler(name)
 
   return (
-    <header className="h-toolbar flex">
+    <header
+      className="flex gap-2xs"
+      style={{blockSize: "calc(var(--toolbar-height) + 1px)"}}
+    >
       <div
         className="vertical-rule border-more"
         style={{marginBlock: "var(--space-2xs)"}}
       />
-      <div className="border-b-solid border-more w-full">
+      <div className="w-full border-b-solid border-more" style={{}}>
         <SectionTabs options={handler.options} />
       </div>
     </header>

--- a/apps/zui/src/views/right-pane/header.tsx
+++ b/apps/zui/src/views/right-pane/header.tsx
@@ -2,6 +2,7 @@ import {SectionTabs} from "src/components/section-tabs"
 import {HeaderHandler} from "./header-handler"
 import {useSelector} from "react-redux"
 import Layout from "src/js/state/Layout"
+import {RightSidebarToggleButton} from "../sidebar/sidebar-toggle-button"
 
 export function Header() {
   const name = useSelector(Layout.getCurrentPaneName)
@@ -9,15 +10,19 @@ export function Header() {
 
   return (
     <header
-      className="flex gap-2xs"
+      className="flex gap-2xs border-more overflow-hidden"
       style={{blockSize: "calc(var(--toolbar-height) + 1px)"}}
     >
       <div
-        className="vertical-rule border-more"
+        className="vertical-rule"
         style={{marginBlock: "var(--space-2xs)"}}
       />
-      <div className="w-full border-b-solid border-more" style={{}}>
-        <SectionTabs options={handler.options} />
+      <div
+        className="flex items-center w-full border-b-solid overflow-hidden"
+        style={{marginInlineEnd: "var(--gutter-space)"}}
+      >
+        <RightSidebarToggleButton />
+        <SectionTabs options={handler.options} className="justify-end" />
       </div>
     </header>
   )

--- a/apps/zui/src/views/right-pane/header.tsx
+++ b/apps/zui/src/views/right-pane/header.tsx
@@ -10,8 +10,10 @@ export function Header() {
 
   return (
     <header
-      className="flex gap-2xs border-more overflow-hidden"
-      style={{blockSize: "calc(var(--toolbar-height) + 1px)"}}
+      className="flex border-more overflow-hidden"
+      style={{
+        blockSize: "calc(var(--toolbar-height) + 1px)",
+      }}
     >
       <div
         className="vertical-rule"
@@ -19,7 +21,7 @@ export function Header() {
       />
       <div
         className="flex items-center w-full border-b-solid overflow-hidden"
-        style={{marginInlineEnd: "var(--gutter-space)"}}
+        style={{marginInline: "var(--gutter)"}}
       >
         <RightSidebarToggleButton />
         <SectionTabs options={handler.options} className="justify-end" />

--- a/apps/zui/src/views/right-pane/index.tsx
+++ b/apps/zui/src/views/right-pane/index.tsx
@@ -41,7 +41,7 @@ export default function RightPane() {
     <DraggablePane
       onDrag={(e) => handler.onDrag(e)}
       dragAnchor="left"
-      className="stack"
+      className="stack border-more"
       style={{gridArea: "secondary-sidebar"}}
     >
       <Header />

--- a/apps/zui/src/views/right-pane/index.tsx
+++ b/apps/zui/src/views/right-pane/index.tsx
@@ -41,7 +41,7 @@ export default function RightPane() {
     <DraggablePane
       onDrag={(e) => handler.onDrag(e)}
       dragAnchor="left"
-      className="flex-stack"
+      className="stack"
       style={{gridArea: "secondary-sidebar"}}
     >
       <Header />

--- a/apps/zui/src/views/right-pane/index.tsx
+++ b/apps/zui/src/views/right-pane/index.tsx
@@ -13,7 +13,6 @@ import Current from "src/js/state/Current"
 import {CorrelationsPane} from "../correlations-pane"
 import {Header} from "./header"
 import {RightPaneHandler} from "./right-pane-handler"
-import {Show} from "src/components/show"
 
 function Contents() {
   switch (useSelector(Layout.getCurrentPaneName)) {

--- a/apps/zui/src/views/right-pane/index.tsx
+++ b/apps/zui/src/views/right-pane/index.tsx
@@ -1,28 +1,22 @@
 import React from "react"
 import DetailSection from "./detail-section"
 
-import styled from "styled-components"
-import {useDispatch} from "src/core/use-dispatch"
 import {useSelector} from "react-redux"
 import Layout from "src/js/state/Layout"
 import {DraggablePane} from "src/js/components/draggable-pane"
 import VersionsSection from "./versions-section"
 import AppErrorBoundary from "src/js/components/AppErrorBoundary"
 import {HistorySection} from "./history/section"
-import {SectionTabs} from "src/components/section-tabs"
-import {PaneName} from "src/js/state/Layout/types"
 import {ColumnsPane} from "src/views/columns-pane"
 import Appearance from "src/js/state/Appearance"
 import Current from "src/js/state/Current"
+import {CorrelationsPane} from "../correlations-pane"
+import {Header} from "./header"
+import {RightPaneHandler} from "./right-pane-handler"
+import {Show} from "src/components/show"
 
-const Pane = styled(DraggablePane)`
-  display: flex;
-  flex-direction: column;
-  grid-area: secondary-sidebar;
-`
-
-const PaneContentSwitch = ({paneName}) => {
-  switch (paneName) {
+function Contents() {
+  switch (useSelector(Layout.getCurrentPaneName)) {
     case "detail":
       return <DetailSection />
     case "versions":
@@ -31,84 +25,30 @@ const PaneContentSwitch = ({paneName}) => {
       return <HistorySection />
     case "columns":
       return <ColumnsPane />
+    case "correlations":
+      return <CorrelationsPane />
     default:
       return null
   }
 }
 
-const BG = styled.div`
-  height: 41px;
-  flex-shrink: 0;
-  padding: 0 8px;
-`
-
-export function Menu(props: {paneName: string}) {
-  const dispatch = useDispatch()
-
-  const onChange = (name: string) => {
-    if (name === props.paneName) return
-    dispatch(Layout.setCurrentPaneName(name as PaneName))
-  }
-
-  function makeOption(label: string, value: string) {
-    return {
-      label,
-      click: () => onChange(value),
-      checked: props.paneName === value,
-    }
-  }
-
-  return (
-    <BG>
-      <SectionTabs
-        options={[
-          makeOption("History", "history"),
-          makeOption("Detail", "detail"),
-          makeOption("Versions", "versions"),
-          makeOption("Columns", "columns"),
-        ]}
-      />
-    </BG>
-  )
-}
-
-function Container({children}) {
-  const dispatch = useDispatch()
+export default function RightPane() {
   const isOpen = useSelector(Appearance.secondarySidebarIsOpen)
-
-  const onDrag = (e: React.MouseEvent) => {
-    const width = window.innerWidth - e.clientX
-    const max = window.innerWidth
-    dispatch(Appearance.resizeSecondarySidebar(Math.min(width, max)))
-  }
-
-  if (!isOpen) return null
-
-  return (
-    // @ts-ignore
-    <Pane onDrag={onDrag} dragAnchor="left">
-      {children}
-    </Pane>
-  )
-}
-
-const RightPane = () => {
-  const currentPaneName = useSelector(Layout.getCurrentPaneName)
-
-  return (
-    <Container>
-      <Menu paneName={currentPaneName} />
-      <AppErrorBoundary>
-        <PaneContentSwitch paneName={currentPaneName} />
-      </AppErrorBoundary>
-    </Container>
-  )
-}
-
-const WithRightPane = () => {
   const tab = useSelector(Current.getTabId)
-  if (!tab) return null
-  return <RightPane />
-}
+  const handler = new RightPaneHandler()
+  if (!tab && isOpen) return null
 
-export default WithRightPane
+  return (
+    <DraggablePane
+      onDrag={(e) => handler.onDrag(e)}
+      dragAnchor="left"
+      className="flex-stack"
+      style={{gridArea: "secondary-sidebar"}}
+    >
+      <Header />
+      <AppErrorBoundary>
+        <Contents />
+      </AppErrorBoundary>
+    </DraggablePane>
+  )
+}

--- a/apps/zui/src/views/right-pane/right-pane-handler.ts
+++ b/apps/zui/src/views/right-pane/right-pane-handler.ts
@@ -1,0 +1,10 @@
+import {ViewHandler} from "src/core/view-handler"
+import Appearance from "src/js/state/Appearance"
+
+export class RightPaneHandler extends ViewHandler {
+  onDrag(e: React.MouseEvent) {
+    const width = window.innerWidth - e.clientX
+    const max = window.innerWidth
+    this.dispatch(Appearance.resizeSecondarySidebar(Math.min(width, max)))
+  }
+}

--- a/apps/zui/src/views/sidebar/index.tsx
+++ b/apps/zui/src/views/sidebar/index.tsx
@@ -58,7 +58,7 @@ export function Sidebar() {
   const currentSectionName = useSelector(Appearance.getCurrentSectionName)
   const l = useSelector(Current.getLake)
   const id = get(l, ["id"], "")
-  function onDragPane(e: MouseEvent) {
+  function onDragPane(e: any) {
     const width = e.clientX
     const max = window.innerWidth
     dispatch(Appearance.resizeSidebar(Math.min(width, max)))

--- a/apps/zui/src/views/sidebar/menu.tsx
+++ b/apps/zui/src/views/sidebar/menu.tsx
@@ -17,8 +17,13 @@ export function Menu() {
   })
   return (
     <div
-      className="h-toolbar border-b-solid border-more gutter"
-      style={{"--gutter-space": "var(--half-gutter)"} as any}
+      className="border-b-solid border-more gutter flex-shrink-0"
+      style={
+        {
+          "--gutter-space": "var(--half-gutter)",
+          flexBasis: "var(--toolbar-height)",
+        } as any
+      }
     >
       <SectionTabs
         options={[

--- a/apps/zui/src/views/sidebar/menu.tsx
+++ b/apps/zui/src/views/sidebar/menu.tsx
@@ -4,12 +4,6 @@ import {useSelector} from "react-redux"
 import Appearance from "src/js/state/Appearance"
 import {SectionName} from "src/js/state/Appearance/types"
 import {SectionTabs} from "src/components/section-tabs"
-import styled from "styled-components"
-
-const BG = styled.div`
-  height: 36px;
-  padding: 0 8px;
-`
 
 export function Menu() {
   const dispatch = useDispatch()
@@ -22,13 +16,16 @@ export function Menu() {
     },
   })
   return (
-    <BG>
+    <div
+      className="h-toolbar border-b-solid border-more gutter"
+      style={{"--gutter-space": "var(--half-gutter)"} as any}
+    >
       <SectionTabs
         options={[
           makeOption("Pools", "pools"),
           makeOption("Queries", "queries"),
         ]}
       />
-    </BG>
+    </div>
   )
 }


### PR DESCRIPTION
This PR is preparing the grounds for swapping out the fields detail view with and inspector.

A summary of changes:

1. A new correlation pane arrived on the detail view.
2. The look of the header in the detail pane is slightly different.
3. The look of the toolbar in the "columns" pane is slightly different.
4. The "TCP connection diagram" will now wrap if the detail pane gets too small, rather than overflow.
5. The button to collapse the right pane has been moved into the right pane when it is open, and back outside when it is closed.
6. The detail window now only shows the fields from the record.


https://github.com/brimdata/zui/assets/3460638/a73b8868-ba01-48f6-b919-dd6238689b22


