### PR TITLE
Change "advance-zed" workflow to "advance-super"

### DIFF
--- a/.github/workflows/advance-super.yml
+++ b/.github/workflows/advance-super.yml
@@ -1,26 +1,26 @@
-name: Advance Zed
+name: Advance Super
 
 concurrency: ${{ github.workflow }}
 
-# This type must match the event type from Zed.
+# This type must match the event type received from the super repo.
 # https://help.github.com/en/actions/reference/events-that-trigger-workflows#external-events-repository_dispatch
 # These events only trigger on the GitHub default branch (usually main
 # or master).
 on:
   repository_dispatch:
-    types: [zed-pr-merged]
+    types: [super-pr-merged]
   workflow_dispatch:
     inputs:
-      zed_ref:
+      super_ref:
         required: true
         type: string
 
 env:
-  zed_ref: ${{ github.event.client_payload.merge_commit_sha || inputs.zed_ref }}
+  super_ref: ${{ github.event.client_payload.merge_commit_sha || inputs.super_ref }}
 
 jobs:
-  advance-zed:
-    name: Advance Zed
+  advance-super:
+    name: Advance Super
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -34,22 +34,19 @@ jobs:
           # that caused it to wait, reducing push failures down below.
           ref: ${{ github.ref }}
           # We need a token with permission to push.
-          token: ${{ secrets.ZQ_UPDATE_PAT }}
+          token: ${{ secrets.PAT_TOKEN }}
       - uses: ./.github/actions/setup-app
       - run: sudo apt-get -y install whois
-      - run: yarn workspace zui add zed@brimdata/zed#${{ env.zed_ref }}
+      - run: yarn workspace zui add super@brimdata/super#${{ env.super_ref }}
       - run: yarn lint
       - run: yarn test
       - run: yarn build
       - name: End to end tests
         id: playwright
         run: |
-          # Mock for pcap slice opening to avoid hanging Actions Runner.
-          # See https://github.com/brimdata/zui/pull/2987
-          echo "application/vnd.tcpdump.pcap; /usr/bin/true" >> /home/runner/.mailcap
           /usr/bin/xvfb-run --auto-servernum -s "-screen 0 1280x1024x24" yarn e2e:ci
 
-      - run: git -c user.name='Brim Automation' -c user.email=automation@brimdata.io commit -a -m 'upgrade Zed to ${{ env.zed_ref }}'
+      - run: git -c user.name='Brim Automation' -c user.email=automation@brimdata.io commit -a -m 'upgrade super to ${{ env.super_ref }}'
 
       # If this push fails because a PR was merged while this job was
       # running, you can re-run the failed job via


### PR DESCRIPTION
Back in October, 2024 via https://github.com/brimdata/super/pull/5347 I disabled the auto-update of the Zed dependency in the Zui repo because changes in super were starting to happen that would break the app. We were focused on other things at the time so we didn't prioritize getting them back in sync and keeping them that way. Now that @jameskerr has recently done the work to start turning Zui into SuperDB Desktop and we've got the app working again with a recent super commit, it seems like it's time to get this auto-update workflow running again so the app will always have the benefit of the latest super changes and we'll know immediately when something breaks it.

While we're at it, here I've done some de-Zed-ing of the workflow in question. Once this is merged and it's prepared to receive the updates from the super side, I'll put up a PR in the super repo to make sure the merge commit notifications are sent with the correct event name and such that it'll match what's done here.