### PR TITLE
Fix Deeply Nested Data Crash

### DIFF
--- a/apps/zui/src/zui-kit/core/list-view/list-view-api.ts
+++ b/apps/zui/src/zui-kit/core/list-view/list-view-api.ts
@@ -61,7 +61,11 @@ export class ListViewApi {
       const value = this.args.values[index]
       if (this.rows[rowIndex]) continue
       const newRows = this.inspect(value, index)
-      this.rows.splice(rowIndex, newRows.length, ...newRows)
+      this.rows = [
+        ...this.rows.slice(0, rowIndex),
+        ...newRows,
+        ...this.rows.slice(rowIndex + newRows.length)
+      ]
     }
   }
 


### PR DESCRIPTION
It's still slow on the deeply nested data, but it does not crash anymore!

Array.slice was not working for us. Changing to an array copy algorithm allowed the operation to succeed.