### PR TITLE
Use ubuntu-24.04 runners to work around actions/runner-images#11988

### DIFF
--- a/.github/workflows/advance-super.yml
+++ b/.github/workflows/advance-super.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-insiders.yml
+++ b/.github/workflows/build-insiders.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   check_latest:
     name: Get last released version
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Get last released version
         id: latest_release
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         # macos-13 is is Intel-based (x64), macos-14 is Apple Silicon (arm64)
-        platform: [windows-2019, macos-13, macos-14, ubuntu-22.04]
+        platform: [windows-2019, macos-13, macos-14, ubuntu-24.04]
 
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         # macos-13 is is Intel-based (x64), macos-14 is Apple Silicon (arm64)
-        platform: [macos-13, macos-14, ubuntu-22.04, windows-2019]
+        platform: [macos-13, macos-14, ubuntu-24.04, windows-2019]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         # macos-13 is is Intel-based (x64), macos-14 is Apple Silicon (arm64)
-        os: [macos-13, macos-14, ubuntu-22.04, windows-2019]
+        os: [macos-13, macos-14, ubuntu-24.04, windows-2019]
     steps:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,7 +9,7 @@ on:
         required: true
       platforms:
         description: OS platforms to test on (list of strings in JSON format)"
-        default: '["ubuntu-22.04"]'
+        default: '["ubuntu-24.04"]'
         required: true
       video:
         description: Whether to record videos of Playwright test runs

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   markdown-link-check:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: Extract branch name

--- a/.github/workflows/notify-docs-update.yaml
+++ b/.github/workflows/notify-docs-update.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Send dispatch event
         run: |

--- a/.github/workflows/notify-main-failure.yml
+++ b/.github/workflows/notify-main-failure.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   slackNotify:
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Notify Brim HQ of failure on main
         uses: tiloio/slack-webhook-action@v1.1.2

--- a/.github/workflows/release-insiders.yml
+++ b/.github/workflows/release-insiders.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   check_latest:
     name: Check If Release Is Needed
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Get last released version
         id: latest_release
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         # macos-13 is is Intel-based (x64), macos-14 is Apple Silicon (arm64)
-        platform: [windows-2019, macos-13, macos-14, ubuntu-22.04]
+        platform: [windows-2019, macos-13, macos-14, ubuntu-24.04]
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -90,7 +90,7 @@ jobs:
   record_build_sha:
     needs: release
     name: Upload the Build Sha
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Create the build_sha file
         run: echo ${{ github.sha }} > build_sha.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         # macos-13 is is Intel-based (x64), macos-14 is Apple Silicon (arm64)
-        platform: [macos-13, macos-14, ubuntu-22.04, windows-2019]
+        platform: [macos-13, macos-14, ubuntu-24.04, windows-2019]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout


### PR DESCRIPTION
## tl;dr

Use `ubuntu-24.04` runners instead of `ubuntu-22.04` to work around an Actions problem.

## Details

It's normally my preference to stay pinned on older CI runners until there's a deprecation notice or some other compelling reason to jump to the newer. But for over a week our jobs have been failing intermittently due to the problem described in https://github.com/actions/runner-images/issues/11988. Their one change they thought might fix it has not panned out, and the ongoing problem doesn't seem to be getting treated with much urgency. I've already done the work to confirm that our jobs should run fine on the Ubuntu 24.04 runners and other folks who chimed into https://github.com/actions/runner-images/issues/11988 have said the same. I'm getting sick of the failures so I'm ready to just make the jump forward now.