### PR TITLE
Change guidance that mentions fuse when there's multiple shapes

### DIFF
--- a/apps/zui/src/views/results-pane/table-inspector.tsx
+++ b/apps/zui/src/views/results-pane/table-inspector.tsx
@@ -32,11 +32,11 @@ export function TableInspector() {
       {shapes.length > 1 && (
         <div style={{height: config.headerHeight}}>
           <Warning>
-            <b>{shapes.length} Shapes</b> — Filter to one shape or{" "}
+            <b>{shapes.length} Shapes</b> — Filter or{" "}
             <b>
               <a onClick={() => fuse()}>fuse</a>
             </b>{" "}
-            results to view as a table.
+            to view results as one shape.
           </Warning>
         </div>
       )}


### PR DESCRIPTION
## tl;dr

When results contain multiple shapes, I'm proposing changing the wording of the guidance in the default Table view to:

> N Shapes — Filter or `fuse` to view results as one shape.

## Details

This is one that hit me when I was testing the changes in #3145.

Right now when the results contain multiple shapes, the default Table view shows the guidance:

> N Shapes — Filter to one shape or `fuse` results to view as a table.

This guidance is accurate if the data happens to be records, which it often is. However (and maybe this is spitting hairs), if the data contains one or more primitive values, such as this ZSON test data:

```
1
"hello"
3.14
```

the guidance becomes inaccurate because even if the user _does_ apply `fuse`, the data shown is still not in a "table" in the traditional sense because there's no header containing a field name. Rather, the data is instead still just a sequence of values, though now `fuse` has applied a union type to all of them such that the user is, indeed, now looking at a single shape.

Therefore, in this PR I've proposed adjusting the guidance to instead say:

> N Shapes — Filter or fuse to view results as one shape.

since this seems to cover all cases in a technically accurate way.

(Thanks to @nwt for the proposed wording!)

![image](https://github.com/user-attachments/assets/4888b73f-e390-44a3-930a-0b860b21dcbc)

(Really, I think the most important part of this guidance has always been giving the user the one-click access to `fuse`, since this is probably what users are looking for much of the time, but new users in particular are unlikely to immediately read through the Zed docs and find it right off the bat. All that is still fully intact with this change, so hopefully it's non-controversial.)