### PR TITLE
Convert to ESM

### DIFF
--- a/.github/workflows/advance-super.yml
+++ b/.github/workflows/advance-super.yml
@@ -37,7 +37,7 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
       - uses: ./.github/actions/setup-app
       - run: sudo apt-get -y install whois
-      - run: yarn workspace zui add super@brimdata/super#${{ env.super_ref }}
+      - run: yarn workspace superdb-desktop add super@brimdata/super#${{ env.super_ref }}
       - run: yarn lint
       - run: yarn test
       - run: yarn build

--- a/packages/zui-player/ci.config.js
+++ b/packages/zui-player/ci.config.js
@@ -1,6 +1,6 @@
-const baseConfig = require('./playwright.config');
+import baseConfig from './playwright.config';
 
-module.exports = {
+export default {
   ...baseConfig,
   /* This is the list of flaky tests to ignore when running on CI */
   testIgnore: /(pool-load-fail|pool-groups).spec/,


### PR DESCRIPTION
I've made the zui-player repo a "ESModule" instead of a "commonjs" module. So we need to use this module syntax when importing files.