### PR TITLE
Increase expected VNG file size due to zed#5320 change

### DIFF
--- a/apps/zui/package.json
+++ b/apps/zui/package.json
@@ -159,7 +159,7 @@
     "web-file-polyfill": "^1.0.4",
     "web-streams-polyfill": "^3.2.0",
     "when-clause": "^0.0.4",
-    "zed": "brimdata/zed#65b575c5ff9a95c7c2bf7dd9ceb935b1a51d7676",
+    "zed": "brimdata/zed#c0775aa34de31edf29c8955ee03f85c1b9c30bba",
     "zui-test-data": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/zui-player/tests/export.spec.ts
+++ b/packages/zui-player/tests/export.spec.ts
@@ -12,7 +12,7 @@ const formats = [
   { label: 'JSON', expectedSize: 13659 },
   { label: 'NDJSON', expectedSize: 13657 },
   { label: 'TSV', expectedSize: 10797 },
-  { label: 'VNG', expectedSize: 7983 },
+  { label: 'VNG', expectedSize: 7984 },
   { label: 'Zeek', expectedSize: 10138 },
   { label: 'ZJSON', expectedSize: 18007 },
   { label: 'ZNG', expectedSize: 3745 },

--- a/yarn.lock
+++ b/yarn.lock
@@ -18551,10 +18551,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zed@brimdata/zed#65b575c5ff9a95c7c2bf7dd9ceb935b1a51d7676":
+"zed@brimdata/zed#c0775aa34de31edf29c8955ee03f85c1b9c30bba":
   version: 0.33.0-dev
-  resolution: "zed@https://github.com/brimdata/zed.git#commit=65b575c5ff9a95c7c2bf7dd9ceb935b1a51d7676"
-  checksum: 08d01f11a6204ce1eb2f1575aae1319033be7e11df9080063082fe75138ba9ba62d832e77cc81acb982d7b74b424c505c41ef614857461be758b1117a29f5b13
+  resolution: "zed@https://github.com/brimdata/zed.git#commit=c0775aa34de31edf29c8955ee03f85c1b9c30bba"
+  checksum: fbd36dc625de0c04ff29347c82973f3c18221950962f5d1dc297b15117016b1f87dcc8da13582f870e0f073d61cc5ebdf35ac33109a2769b16f9f11a8e9e4a34
   languageName: node
   linkType: hard
 
@@ -18753,7 +18753,7 @@ __metadata:
     web-file-polyfill: ^1.0.4
     web-streams-polyfill: ^3.2.0
     when-clause: ^0.0.4
-    zed: "brimdata/zed#65b575c5ff9a95c7c2bf7dd9ceb935b1a51d7676"
+    zed: "brimdata/zed#c0775aa34de31edf29c8955ee03f85c1b9c30bba"
     zui-test-data: "workspace:*"
   peerDependencies:
     react: ^18.0.0


### PR DESCRIPTION
The Zui CI started failing when https://github.com/brimdata/zed/pull/5320 merged because the exported VNG file size had increased by a byte. From the Zed PR it looks like this is all quite expected so this adjusts the test to run successfully again.