### PR TITLE
Sync up the super dependency between the app and Node client

### DIFF
--- a/apps/superdb-desktop/package.json
+++ b/apps/superdb-desktop/package.json
@@ -142,7 +142,7 @@
     "set-tz": "^0.2.0",
     "sprintf-js": "^1.1.2",
     "styled-components": "^5.3.5",
-    "super": "brimdata/super#de8a72e4b43f6e466c9437c57a4bd7b683c73624",
+    "super": "brimdata/super#38af4626fc7cc83f8e298d4b269efb0520e6be8a",
     "superdb-node-client": "workspace:*",
     "superdb-types": "workspace:*",
     "tmp": "^0.1.0",

--- a/packages/superdb-node-client/package.json
+++ b/packages/superdb-node-client/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "fs-extra": "^11.3.0",
-    "super": "brimdata/super#cc30b87cc286ce7fbb783bb463d519a0ae86ea02",
+    "super": "brimdata/super#38af4626fc7cc83f8e298d4b269efb0520e6be8a",
     "superdb-types": "workspace:*"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11909,10 +11909,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"super@brimdata/super#de8a72e4b43f6e466c9437c57a4bd7b683c73624":
+"super@brimdata/super#38af4626fc7cc83f8e298d4b269efb0520e6be8a":
   version: 0.0.1-dev
-  resolution: "super@https://github.com/brimdata/super.git#commit=de8a72e4b43f6e466c9437c57a4bd7b683c73624"
-  checksum: 340109b3fde07fde3d0fb87b0be2a54099b951f4d05f9464a16455c19fdb2feb19b75f0c51491db07804dbff7286db6123279cc502ecc78154bf1cb13d70b75f
+  resolution: "super@https://github.com/brimdata/super.git#commit=38af4626fc7cc83f8e298d4b269efb0520e6be8a"
+  checksum: 4f47beb4e8641694e6428c80f65f75c12501e9dd311c1fbbeabde77d7724964a112ce0a36e0179b5daabfb84af51e782786aabac4efc91678b244f0fc88789d4
   languageName: node
   linkType: hard
 
@@ -12025,7 +12025,7 @@ __metadata:
     set-tz: ^0.2.0
     sprintf-js: ^1.1.2
     styled-components: ^5.3.5
-    super: "brimdata/super#de8a72e4b43f6e466c9437c57a4bd7b683c73624"
+    super: "brimdata/super#38af4626fc7cc83f8e298d4b269efb0520e6be8a"
     superdb-node-client: "workspace:*"
     superdb-types: "workspace:*"
     tmp: ^0.1.0
@@ -12050,7 +12050,7 @@ __metadata:
     jest: ^29.7.0
     node-fetch: ^2.6.1
     rimraf: ^6.0.1
-    super: "brimdata/super#cc30b87cc286ce7fbb783bb463d519a0ae86ea02"
+    super: "brimdata/super#38af4626fc7cc83f8e298d4b269efb0520e6be8a"
     superdb-types: "workspace:*"
     typescript: 5.1.5
   languageName: unknown


### PR DESCRIPTION
It looks like in #3190 I made a mistake of not running `yarn` a final time and committing the resulting `yarn.lock`, since right now at tip-of-`main` if I run `yarn` it does indeed produce a diff to `yarn.lock`. A couple times now the automation has tried to automatically advance the pointer and that's causing a failure like the one shown below. I'm attempting to fix that in this PR via one more manual update get the super commit pointers in current & in sync and commit the resulting `yarn.lock`.

```
Post-resolution validation
  ➤ YN0000: │ @@ -11908,8 +11908,14 @@
  ➤ YN0000: │    checksum: 31ba7a62c889236b5b07f75b5c250d481158a1ca061b8f234fca0457bdbe48a20e5011c12c715343dc577e111463dc3d9e721b98015a445a2a88c35e0c9f0f91
  ➤ YN0000: │    languageName: node
  ➤ YN0000: │    linkType: hard
  ➤ YN0000: │  
  ➤ YN0028: │ +"super@brimdata/super#cc30b87cc286ce7fbb783bb463d519a0ae86ea02":
  ➤ YN0028: │ +  version: 0.0.1-dev
  ➤ YN0028: │ +  resolution: "super@https://github.com/brimdata/super.git#commit=cc30b87cc286ce7fbb783bb463d519a0ae86ea02"
  ➤ YN0028: │ +  languageName: node
  ➤ YN0028: │ +  linkType: hard
  ➤ YN0028: │ +
  ➤ YN0000: │  "super@brimdata/super#de8a72e4b43f6e466c9437c57a4bd7b683c73624":
  ➤ YN0000: │    version: 0.0.1-dev
  ➤ YN0000: │    resolution: "super@https://github.com/brimdata/super.git#commit=de8a72e4b43f6e466c9437c57a4bd7b683c73624"
  ➤ YN0000: │    checksum: 340109b3fde07fde3d0fb87b0be2a54099b951f4d05f9464a16455c19fdb2feb19b75f0c51491db07804dbff7286db6123279cc502ecc78154bf1cb13d70b75f
  ➤ YN0000: │ 
  ➤ YN0028: │ The lockfile would have been modified by this install, which is explicitly forbidden.
```