### PR TITLE
Advance Node client's super dependency automatically (regular dep)

### DIFF
--- a/.github/workflows/advance-super.yml
+++ b/.github/workflows/advance-super.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: ./.github/actions/setup-app
       - run: sudo apt-get -y install whois
       - run: yarn workspace superdb-desktop add super@brimdata/super#${{ env.super_ref }}
+      - run: yarn workspace superdb-node-client add super@brimdata/super#${{ env.super_ref }}
       - run: yarn lint
       - run: yarn test
       - run: yarn build

--- a/packages/superdb-node-client/package.json
+++ b/packages/superdb-node-client/package.json
@@ -11,16 +11,13 @@
   },
   "dependencies": {
     "fs-extra": "^11.3.0",
+    "super": "brimdata/super#cc30b87cc286ce7fbb783bb463d519a0ae86ea02",
     "superdb-types": "workspace:*"
   },
   "devDependencies": {
     "jest": "^29.7.0",
     "node-fetch": "^2.6.1",
     "rimraf": "^6.0.1",
-    "super": "github:brimdata/super#28294a64f823856cf28809d477d75faecde36742",
     "typescript": "5.1.5"
-  },
-  "peerDependencies": {
-    "super": "*"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11916,13 +11916,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"super@github:brimdata/super#28294a64f823856cf28809d477d75faecde36742":
-  version: 0.0.1-dev
-  resolution: "super@https://github.com/brimdata/super.git#commit=28294a64f823856cf28809d477d75faecde36742"
-  checksum: 332c18fa9a858a756f3abe7fdda12a442ba5f21216241a25ceee4e1f3b1be503db342ed6c7bfdf3d26412f17c4a38c191929f19af17add36d0f5a1068f452629
-  languageName: node
-  linkType: hard
-
 "superdb-desktop@workspace:apps/superdb-desktop":
   version: 0.0.0-use.local
   resolution: "superdb-desktop@workspace:apps/superdb-desktop"
@@ -12057,11 +12050,9 @@ __metadata:
     jest: ^29.7.0
     node-fetch: ^2.6.1
     rimraf: ^6.0.1
-    super: "github:brimdata/super#28294a64f823856cf28809d477d75faecde36742"
+    super: "brimdata/super#cc30b87cc286ce7fbb783bb463d519a0ae86ea02"
     superdb-types: "workspace:*"
     typescript: 5.1.5
-  peerDependencies:
-    super: "*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## What's Changing

This change enables the automatic advancing of the Node client's `super` dependency via Actions workflow, just like we do for the app's `super` dependency.

## Why

https://github.com/brimdata/zui/pull/3187 illustrated how we'll sometimes need to advance the Node client's dependency, and so I ended up doing a one-shot advance of the dependency in that PR with intent to follow up and make it automatic in a separate PR, and that's what this PR is.

## Details

When I set out to make the change, I had some struggles. At first I tried to just repeat the same `yarn workspace ... add ...` approach that's already used for the app's dependency, but this caused some errors related to how superdb-node-client had `super` listed as both a `devDependency` and a `peerDependency`. The relevant docs online didn't 100% make sense to me so after some false starts in #3188 and #3189 I flagged down @jameskerr who advised:

>  I think it's more preferable to have superdb-node-client be it's own self-contained thing. So it depends on super directly. As a normal dependency. Not peer, not dev.
>
> In a project like superdb-desktop which depends on both, yarn will see that they depend on the same commit and it will only download that one for both.

That's the approach I'm using in these changes here. Both `yarn test` and `yarn e2e` pass locally.