### PR TITLE
Explicit Slice Names Required

### DIFF
--- a/apps/zui/src/models/snapshot.ts
+++ b/apps/zui/src/models/snapshot.ts
@@ -26,6 +26,7 @@ export class Snapshot extends ApplicationEntity<SnapshotAttrs> {
   /* Configuration */
   static schema = schema
   static actionPrefix = "$snapshots"
+  static sliceName = "snapshots"
 
   /* Attributes */
   value: string


### PR DESCRIPTION
Fixes #3161 

The bug was caused by the nextjs build step obfuscating all the names of the symbols in the code. Some code introspects itself to get the name of its class, then lowercases and pluralizes it to become the key in the state object.

The snapshots slice in dev mode looks like this.
```
{
  snapshots: {...}
}
```
That key is derived from the class called `Snapshot`.

But when we build for production, that class becomes the single letter `p`.

So on zui insiders, the state object looks like.

```
{
  ps: {...}
}
```

There is other code that relies on there being a "snapshots" key in the state and that is where the error occurs.

This fix introduces a static, explicit name for the key, instead of the derived one. Looks like we will need to do this each time we introduce a new slice of state in this way.