### PR TITLE
Update Electron docs link

### DIFF
--- a/apps/superdb-desktop/CONTRIBUTING.md
+++ b/apps/superdb-desktop/CONTRIBUTING.md
@@ -30,7 +30,7 @@ On subsequent updates, `git pull` and `yarn`.
 
 Zui is a TypeScript, React, Electron app.
 
-- [Electron](https://www.electronjs.org/docs/latest) - it's helpful to understand the [main vs renderer processes](https://www.electronjs.org/docs/latest/tutorial/quick-start#main-and-renderer-processes)
+- [Electron](https://www.electronjs.org/docs/latest) - it's helpful to understand the [main vs renderer processes](https://www.electronjs.org/docs/latest/tutorial/process-model)
 - [TypeScript](https://www.typescriptlang.org/)
 - [Prettier](https://prettier.io/docs/en/index.html)
 - [React](https://reactjs.org/docs/getting-started.html)


### PR DESCRIPTION
The nightly link checker run hit a 404 with an Electron docs link. I can see they moved it to a new location, so I've updated that here.