### PR TITLE
Change SUP union syntax to use pipe(|) instead of comma separator

### DIFF
--- a/apps/superdb-desktop/package.json
+++ b/apps/superdb-desktop/package.json
@@ -142,7 +142,7 @@
     "set-tz": "^0.2.0",
     "sprintf-js": "^1.1.2",
     "styled-components": "^5.3.5",
-    "super": "brimdata/super#cc68d890fecd8d55f115bba02991154aef8a2110",
+    "super": "brimdata/super#bce166968f70b89b73151051b220a373f9675b6b",
     "superdb-node-client": "workspace:*",
     "superdb-types": "workspace:*",
     "tmp": "^0.1.0",

--- a/apps/superdb-desktop/src/test/shared/data/sample.sup
+++ b/apps/superdb-desktop/src/test/shared/data/sample.sup
@@ -53,7 +53,7 @@
 {
     array: ["1", "2", "3"],
     set: |["a", "b", "c"]|,
-    union: "hi james" ((string, int64)),
+    union: "hi james" (int64|string),
     map: |{ "best": 1, "worst": 0 }|,
     null: null
 }

--- a/packages/sample-data/data/sample.sup
+++ b/packages/sample-data/data/sample.sup
@@ -9,7 +9,7 @@
         resp_p: 80 (port)
     } (=0),
     proto: "tcp" (=zenum),
-    service: null ((string, uint64)),
+    service: null (uint64|string),
     duration: 9.698493s (duration),
     orig_bytes: 0 (uint64),
     resp_bytes: 90453565 (uint64),
@@ -53,7 +53,7 @@
 {
     array: ["1", "2", "3"],
     set: |["a", "b", "c"]|,
-    union: "hi james" ((string, int64)),
+    union: "hi james" (int64|string),
     map: |{ "best": 1, "worst": 0 }|,
     null: null
 }

--- a/packages/superdb-node-client/package.json
+++ b/packages/superdb-node-client/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "fs-extra": "^11.3.0",
-    "super": "brimdata/super#cc68d890fecd8d55f115bba02991154aef8a2110",
+    "super": "brimdata/super#bce166968f70b89b73151051b220a373f9675b6b",
     "superdb-types": "workspace:*"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11909,10 +11909,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"super@brimdata/super#cc68d890fecd8d55f115bba02991154aef8a2110":
+"super@brimdata/super#bce166968f70b89b73151051b220a373f9675b6b":
   version: 0.0.1-dev
-  resolution: "super@https://github.com/brimdata/super.git#commit=cc68d890fecd8d55f115bba02991154aef8a2110"
-  checksum: 72b3a3b4f36948a6130f4e340010691ab5841c34c10a5d79fe0be8c81071a37f7185cafaa56bc643c8df1750e41b2224923b92b0032cc7cb309961bade55c5cf
+  resolution: "super@https://github.com/brimdata/super.git#commit=bce166968f70b89b73151051b220a373f9675b6b"
+  checksum: 4c59688744a58af5ca02f782ecc7c84aa2bcf4246a83e7dd0d6245d373f2015c6e2d3e2285ae165741949677276cfb2f0a4c8c00df47c40648d3ec082510be3a
   languageName: node
   linkType: hard
 
@@ -12025,7 +12025,7 @@ __metadata:
     set-tz: ^0.2.0
     sprintf-js: ^1.1.2
     styled-components: ^5.3.5
-    super: "brimdata/super#cc68d890fecd8d55f115bba02991154aef8a2110"
+    super: "brimdata/super#bce166968f70b89b73151051b220a373f9675b6b"
     superdb-node-client: "workspace:*"
     superdb-types: "workspace:*"
     tmp: ^0.1.0
@@ -12050,7 +12050,7 @@ __metadata:
     jest: ^29.7.0
     node-fetch: ^2.6.1
     rimraf: ^6.0.1
-    super: "brimdata/super#cc68d890fecd8d55f115bba02991154aef8a2110"
+    super: "brimdata/super#bce166968f70b89b73151051b220a373f9675b6b"
     superdb-types: "workspace:*"
     typescript: 5.1.5
   languageName: unknown


### PR DESCRIPTION
This adapts to the changes in https://github.com/brimdata/super/pull/6000 so Zui tests will pass in CI again.