### PR TITLE
Adapt to changes in the SuperSQL load operator

### DIFF
--- a/apps/superdb-desktop/package.json
+++ b/apps/superdb-desktop/package.json
@@ -142,7 +142,7 @@
     "set-tz": "^0.2.0",
     "sprintf-js": "^1.1.2",
     "styled-components": "^5.3.5",
-    "super": "brimdata/super#44adab703c710867f3f734f27ee46b21955e60b5",
+    "super": "brimdata/super#e75dfdaf1809d7730dd810a37c8eb2c0749cfc5d",
     "superdb-node-client": "workspace:*",
     "superdb-types": "workspace:*",
     "tmp": "^0.1.0",

--- a/apps/superdb-desktop/src/domain/loads/query-loader.ts
+++ b/apps/superdb-desktop/src/domain/loads/query-loader.ts
@@ -19,13 +19,13 @@ export class QueryLoader implements Loader {
 
   private get loadQuery() {
     // This is the load op syntax
-    // load <pool>[@<branch>] [author <author>] [message <message>] [meta <meta>]
+    // load <pool>[@<branch>] ([author <author>] [message <message>] [meta <meta>])
     return [
       this.ctx.query,
       "| load",
       this.ctx.poolId + "@" + this.ctx.branch,
-      "author " + JSON.stringify(this.ctx.author),
-      "message " + JSON.stringify(this.ctx.body),
+      "(author " + JSON.stringify(this.ctx.author),
+      "message " + JSON.stringify(this.ctx.body) + ")",
     ].join(" ")
   }
 }

--- a/packages/superdb-node-client/package.json
+++ b/packages/superdb-node-client/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "fs-extra": "^11.3.0",
-    "super": "brimdata/super#44adab703c710867f3f734f27ee46b21955e60b5",
+    "super": "brimdata/super#e75dfdaf1809d7730dd810a37c8eb2c0749cfc5d",
     "superdb-types": "workspace:*"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11909,10 +11909,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"super@brimdata/super#44adab703c710867f3f734f27ee46b21955e60b5":
+"super@brimdata/super#e75dfdaf1809d7730dd810a37c8eb2c0749cfc5d":
   version: 0.0.1-dev
-  resolution: "super@https://github.com/brimdata/super.git#commit=44adab703c710867f3f734f27ee46b21955e60b5"
-  checksum: 6b3e451f0c78976af9b725d239dfe14fb4d94dc1ff85fc652b3749df8807481ed66f0aca993db4848bdad058963a185695c3fbf8d01750376322523f0fb2d23d
+  resolution: "super@https://github.com/brimdata/super.git#commit=e75dfdaf1809d7730dd810a37c8eb2c0749cfc5d"
+  checksum: f7cfd9fa3aadb454ab2e0eb50a4ecfa98ddeb7e7ec68d0beacb2874cca32e5e3de3af6d6fc88573b4add9a6052b70b1db4cfdedeafc0d5ad0505d1bb321e7638
   languageName: node
   linkType: hard
 
@@ -12025,7 +12025,7 @@ __metadata:
     set-tz: ^0.2.0
     sprintf-js: ^1.1.2
     styled-components: ^5.3.5
-    super: "brimdata/super#44adab703c710867f3f734f27ee46b21955e60b5"
+    super: "brimdata/super#e75dfdaf1809d7730dd810a37c8eb2c0749cfc5d"
     superdb-node-client: "workspace:*"
     superdb-types: "workspace:*"
     tmp: ^0.1.0
@@ -12050,7 +12050,7 @@ __metadata:
     jest: ^29.7.0
     node-fetch: ^2.6.1
     rimraf: ^6.0.1
-    super: "brimdata/super#44adab703c710867f3f734f27ee46b21955e60b5"
+    super: "brimdata/super#e75dfdaf1809d7730dd810a37c8eb2c0749cfc5d"
     superdb-types: "workspace:*"
     typescript: 5.1.5
   languageName: unknown


### PR DESCRIPTION
This adapts to the changes in https://github.com/brimdata/super/pull/6059 so the Zui tests in CI will pass again.