### PR TITLE
Ensure right panel contents are unloaded when closed

### DIFF
--- a/apps/zui/package.json
+++ b/apps/zui/package.json
@@ -158,7 +158,7 @@
     "utopia-core-scss": "^1.0.1",
     "web-file-polyfill": "^1.0.4",
     "web-streams-polyfill": "^3.2.0",
-    "zed": "brimdata/zed#6b4afe503362074fc1cf88d5e0d742845f268440",
+    "zed": "brimdata/zed#6e61673c6dd5272230fce02246c8c8f26051f396",
     "zui-test-data": "workspace:*"
   },
   "peerDependencies": {

--- a/apps/zui/src/views/right-pane/index.tsx
+++ b/apps/zui/src/views/right-pane/index.tsx
@@ -35,7 +35,7 @@ export default function RightPane() {
   const isOpen = useSelector(Appearance.secondarySidebarIsOpen)
   const tab = useSelector(Current.getTabId)
   const handler = new RightPaneHandler()
-  if (!tab && isOpen) return null
+  if (!tab || !isOpen) return null
 
   return (
     <DraggablePane

--- a/yarn.lock
+++ b/yarn.lock
@@ -18200,10 +18200,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zed@brimdata/zed#6b4afe503362074fc1cf88d5e0d742845f268440":
+"zed@brimdata/zed#6e61673c6dd5272230fce02246c8c8f26051f396":
   version: 0.33.0-dev
-  resolution: "zed@https://github.com/brimdata/zed.git#commit=6b4afe503362074fc1cf88d5e0d742845f268440"
-  checksum: 2f94bdb2661bd3523f1431d0d16d9c68f66ad25045a514d5d548055f10437765810bffe37966debf2d04bb15d777414067839f97a9f024163babfcd7cf650388
+  resolution: "zed@https://github.com/brimdata/zed.git#commit=6e61673c6dd5272230fce02246c8c8f26051f396"
+  checksum: 451bfc194b8dc4d0d90901106a22ff2942f9d9b3121fa819bbf5ff7a09c4f0fa0fac1465de4b42683acfd121655cb3ff5999c89b9bb0bbbc081d9e597d7e6a67
   languageName: node
   linkType: hard
 
@@ -18401,7 +18401,7 @@ __metadata:
     utopia-core-scss: ^1.0.1
     web-file-polyfill: ^1.0.4
     web-streams-polyfill: ^3.2.0
-    zed: "brimdata/zed#6b4afe503362074fc1cf88d5e0d742845f268440"
+    zed: "brimdata/zed#6e61673c6dd5272230fce02246c8c8f26051f396"
     zui-test-data: "workspace:*"
   peerDependencies:
     react: ^18.0.0


### PR DESCRIPTION
## What's changing

The change in this branch ensures that when the right panel is closed its contents are unloaded.

## Why

Fixes #3128

## Details

I traced the root cause of the failures described in #3128 to these two lines, which are in the `table show details` test.

https://github.com/brimdata/zui/blob/a32bb549ecba530a190bdd7f73ba3246337572dd/packages/zui-player/tests/right-click-menus.spec.ts#L87-L88

At that spot in the test, it's intending to right-click on the `conn` tile in the query results with intent to select the **Show In Detail Pane** option from the drop-down menu. However, the changes in #3127 caused a problem with this because, now that we have Inspector-style results in the right panel, that made a `conn` gridcell appear in the right panel that wasn't there previously (specifically, the one brought up in the prior test `inspector show details`) and hence the test might try to right-click it when the underlying `locate()` is performed to find the `conn` on which to right-click. Since the `conn` in the right panel _can't_ be right-clicked, when the test happens to find and try to use that one, the no-op right-click causes the timeout in the test since the `Show In Detail Pane` never appears.

I verified this theory by trying my own hack fix first, which was to have the _prior_ test (`inspector show details`) click a non-**Detail** tab in the right panel before closing the panel (I went with **Correlations**) since this had the effect of sweeping the `conn`-in-right-panel out of the way so it would not trip up the _next_ test (`table show details`). Indeed, this was effective such that looped repeats of the `right-click-menus.spec.ts` tests no longer saw the intermittent failures described in #3128.

However, after showing this all to @jameskerr, he saw the cleaner fix would be to make sure the right panel contents are properly unloaded via the change that's now in this branch. Indeed, a looping repeat showed this fix to be effective as well.

Since #3128 prevented some recent advancements in the Zed pointer, I've gone ahead and advanced Zed in this branch as well.