### PR TITLE
Use scrolltop and height to determine if we should load more

### DIFF
--- a/apps/zui/src/views/results-pane/inspector.tsx
+++ b/apps/zui/src/views/results-pane/inspector.tsx
@@ -26,7 +26,7 @@ export function Inspector(props: {height?: number}) {
 
   function onScroll({top, left}) {
     dispatch(Slice.setScrollPosition({top, left}))
-    if (list.current?.nearBottom(30)) loadMore()
+    if (list.current?.nearBottom(30, top)) loadMore()
   }
 
   useEffect(() => {

--- a/apps/zui/src/zui-kit/core/list-view/list-view-api.ts
+++ b/apps/zui/src/zui-kit/core/list-view/list-view-api.ts
@@ -5,6 +5,7 @@ import {RowData} from "../../../views/inspector/types"
 import {createView} from "../../../views/inspector/views/create"
 import {ListViewArgs} from "./types"
 import {call} from "src/util/call"
+import {config} from "src/components/zed-table/config"
 
 /**
  * This calculates the total number of
@@ -16,6 +17,8 @@ import {call} from "src/util/call"
  * filled in more and more as you travel (scroll) around.
  */
 export class ListViewApi {
+  width?: number
+  height?: number
   element?: HTMLDivElement
   count = 0
   rows = [] as (RowData | null)[]
@@ -41,6 +44,10 @@ export class ListViewApi {
     })
     this.rows = Array(this.count).fill(null)
     this.rendered = {startIndex: 0, stopIndex: 0}
+  }
+
+  get rowHeight() {
+    return this.args.rowHeight || config.rowHeight
   }
 
   fill() {
@@ -87,8 +94,9 @@ export class ListViewApi {
     return call(this.args?.onScroll, pos, this)
   }
 
-  nearBottom(n: number) {
-    return this.rendered.stopIndex >= this.count - n
+  nearBottom(n: number, scrollTop: number) {
+    const lastIndex = (scrollTop + this.height) / this.rowHeight
+    return lastIndex >= this.count - n
   }
 
   scrollTo(args: {top: number; left: number}) {

--- a/apps/zui/src/zui-kit/core/list-view/types.ts
+++ b/apps/zui/src/zui-kit/core/list-view/types.ts
@@ -21,4 +21,5 @@ export type ListViewArgs = {
   }
   onScroll?: (props: {top: number; left: number}, list: ListViewApi) => void
   state?: ControllerOpts<ListViewState>
+  rowHeight?: number
 } & ListViewControllers

--- a/apps/zui/src/zui-kit/react/list-view.tsx
+++ b/apps/zui/src/zui-kit/react/list-view.tsx
@@ -14,15 +14,9 @@ import {defaultListViewState} from "../core/list-view/state"
 import {ListViewArgs} from "../core/list-view/types"
 import {ReactAdapterProps} from "./types"
 import {useStateControllers} from "./use-state-controllers"
-import {mergeRefs, useInitialScrollPosition, useOnScroll} from "./utils"
+import {useInitialScrollPosition, useOnScroll} from "./utils"
 import classNames from "classnames"
 import {useParentSize} from "src/util/hooks/use-parent-size"
-import {
-  TopShadow,
-  useScrollShadow,
-} from "src/views/preview-load-modal/scroll-shadow"
-import {call} from "src/util/call"
-import {config} from "src/components/zed-table/config"
 
 const padding = 8
 
@@ -31,32 +25,6 @@ export const InnerElement = forwardRef<any, any>(function Inner(props, ref) {
   const height = `${parseFloat(style.height) + (padding ?? 0) * 2}px`
 
   return <div role="list" ref={ref} style={{...style, height}} {...rest} />
-})
-
-export const OuterElement = forwardRef<any, any>(function Outer(props, ref) {
-  const {children, ...rest} = props
-  const shadow = useScrollShadow(200)
-  return (
-    <div style={{height: "100%", width: "100%", position: "relative"}}>
-      <TopShadow
-        opacity={shadow.top}
-        style={{
-          height: "2px",
-          background: "linear-gradient(rgba(0,0,0,0.25), transparent)",
-        }}
-      />
-      <div
-        {...rest}
-        ref={mergeRefs(shadow.ref, ref)}
-        onScroll={(e) => {
-          call(rest.onScroll, e)
-          shadow.onScroll()
-        }}
-      >
-        {children}
-      </div>
-    </div>
-  )
 })
 
 export const Row: React.ComponentType<
@@ -104,7 +72,8 @@ export const ListView = forwardRef(function ListView(
   }, [list])
 
   const {width, height} = useParentSize(outerRef)
-
+  list.width = width
+  list.height = height
   return (
     <FixedSizeList
       className={classNames(props.className, "zed-list-view")}
@@ -113,11 +82,10 @@ export const ListView = forwardRef(function ListView(
       width={props.width ?? width}
       outerRef={outerRef}
       itemCount={list.count}
-      itemSize={config.rowHeight}
+      itemSize={list.rowHeight}
       itemData={[...list.rows]}
       itemKey={(i) => i.toString()}
       innerElementType={InnerElement}
-      // outerElementType={OuterElement}
       overscanCount={8}
       onItemsRendered={(args) => {
         setRendered({


### PR DESCRIPTION
Fixes #2742

The previous version of the code was relying on the rendered visible index, which didn't get updated fast enough. So now the code relies on the scrollTop and the height to determine if we are near the bottom of the scrollable area.