### PR TITLE
Always point to last GA Zed docs for now

### DIFF
--- a/apps/zui/src/config/links.ts
+++ b/apps/zui/src/config/links.ts
@@ -3,7 +3,7 @@ import pkg from "../../package.json"
 const currentZedTag = pkg.devDependencies.zed.split("#")[1] || "main"
 const zedDocsTag = currentZedTag.startsWith("v")
   ? currentZedTag.replace(/\.\d+$/, ".0")
-  : "next"
+  : "v1.18.0" // Change back to "next" when we make the zed->super transition
 
 export default {
   ZED_DOCS_ROOT: `https://zed.brimdata.io/docs/${zedDocsTag}/commands/zed`,


### PR DESCRIPTION
The zed->super transition is well underway on the super side of things, so the super docs tagged "Next" are starting to have some totally new paths. Zui is holding still in the interim. Because of link checks, this has started to cause failures in Zui's CI like [this one](https://github.com/brimdata/zui/actions/runs/11619491225). To avoid this while still being able to put out Zui Insiders releases with bug fixes, here I'm proposing that we just point Zui's docs links at the last GA release for now. When there's a mass zed->super transition when Zui turns into Super Desktop, we can put this back.
