### PR TITLE
Make sysctl setting and install libsecret-1-0 before starting e2e tests on Linux

### DIFF
--- a/.github/workflows/advance-super.yml
+++ b/.github/workflows/advance-super.yml
@@ -36,12 +36,15 @@ jobs:
           # We need a token with permission to push.
           token: ${{ secrets.PAT_TOKEN }}
       - uses: ./.github/actions/setup-app
-      - run: sudo apt-get -y install whois
+      # Installing libsecret-1-dev was necessary to get e2e tests to run on ubuntu-24.04 Actions Runners
+      - run: sudo apt-get -y install whois libsecret-1-dev
       - run: yarn workspace superdb-desktop add super@brimdata/super#${{ env.super_ref }}
       - run: yarn workspace superdb-node-client add super@brimdata/super#${{ env.super_ref }}
       - run: yarn lint
       - run: yarn test
       - run: yarn build
+      # The following sysctl setting is to work around https://github.com/brimdata/zui/issues/3194
+      - run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
       - name: End to end tests
         id: playwright
         run: |

--- a/.github/workflows/advance-super.yml
+++ b/.github/workflows/advance-super.yml
@@ -36,20 +36,19 @@ jobs:
           # We need a token with permission to push.
           token: ${{ secrets.PAT_TOKEN }}
       - uses: ./.github/actions/setup-app
-      # Installing libsecret-1-dev was necessary to get e2e tests to run on ubuntu-24.04 Actions Runners
-      - run: sudo apt-get -y install whois libsecret-1-dev
       - run: yarn workspace superdb-desktop add super@brimdata/super#${{ env.super_ref }}
       - run: yarn workspace superdb-node-client add super@brimdata/super#${{ env.super_ref }}
       - run: yarn lint
       - run: yarn test
       - run: yarn build
-      # The following sysctl setting is to work around https://github.com/brimdata/zui/issues/3194
-      - run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
       - name: End to end tests
         id: playwright
         run: |
+          # Installing libsecret-1-0 was necessary to get e2e tests to run on ubuntu-24.04 Actions Runners (https://github.com/brimdata/zui/pull/3195)
+          sudo apt-get -y install whois libsecret-1-0
+          # The following sysctl setting is to work around https://github.com/brimdata/zui/issues/3194
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
           /usr/bin/xvfb-run --auto-servernum -s "-screen 0 1280x1024x24" yarn e2e:ci
-
       - run: git -c user.name='Brim Automation' -c user.email=automation@brimdata.io commit -a -m 'upgrade super to ${{ env.super_ref }}'
 
       # If this push fails because a PR was merged while this job was

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,13 +45,16 @@ jobs:
       - uses: ./.github/actions/setup-app
       - name: Install dependencies (Linux)
         if: startsWith(matrix.os, 'ubuntu-')
-        run: sudo apt-get -y install whois
+        # Installing libsecret-1-dev was necessary to get e2e tests to run on ubuntu-24.04 Actions Runners
+        run: sudo apt-get -y install whois libsecret-1-dev
       - name: Install dependencies (Windows)
         if: startsWith(matrix.os, 'windows-')
         run: choco install -y --no-progress whois
       - run: yarn lint
       - run: yarn test
       - run: yarn build
+      # The following sysctl setting is to work around https://github.com/brimdata/zui/issues/3194
+      - run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
       - name: End to end tests
         id: playwright
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,22 +43,20 @@ jobs:
         shell: sh
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-app
-      - name: Install dependencies (Linux)
-        if: startsWith(matrix.os, 'ubuntu-')
-        # Installing libsecret-1-dev was necessary to get e2e tests to run on ubuntu-24.04 Actions Runners
-        run: sudo apt-get -y install whois libsecret-1-dev
       - name: Install dependencies (Windows)
         if: startsWith(matrix.os, 'windows-')
         run: choco install -y --no-progress whois
       - run: yarn lint
       - run: yarn test
       - run: yarn build
-      # The following sysctl setting is to work around https://github.com/brimdata/zui/issues/3194
-      - run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
       - name: End to end tests
         id: playwright
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
+            # Installing libsecret-1-0 was necessary to get e2e tests to run on ubuntu-24.04 Actions Runners (https://github.com/brimdata/zui/pull/3195)
+            sudo apt-get -y install whois libsecret-1-0
+            # The following sysctl setting is to work around https://github.com/brimdata/zui/issues/3194
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
             /usr/bin/xvfb-run --auto-servernum -s "-screen 0 1280x1024x24" ${{ inputs.run-target }}
           else
             ${{ inputs.run-target }}


### PR DESCRIPTION
## tl;dr

These changes get the e2e tests running again on Ubuntu 24.04. I've got some uncertainty about if it's the best possible "fix", but it may be good enough.

Closes #3194

## Details

#3194 has the background on the symptom, and [this successful job](https://github.com/brimdata/zui/actions/runs/14584692958) shows the `sysctl` workaround is effective in getting the e2e tests running again.

After initially trying _just_ the `sysctl` setting change it still failed on the Action Runner, and further debug showed a `yarn start` still failing with this message:

```
$ yarn start

> nx run superdb-desktop:start

‣ Compiling...
‣ Launching...
[nodemon] 2.0.22
[nodemon] to restart at any time, enter `rs`
[nodemon] watching path(s): dist/**/*
[nodemon] watching extensions: js,mjs,json
[nodemon] starting `node ../../node_modules/electron/cli.js .`
event - compiled client and server successfully in 890 ms (318 modules)
App threw an error during load
Error: libsecret-1.so.0: cannot open shared object file: No such file or directory
    at process.func [as dlopen] (node:electron/js2c/node_init:2:2214)
    at Module._extensions..node (node:internal/modules/cjs/loader:1489:18)
    at Object.func [as .node] (node:electron/js2c/node_init:2:2214)
    at Module.load (node:internal/modules/cjs/loader:1214:32)
    at Module._load (node:internal/modules/cjs/loader:1030:12)
    at c._load (node:electron/js2c/node_init:2:13672)
    at Module.require (node:internal/modules/cjs/loader:1242:19)
    at require (node:internal/modules/helpers:176:18)
    at Object.<anonymous> (/home/runner/zui/node_modules/keytar/lib/keytar.js:1:14)
    at Module._compile (node:internal/modules/cjs/loader:1391:14)
```

A Google search indicated that installing a libsecret package would address this, and indeed it did.

Now, this all begs the question of whether the `sysctl` workaround is _appropriate_, since the issue https://github.com/electron/electron/issues/42510 (which is what informed me of the workaround) has plenty of people advising that the workaround is somehow insecure, is ok for personal use but not production, etc. Unfortunately, my knowledge of the referenced technologies like AppArmor and Chrome Sandbox is very limited so it's hard for me to tell if the most dire of their warnings are as relevant to our app in particular. For instance, across the tons of comments in https://github.com/electron/electron/issues/42510 I can't tell if an app _packaged for release_ while that `sysctl` setting is in effect somehow becomes insecure for users to install and run, and/or if an app packaged that way would simply not be runnable unless end users make the same `sysctl` setting on their own workstations. It's also not clear if apps like we could still be packaging on Ubuntu 22.04 (were it not for https://github.com/actions/runner-images/issues/11988) are somehow "bad" compared to what happens in this new Ubuntu 24.04 world with a more restrictive AppArmor configuration.

One test I ran that has me thinking we're ok for now is that I was able to run the `yarn nx release-app superdb-desktop` successfully _on an Ubuntu 24.04 system that did **not** have the `sysctl` setting in place_ to create a `.deb` package of what would be the released app, install that on a system that also _did **not** have the `sysctl` setting in place_, and was then able to use the app successfully for basic functionality (e.g., load data, issue queries). So based on this it feels like the workaround truly only affects the running of our e2e tests.

In conclusion, it seems like we could make use of this workaround to have our e2e tests start running reliably in CI again. If the workaround still makes us somewhat uncomfortable, when there's some resolution on https://github.com/actions/runner-images/issues/11988 we could consider backing out this change and going back to `ubuntu-22.04` runners to buy some time and see if a better fix/workaround emerges for https://github.com/electron/electron/issues/42510.