### PR TITLE
In Actions workflows, move from ubuntu-20.04 to ubuntu-22.04

### DIFF
--- a/.github/workflows/advance-zed.yml
+++ b/.github/workflows/advance-zed.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-insiders.yml
+++ b/.github/workflows/build-insiders.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   check_latest:
     name: Get last released version
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Get last released version
         id: latest_release
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         # macos-13 is is Intel-based (x64), macos-14 is Apple Silicon (arm64)
-        platform: [windows-2019, macos-13, macos-14, ubuntu-20.04]
+        platform: [windows-2019, macos-13, macos-14, ubuntu-22.04]
 
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         # macos-13 is is Intel-based (x64), macos-14 is Apple Silicon (arm64)
-        platform: [macos-13, macos-14, ubuntu-20.04, windows-2019]
+        platform: [macos-13, macos-14, ubuntu-22.04, windows-2019]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout Zui

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         # macos-13 is is Intel-based (x64), macos-14 is Apple Silicon (arm64)
-        os: [macos-13, macos-14, ubuntu-20.04, windows-2019]
+        os: [macos-13, macos-14, ubuntu-22.04, windows-2019]
     steps:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,7 +9,7 @@ on:
         required: true
       platforms:
         description: OS platforms to test on (list of strings in JSON format)"
-        default: '["ubuntu-20.04"]'
+        default: '["ubuntu-22.04"]'
         required: true
       video:
         description: Whether to record videos of Playwright test runs

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   markdown-link-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: Extract branch name

--- a/.github/workflows/notify-docs-update.yaml
+++ b/.github/workflows/notify-docs-update.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Send dispatch event
         run: |

--- a/.github/workflows/notify-main-failure.yml
+++ b/.github/workflows/notify-main-failure.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   slackNotify:
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Notify Brim HQ of failure on main
         uses: tiloio/slack-webhook-action@v1.1.2

--- a/.github/workflows/release-insiders.yml
+++ b/.github/workflows/release-insiders.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   check_latest:
     name: Check If Release Is Needed
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Get last released version
         id: latest_release
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         # macos-13 is is Intel-based (x64), macos-14 is Apple Silicon (arm64)
-        platform: [windows-2019, macos-13, macos-14, ubuntu-20.04]
+        platform: [windows-2019, macos-13, macos-14, ubuntu-22.04]
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -90,7 +90,7 @@ jobs:
   record_build_sha:
     needs: release
     name: Upload the Build Sha
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Create the build_sha file
         run: echo ${{ github.sha }} > build_sha.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         # macos-13 is is Intel-based (x64), macos-14 is Apple Silicon (arm64)
-        platform: [macos-13, macos-14, ubuntu-20.04, windows-2019]
+        platform: [macos-13, macos-14, ubuntu-22.04, windows-2019]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout Zui


### PR DESCRIPTION
## What's Changing

In our Actions workflows, this moves us from using `ubuntu-20.04` to `ubuntu-22.04`.

## Why

Per https://github.com/actions/runner-images/issues/11101, `ubuntu-20.04` is set to be deprecated soon. This includes planned "brownouts" in March in which they'll intentionally cause failure of some jobs still using `ubuntu-20.04` to alert users of the change. The changes in this PR get ahead of that.

## Details

I've always been a fan of pointing at specific/old runner versions (as opposed to `-latest`) so that way we can have more confidence in a support statement that says we can run on platforms older than the very latest. However, this requires moving the pointers periodically. Thankfully they give us plenty of advance warning.