### PR TITLE
Use windows-2022 Actions runners since windows-2019 is going EOS

### DIFF
--- a/.github/workflows/build-insiders.yml
+++ b/.github/workflows/build-insiders.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         # macos-13 is is Intel-based (x64), macos-14 is Apple Silicon (arm64)
-        platform: [windows-2019, macos-13, macos-14, ubuntu-24.04]
+        platform: [windows-2022, macos-13, macos-14, ubuntu-24.04]
 
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         # macos-13 is is Intel-based (x64), macos-14 is Apple Silicon (arm64)
-        platform: [macos-13, macos-14, ubuntu-24.04, windows-2019]
+        platform: [macos-13, macos-14, ubuntu-24.04, windows-2022]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         # macos-13 is is Intel-based (x64), macos-14 is Apple Silicon (arm64)
-        os: [macos-13, macos-14, ubuntu-24.04, windows-2019]
+        os: [macos-13, macos-14, ubuntu-24.04, windows-2022]
     steps:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@v4

--- a/.github/workflows/release-insiders.yml
+++ b/.github/workflows/release-insiders.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         # macos-13 is is Intel-based (x64), macos-14 is Apple Silicon (arm64)
-        platform: [windows-2019, macos-13, macos-14, ubuntu-24.04]
+        platform: [windows-2022, macos-13, macos-14, ubuntu-24.04]
 
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         # macos-13 is is Intel-based (x64), macos-14 is Apple Silicon (arm64)
-        platform: [macos-13, macos-14, ubuntu-24.04, windows-2019]
+        platform: [macos-13, macos-14, ubuntu-24.04, windows-2022]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout


### PR DESCRIPTION
GitHub sent out their notice that the Windows Server 2019 runner image will be fully unsupported by June 30, 2025 and so they're about to start doing scheduled brownouts of jobs that still use the 2019 runner to make people aware. To get ahead of this, here I modify the workflows to use the 2022 runner instead. I did a test run of the CI workflow on this branch and it ran fine.