### PR TITLE
Adjust packets test and fix standalone e2e Actions Workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,9 +56,6 @@ jobs:
         id: playwright
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
-            # Mock for pcap slice opening to avoid hanging Actions Runner.
-            # See https://github.com/brimdata/zui/pull/2987
-            echo "application/vnd.tcpdump.pcap; /usr/bin/true" >> /home/runner/.mailcap
             /usr/bin/xvfb-run --auto-servernum -s "-screen 0 1280x1024x24" ${{ inputs.run-target }}
           else
             ${{ inputs.run-target }}
@@ -69,13 +66,13 @@ jobs:
         shell: sh
       - name: Put system logs alongside other artifacts
         run: |
-          mkdir -p packages/player/run/var_log
-          cp /var/log/sys*log* /var/log/kern.log* packages/player/run/var_log || true
+          mkdir -p packages/app-player/run/var_log
+          cp /var/log/sys*log* /var/log/kern.log* packages/app-player/run/var_log || true
         shell: sh
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: (failure() && steps.playwright.outcome == 'failure') || inputs.always-upload
         with:
           name: artifacts-${{ matrix.os }}
           path: |
-            packages/player/run/**
-            packages/player/test-results
+            packages/app-player/run/**
+            packages/app-player/test-results

--- a/packages/app-player/tests/packets.spec.ts
+++ b/packages/app-player/tests/packets.spec.ts
@@ -1,11 +1,9 @@
 import { play } from 'app-player';
 import { getPath } from '@brimdata/sample-data';
 
-// Timeouts are increased due to observed long pcap load times in CI.
-// See https://github.com/brimdata/zui/pull/2978
 play('packets.spec', (app, test) => {
   test('dropping a pcap throw an error now', async () => {
     await app.dropFile(getPath('sample.pcap'));
-    await app.attached(/Error Reading Data/);
+    await app.attached(/wrong number of fields/);
   });
 });


### PR DESCRIPTION
Since reviving the backend dependency updating via the changes in #3180, the e2e test portion of the Actions Workflow now known as `advance-super.yml` has been consistently failing in CI though it runs ok locally. The specific failure such as observed in [this recent job](https://github.com/brimdata/zui/actions/runs/13796048677/job/38587841092) reflects a timeout in the `packets.spec.ts` test.

I tried using the separate Actions Workflow `e2e.yml` that runs the same test to study the problem and found it needed some updates to run at all, so I've made those necessary changes here. Once I got it to run, I used Playwright's video capture to get a closer look at it failing. [This job](https://github.com/brimdata/zui/actions/runs/13795660794) resulted in the following screenshot that shows the failure message appearing in the **Preview** panel with the headline **Shaper Error**.

![image](https://github.com/user-attachments/assets/ff7bef45-b7e5-4d40-bebc-0d701e905564)

By comparison, when I watch the same test pass locally or run the same steps locally by hand, the error is presented like this with the headline **Error Reading Data**:

![image](https://github.com/user-attachments/assets/d12557f9-c5ac-4bde-a4de-57dac81bc7e8)

Since the test was waiting on the **Error Reading Data** message, that explains why it was passing locally. I asked @kerr if he had a guess why it showed up differently in CI, and it sounds like it may come down to timing. In his own words:

>I think I run the original query and the shaper query at the same time. It's probably the shaper finishing first in the CI case?

This test was recently morphed into this much simpler "confirm pcap doesn't work" test since we recently dropped pcap support in the app, so it's probably not worth obsessively fiddling with the app code or the test to make this more deterministic. Instead I'm just morphing the test here to instead look for the "wrong number of fields" message since that appears in both contexts. I've confirmed this now runs successfully in [this job](https://github.com/brimdata/zui/actions/runs/13798460167), so once this merges the "advance super" Workflow should similarly work.