### PR TITLE
Address timing issue in e2e pool-load-success and advance super dependency

### DIFF
--- a/apps/superdb-desktop/package.json
+++ b/apps/superdb-desktop/package.json
@@ -142,7 +142,7 @@
     "set-tz": "^0.2.0",
     "sprintf-js": "^1.1.2",
     "styled-components": "^5.3.5",
-    "super": "brimdata/super#5075037c83ea92565c7fff2c48ebb6b33ffef319",
+    "super": "brimdata/super#f432555a2a9139d7ad2bf8c85fd5f5efd1dc5e10",
     "superdb-node-client": "workspace:*",
     "superdb-types": "workspace:*",
     "tmp": "^0.1.0",

--- a/packages/app-player/tests/pool-load-success.spec.ts
+++ b/packages/app-player/tests/pool-load-success.spec.ts
@@ -35,6 +35,8 @@ test.describe('Pool Loads (successes)', () => {
     await app.attached(/successfully loaded/i);
     await app.click('button', 'Query Pool');
     await app.query('count()');
+    await app.hidden(/successfully loaded/i);
+
     const results = await app.getInspectorResults();
     expect(results).toEqual(['2 ( uint64 )']);
   });

--- a/packages/superdb-node-client/package.json
+++ b/packages/superdb-node-client/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "fs-extra": "^11.3.0",
-    "super": "brimdata/super#5075037c83ea92565c7fff2c48ebb6b33ffef319",
+    "super": "brimdata/super#f432555a2a9139d7ad2bf8c85fd5f5efd1dc5e10",
     "superdb-types": "workspace:*"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11909,10 +11909,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"super@brimdata/super#5075037c83ea92565c7fff2c48ebb6b33ffef319":
+"super@brimdata/super#f432555a2a9139d7ad2bf8c85fd5f5efd1dc5e10":
   version: 0.0.1-dev
-  resolution: "super@https://github.com/brimdata/super.git#commit=5075037c83ea92565c7fff2c48ebb6b33ffef319"
-  checksum: 8fb5b961742f3a833e08e8bbe71cd8392fbeb0213995183a9c68754e617a6764a39845c098bec8b13eeba3b538b0fe5726a0542b0f10f6fd0079992008982407
+  resolution: "super@https://github.com/brimdata/super.git#commit=f432555a2a9139d7ad2bf8c85fd5f5efd1dc5e10"
+  checksum: 4e40d6ef4797eda0e15b02efecf6f9a3e80cdc1e8e11590feaa55714674cd3d47582eee28fa083cac9b1c050f84f040c8c471666d4c1774a49e2ebc0fae475fa
   languageName: node
   linkType: hard
 
@@ -12025,7 +12025,7 @@ __metadata:
     set-tz: ^0.2.0
     sprintf-js: ^1.1.2
     styled-components: ^5.3.5
-    super: "brimdata/super#5075037c83ea92565c7fff2c48ebb6b33ffef319"
+    super: "brimdata/super#f432555a2a9139d7ad2bf8c85fd5f5efd1dc5e10"
     superdb-node-client: "workspace:*"
     superdb-types: "workspace:*"
     tmp: ^0.1.0
@@ -12050,7 +12050,7 @@ __metadata:
     jest: ^29.7.0
     node-fetch: ^2.6.1
     rimraf: ^6.0.1
-    super: "brimdata/super#5075037c83ea92565c7fff2c48ebb6b33ffef319"
+    super: "brimdata/super#f432555a2a9139d7ad2bf8c85fd5f5efd1dc5e10"
     superdb-types: "workspace:*"
     typescript: 5.1.5
   languageName: unknown


### PR DESCRIPTION
## tl;dr

The merge of the changes in https://github.com/brimdata/super/pull/6156 are correlated with the e2e test `pool-load-success.spec.ts` starting to consistently fail. It seems likely that the SuperDB change aggravated an existing timing problem with the test, so here I make the test more deterministic. I'm not in love with the fix, but the overall Zui test suite is in need of improvements and I'm not in a position to fix all of it right now.

## Details

An example failure can be seen in [this Actions run](https://github.com/brimdata/zui/actions/runs/17272369886). Here's a local repro of the same failure by just running that specific test:

```
$ yarn e2e pool-load-success.spec.ts

> nx run app-player:test pool-load-success.spec.ts

Running 2 tests using 1 worker
  ✓  1 pool-load-success.spec.ts:17:3 › Pool Loads (successes) › load data into a pool (4.3s)
  ✘  2 pool-load-success.spec.ts:27:3 › Pool Loads (successes) › load more data into the pool (2.6s)
  1) pool-load-success.spec.ts:27:3 › Pool Loads (successes) › load more data into the pool ────────
    Error: locator.waitFor: Error: strict mode violation: locator('.zed-view') resolved to 2 elements:
        1) <div role="row" class="zed-view">…</div> aka getByRole('row', { name: '[ {url: "https://api.github.' }).first()
        2) <div role="row" class="zed-view">…</div> aka getByRole('row', { name: '[ {url: "https://api.github.' }).nth(1)
    Call log:
      - waiting for locator('.zed-view') to be visible
       at ../helpers/test-app.ts:162
      160 |   async getInspectorResults(): Promise<string[]> {
      161 |     const fields = await this.mainWin.locator('.zed-view');
    > 162 |     await fields.waitFor();
          |                  ^
      163 |     let results = await fields.evaluateAll<string[], HTMLElement>((nodes) =>
      164 |       nodes.map((n) => n.innerText.trim().replaceAll(/\s+/g, ' '))
      165 |     );
        at TestApp.getInspectorResults (/Users/phil/work/zui/packages/app-player/helpers/test-app.ts:162:18)
        at /Users/phil/work/zui/packages/app-player/tests/pool-load-success.spec.ts:41:21
  1 failed
    pool-load-success.spec.ts:27:3 › Pool Loads (successes) › load more data into the pool ─────────
  1 passed (10.4s)
```

I stared at this one for a while because the SuperDB change only affected the SuperSQL parser and the failure messages seen here no way reflect a direct interaction with the parser. A manual repro of the equivalent steps from the test also run fine. However, I took some screen recordings of a baseline run with super commit `5075037` (i.e., right before the merge of the changes in https://github.com/brimdata/super/pull/6156):

https://github.com/user-attachments/assets/65ba43bb-efba-4058-8ce4-0da02c9a1373

Then a repro run with super commit `b396750` (i.e., right after the advance of the super dependency from https://github.com/brimdata/super/pull/6156 having merged):

https://github.com/user-attachments/assets/17dbce2c-2460-4260-8201-426bff947cdb

These provided a little more evidence as to what might be going on.

If you jump to second 14 in the baseline video and use the left/right arrow keys to advance a frame at a time, you can see the prior `1 (uint14)` is only visible in two frames before it disappears and the Inspector contents are populated with the pool contents and the `count()` is repeated. The equivalent spot in the test happens in the repro video in second 18, but in this case the prior `1 (uint14)` is present for about 20 frames.

This information in itself is not necessarily a smoking gun, but looking at the test code did make me recall James explaining at one point that the `getInspectorResults()` code that purports to wait for query results to be fully populated on the screen before looking for specific contents had some shortcomings in its ability to know with certainty when the results were 100% "done" with being populated. This means a SuperDB-side change that might make the parser now run a little slower/faster might indeed have the potential to affect what the e2e test framework "sees" when it goes to scrape the contents of the Inspector.

Finally, looking at the specific test code, I can see that the first test case (which was still consistently passing) follows a pattern of:

1. Issue `count()`
2. Wait for a status message to disappear from the screen
3. Get the Inspector contents
4. Confirm the Inspector contents

...whereas the failing test was missing a "Wait for a status message to disappear" step.

Testing my theory that it was down to timing, I actually was able to make the test consistently pass by just adding an `await app.sleep(1)` before the call to `getInspectorResults()`, but I know those kinds of static delays are a no-no so in this PR I've instead opted to add a "Wait for a status message to disappear" step. This has the effect of actually slowing down the test by a couple seconds because these pop-ups unfortunately have to be waited out (i.e., no way for a test or user to manually click to dismiss, see #2605) but at least it passes consistently now.

Hopefully someday we'll have an opportunity to tighten up the tests in general when the app gets more attention. In the meantime I'm just keen to keep the CI limping along so we have at least some faith the app is working when we go to reach for it again in the near future.