### PR TITLE
Stop using // for comments

### DIFF
--- a/apps/superdb-desktop/package.json
+++ b/apps/superdb-desktop/package.json
@@ -142,7 +142,7 @@
     "set-tz": "^0.2.0",
     "sprintf-js": "^1.1.2",
     "styled-components": "^5.3.5",
-    "super": "brimdata/super#69d049968e82ca0ef39c5a3c2e87c9cefd602d4c",
+    "super": "brimdata/super#6b321d858b4d8767737ed6e6f9a11dc4770552fe",
     "superdb-node-client": "workspace:*",
     "superdb-types": "workspace:*",
     "tmp": "^0.1.0",

--- a/apps/superdb-desktop/src/js/state/LoadDataForm/reducer.ts
+++ b/apps/superdb-desktop/src/js/state/LoadDataForm/reducer.ts
@@ -7,7 +7,7 @@ const slice = createSlice({
   initialState: {
     format: "auto" as LoadFormat,
     files: [] as string[],
-    shaper: "// Transform the data here before loading it.\npass",
+    shaper: "-- Transform the data here before loading it.\npass",
     editorSize: 200,
     sidebarSize: 360,
     resultsRatio: 0.5,

--- a/packages/superdb-node-client/package.json
+++ b/packages/superdb-node-client/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "fs-extra": "^11.3.0",
-    "super": "brimdata/super#69d049968e82ca0ef39c5a3c2e87c9cefd602d4c",
+    "super": "brimdata/super#6b321d858b4d8767737ed6e6f9a11dc4770552fe",
     "superdb-types": "workspace:*"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11909,10 +11909,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"super@brimdata/super#69d049968e82ca0ef39c5a3c2e87c9cefd602d4c":
+"super@brimdata/super#6b321d858b4d8767737ed6e6f9a11dc4770552fe":
   version: 0.0.1-dev
-  resolution: "super@https://github.com/brimdata/super.git#commit=69d049968e82ca0ef39c5a3c2e87c9cefd602d4c"
-  checksum: 29295d4e6435b7da0db6118a161293af963e145c1e3163213917f85e601d2b45fe8e5b236586d38029bc4aedcf48a9e2f6390d2e8a040d6f37fdf17b750d2892
+  resolution: "super@https://github.com/brimdata/super.git#commit=6b321d858b4d8767737ed6e6f9a11dc4770552fe"
+  checksum: c2e7194e4c8db4a6a39e6431cdb0d74d541e030c2a0fd1010241acfce180a7fc13bf86f144da4addfaa55b7f344a859c9d0bcf4e844a2dfc049dd1d27bbff83f
   languageName: node
   linkType: hard
 
@@ -12025,7 +12025,7 @@ __metadata:
     set-tz: ^0.2.0
     sprintf-js: ^1.1.2
     styled-components: ^5.3.5
-    super: "brimdata/super#69d049968e82ca0ef39c5a3c2e87c9cefd602d4c"
+    super: "brimdata/super#6b321d858b4d8767737ed6e6f9a11dc4770552fe"
     superdb-node-client: "workspace:*"
     superdb-types: "workspace:*"
     tmp: ^0.1.0
@@ -12050,7 +12050,7 @@ __metadata:
     jest: ^29.7.0
     node-fetch: ^2.6.1
     rimraf: ^6.0.1
-    super: "brimdata/super#69d049968e82ca0ef39c5a3c2e87c9cefd602d4c"
+    super: "brimdata/super#6b321d858b4d8767737ed6e6f9a11dc4770552fe"
     superdb-types: "workspace:*"
     typescript: 5.1.5
   languageName: unknown


### PR DESCRIPTION
https://github.com/brimdata/super/pull/5989 enabled `/* */`-style multi-line comments and https://github.com/brimdata/super/pull/5990 removed the `//`style single-line comments altogether. The remaining use of `//` in this one spot in the app was causing CI to break, so, fixing that here.