### PR TITLE
Fix link to prs.json test data

### DIFF
--- a/apps/superdb-desktop/docs/features/Preview-Load.md
+++ b/apps/superdb-desktop/docs/features/Preview-Load.md
@@ -9,7 +9,7 @@ the stacked bar chart.
 
 To further explore the Zed concepts shown in the video, you may want to read
 the [`zq` tutorial](https://zed.brimdata.io/docs/tutorials/zq) and use the
-[`prs.json`](https://github.com/brimdata/zed/raw/main/docs/tutorials/prs.json)
+[`prs.json`](https://github.com/brimdata/super/blob/1c02ef2585a14a59e00bd33efd1d441d818782e5/docs/tutorials/prs.json)
 test data.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/ywPG1a9FLX0?si=xykqAgIPpsocYhJz" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>


### PR DESCRIPTION
The removal of the `docs/` directory in the super repo caused this link to break. This change links instead to the file at the commit right before that removal.