### PR TITLE
Launch SuperDB backend with -db instead of -lake

### DIFF
--- a/apps/superdb-desktop/package.json
+++ b/apps/superdb-desktop/package.json
@@ -142,7 +142,7 @@
     "set-tz": "^0.2.0",
     "sprintf-js": "^1.1.2",
     "styled-components": "^5.3.5",
-    "super": "brimdata/super#c001773ec6b35897f85fce209c334f2c534e9c53",
+    "super": "brimdata/super#3c0e543999cafb540d0856502dae693403541ad5",
     "superdb-node-client": "workspace:*",
     "superdb-types": "workspace:*",
     "tmp": "^0.1.0",

--- a/packages/superdb-node-client/package.json
+++ b/packages/superdb-node-client/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "fs-extra": "^11.3.0",
-    "super": "brimdata/super#c001773ec6b35897f85fce209c334f2c534e9c53",
+    "super": "brimdata/super#3c0e543999cafb540d0856502dae693403541ad5",
     "superdb-types": "workspace:*"
   },
   "devDependencies": {

--- a/packages/superdb-node-client/src/lake.ts
+++ b/packages/superdb-node-client/src/lake.ts
@@ -52,7 +52,7 @@ export class Lake {
       'serve',
       '-l',
       `${this.addr}:${this.port}`,
-      '-lake',
+      '-db',
       this.root,
       '-manage=5m',
       '-log.level=info',

--- a/yarn.lock
+++ b/yarn.lock
@@ -11909,10 +11909,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"super@brimdata/super#c001773ec6b35897f85fce209c334f2c534e9c53":
+"super@brimdata/super#3c0e543999cafb540d0856502dae693403541ad5":
   version: 0.0.1-dev
-  resolution: "super@https://github.com/brimdata/super.git#commit=c001773ec6b35897f85fce209c334f2c534e9c53"
-  checksum: 67b55b6fa4814445c2258e9cc1b86d5d3176f13cc8b0d79d34d48a6a1e073560f6480f54d69bc323e1f1c95af20671e6dee5977bc884e0aa355c474802861c1a
+  resolution: "super@https://github.com/brimdata/super.git#commit=3c0e543999cafb540d0856502dae693403541ad5"
+  checksum: bffbf139eef3b719315c254adb28480eb772823b0ed3c1cdc38aa44727339ad9abefe2c6aeb727b93c568fb407d063c5b45ff1cd1a30cdd438a156d494bf3837
   languageName: node
   linkType: hard
 
@@ -12025,7 +12025,7 @@ __metadata:
     set-tz: ^0.2.0
     sprintf-js: ^1.1.2
     styled-components: ^5.3.5
-    super: "brimdata/super#c001773ec6b35897f85fce209c334f2c534e9c53"
+    super: "brimdata/super#3c0e543999cafb540d0856502dae693403541ad5"
     superdb-node-client: "workspace:*"
     superdb-types: "workspace:*"
     tmp: ^0.1.0
@@ -12050,7 +12050,7 @@ __metadata:
     jest: ^29.7.0
     node-fetch: ^2.6.1
     rimraf: ^6.0.1
-    super: "brimdata/super#c001773ec6b35897f85fce209c334f2c534e9c53"
+    super: "brimdata/super#3c0e543999cafb540d0856502dae693403541ad5"
     superdb-types: "workspace:*"
     typescript: 5.1.5
   languageName: unknown


### PR DESCRIPTION
## What's Changing

The app's SuperDB backend will now be launched with the `-db` flag instead of the `-lake` flag as it had been previously.

## Why

https://github.com/brimdata/super/pull/5966 changed the flag, and CI surfaced the problem because the app could no longer start the persistent storage to run tests.

## Details

I'm only attempting here to make the app functional again so CI will continue passing. That is, I'm not attempting to de-lake the entire UX or docs.