### PR TITLE
Use "unnest" instead of "over"

### DIFF
--- a/apps/superdb-desktop/package.json
+++ b/apps/superdb-desktop/package.json
@@ -142,7 +142,7 @@
     "set-tz": "^0.2.0",
     "sprintf-js": "^1.1.2",
     "styled-components": "^5.3.5",
-    "super": "brimdata/super#fa4174f325bdd78e301c50f25cd967b9878c34d3",
+    "super": "brimdata/super#16aa5b7eab5efe3f9ac94bd7a074e5aa826e9b3c",
     "superdb-node-client": "workspace:*",
     "superdb-types": "workspace:*",
     "tmp": "^0.1.0",

--- a/packages/superdb-node-client/package.json
+++ b/packages/superdb-node-client/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "fs-extra": "^11.3.0",
-    "super": "brimdata/super#fa4174f325bdd78e301c50f25cd967b9878c34d3",
+    "super": "brimdata/super#16aa5b7eab5efe3f9ac94bd7a074e5aa826e9b3c",
     "superdb-types": "workspace:*"
   },
   "devDependencies": {

--- a/packages/superdb-node-client/src/zq.test.ts
+++ b/packages/superdb-node-client/src/zq.test.ts
@@ -86,7 +86,7 @@ test('zq with jsup objects', async () => {
   const path = getPath('prs.json');
   const input = createReadStream(path);
 
-  const data = await zq({ query: 'over this | head 10', as: 'jsup', input });
+  const data = await zq({ query: 'unnest this | head 10', as: 'jsup', input });
 
   expect(data).toHaveLength(10);
 });
@@ -95,7 +95,7 @@ test('zq with a file ', async () => {
   const path = getPath('prs.json');
 
   const data = await zq({
-    query: 'over this | head 10',
+    query: 'unnest this | head 10',
     as: 'jsup',
     file: path,
   });
@@ -106,13 +106,13 @@ test('zq with a file ', async () => {
 test('zq with a bad zed ', async () => {
   const path = getPath('prs.json');
   const promise = zq({
-    query: 'over this | isNull(*) | head 10',
+    query: 'unnest this | isNull(*) | head 10',
     as: 'jsup',
     input: createReadStream(path),
   });
 
   await expect(promise).rejects.toThrowError(
-    /parse error at line 1, column 20/
+    /parse error at line 1, column 22/
   );
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11909,10 +11909,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"super@brimdata/super#fa4174f325bdd78e301c50f25cd967b9878c34d3":
+"super@brimdata/super#16aa5b7eab5efe3f9ac94bd7a074e5aa826e9b3c":
   version: 0.0.1-dev
-  resolution: "super@https://github.com/brimdata/super.git#commit=fa4174f325bdd78e301c50f25cd967b9878c34d3"
-  checksum: b23d393d988d3e87202adf555fe75ef37813711f577ba55dbbd5653ff51b0c6b7c0809b5ff5c09221635543b1a1e9be79ad798656f3edea540ee06725efdcca2
+  resolution: "super@https://github.com/brimdata/super.git#commit=16aa5b7eab5efe3f9ac94bd7a074e5aa826e9b3c"
+  checksum: f5641fddb2852f80ed488754d6f4ceeb9eb885f888159fd947832a71cd27f772670c776e4adcbc1a4e44c35abb541ea3a1e9abfdf730b115868421c27b9daee1
   languageName: node
   linkType: hard
 
@@ -12025,7 +12025,7 @@ __metadata:
     set-tz: ^0.2.0
     sprintf-js: ^1.1.2
     styled-components: ^5.3.5
-    super: "brimdata/super#fa4174f325bdd78e301c50f25cd967b9878c34d3"
+    super: "brimdata/super#16aa5b7eab5efe3f9ac94bd7a074e5aa826e9b3c"
     superdb-node-client: "workspace:*"
     superdb-types: "workspace:*"
     tmp: ^0.1.0
@@ -12050,7 +12050,7 @@ __metadata:
     jest: ^29.7.0
     node-fetch: ^2.6.1
     rimraf: ^6.0.1
-    super: "brimdata/super#fa4174f325bdd78e301c50f25cd967b9878c34d3"
+    super: "brimdata/super#16aa5b7eab5efe3f9ac94bd7a074e5aa826e9b3c"
     superdb-types: "workspace:*"
     typescript: 5.1.5
   languageName: unknown


### PR DESCRIPTION
This adapts to the changes in https://github.com/brimdata/super/pull/6021 so the tests will succeed in CI again.