### PR TITLE
Have Actions Workflows use macos-13 rather than macos-12

### DIFF
--- a/.github/workflows/build-insiders.yml
+++ b/.github/workflows/build-insiders.yml
@@ -29,8 +29,8 @@ jobs:
     needs: check_latest
     strategy:
       matrix:
-        # macos-12 is is Intel-based (x64), macos-14 is Apple Silicon (arm64)
-        platform: [windows-2019, macos-12, macos-14, ubuntu-20.04]
+        # macos-13 is is Intel-based (x64), macos-14 is Apple Silicon (arm64)
+        platform: [windows-2019, macos-13, macos-14, ubuntu-20.04]
 
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,8 @@ jobs:
   release:
     strategy:
       matrix:
-        # macos-12 is is Intel-based (x64), macos-14 is Apple Silicon (arm64)
-        platform: [macos-12, macos-14, ubuntu-20.04, windows-2019]
+        # macos-13 is is Intel-based (x64), macos-14 is Apple Silicon (arm64)
+        platform: [macos-13, macos-14, ubuntu-20.04, windows-2019]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout Zui

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # macos-12 is is Intel-based (x64), macos-14 is Apple Silicon (arm64)
-        os: [macos-12, macos-14, ubuntu-20.04, windows-2019]
+        # macos-13 is is Intel-based (x64), macos-14 is Apple Silicon (arm64)
+        os: [macos-13, macos-14, ubuntu-20.04, windows-2019]
     steps:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@v4

--- a/.github/workflows/release-insiders.yml
+++ b/.github/workflows/release-insiders.yml
@@ -31,8 +31,8 @@ jobs:
     if: ${{ needs.check_latest.outputs.latest_sha != github.sha }}
     strategy:
       matrix:
-        # macos-12 is is Intel-based (x64), macos-14 is Apple Silicon (arm64)
-        platform: [windows-2019, macos-12, macos-14, ubuntu-20.04]
+        # macos-13 is is Intel-based (x64), macos-14 is Apple Silicon (arm64)
+        platform: [windows-2019, macos-13, macos-14, ubuntu-20.04]
 
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,8 @@ jobs:
   release:
     strategy:
       matrix:
-        # macos-12 is is Intel-based (x64), macos-14 is Apple Silicon (arm64)
-        platform: [macos-12, macos-14, ubuntu-20.04, windows-2019]
+        # macos-13 is is Intel-based (x64), macos-14 is Apple Silicon (arm64)
+        platform: [macos-13, macos-14, ubuntu-20.04, windows-2019]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout Zui

--- a/apps/zui/docs/support/Supported-Platforms.md
+++ b/apps/zui/docs/support/Supported-Platforms.md
@@ -12,7 +12,7 @@ recommendations on which to run Zui:
   - Windows 10 or newer
   - Windows Server 2019 or newer
 - macOS
-  - macOS Monterey 12.6.5 or newer (see [below](#hardware) for hardware considerations)
+  - macOS Ventura 13.7 or newer
 - Linux
   - Ubuntu 20.04 or newer
   - Debian 11.0.0 or newer
@@ -43,25 +43,16 @@ we do _not_ recommend attempting to run Zui on Windows 8.1 or older.
 
 #### Software
 
-Zui's [test automation](#automated-testing) runs on Monterey 12 and
+Zui's [test automation](#automated-testing) runs on Ventura 13.7 and
 therefore this is the macOS version on which we are best able to ensure quality
-and prevent regressions. Several Zui developers also run macOS Sonoma 14.1
+and prevent regressions. Several Zui developers also run macOS Sonoma 14.7
 and regularly perform ad hoc testing with it to reproduce reported issues.
 
 #### Hardware
 
-The build procedure for Zui's macOS releases creates binaries intended to
-run on Intel-based Mac hardware. Zui releases are not yet available that
-are built specifically for [M1-based hardware](https://en.wikipedia.org/wiki/Apple_M1).
-However, Apple's [Rosetta 2](https://support.apple.com/en-us/HT211861) makes
-it possible to run Intel-targeted binaries on M1-based Macs.
-
-M1-based hardware has only recently become
-[available](https://github.com/actions/virtual-environments/issues/2187) for
-our automation where we run tests and create builds for Zui. Therefore our
-planned work to deliver M1-specific builds ([zui/1266](https://github.com/brimdata/zui/issues/1266))
-is still ongoing. In the meantime, please [open an issue](./Troubleshooting.md#opening-an-issue)
-if you experience a problem specific to M1-based Macs.
+The build procedure for Zui's macOS releases creates separate binaries
+intended to run on Intel-based or [M1-based](https://en.wikipedia.org/wiki/Apple_M1)
+Mac hardware.
 
 ### Linux
 


### PR DESCRIPTION
## What's Changing

Our GitHub Actions Workflows that previously used the Intel-based `macos-12` runners will now use the Intel-based `macos-13` runners.

## Why

GitHub notified:

> GitHub Actions: The macOS 12 runner image will be removed by 12/3/2024

## Details

The full text of the notification email:

![image](https://github.com/user-attachments/assets/b37271bc-5fea-4ccd-bd39-560b64d060ac)

I've tended toward always using the oldest available runners for each target platform since we expect at least _some_ users are running older OS versions (conservative corporate environments, etc.) and this gives us a better chance of knowing if something unexpected has caused us to lose the ability to run on the older OSes such that we'd need to update our [Supported Platforms](https://zui.brimdata.io/docs/support/Supported-Platforms) statement. Since GitHub has given us this early notice, I figure we might as well make the jump to the newer OS ASAP.

Another consideration is that we surely still have some users out there stuck on older Intel-based Macs (I'm one of them 😛) so we'd like to continue offering builds for these as long as possible. Thankfully the Actions Runners for `macos-13` are still Intel based:

```
Mac-1729112151240:~ runner$ uname -a
Darwin Mac-1729112151240.local 22.6.0 Darwin Kernel Version 22.6.0: Wed Jul 31 21:42:48 PDT 2024; root:xnu-8796.141.3.707.4~1/RELEASE_X86_64 x86_64

Mac-1729112151240:~ runner$ sw_vers
ProductName:		macOS
ProductVersion:		13.7
BuildVersion:		22H123

```

While `macos-14` and newer are M1.

```
Mac-1729112489822:~ runner$ uname -a
Darwin Mac-1729112489822.local 23.6.0 Darwin Kernel Version 23.6.0: Wed Jul 31 20:50:13 PDT 2024; root:xnu-10063.141.1.700.5~1/RELEASE_ARM64_VMAPPLE arm64

Mac-1729112489822:~ runner$ sw_vers
ProductName:		macOS
ProductVersion:		14.7
BuildVersion:		23H124
```

So having the ability to jump to `macos-13` buys us some time before we need to make a decision on if we figure out some cross-compiled approach to making Intel builds or just start supporting only M1.

Finally, taking care of this made me realize that when I added the ability to build on M1 several months ago, I forgot to update the [Supported Platforms](https://zui.brimdata.io/docs/support/Supported-Platforms) statement, so I've done that here.