### PR TITLE
Use an explicit source in program.test.ts

### DIFF
--- a/apps/superdb-desktop/package.json
+++ b/apps/superdb-desktop/package.json
@@ -142,7 +142,7 @@
     "set-tz": "^0.2.0",
     "sprintf-js": "^1.1.2",
     "styled-components": "^5.3.5",
-    "super": "brimdata/super#b0dc05915bf5192574aa2d3bf397536d992d67b7",
+    "super": "brimdata/super#a12d23cc5f4bf498d62ee3ba5717cf5306217e4d",
     "superdb-node-client": "workspace:*",
     "superdb-types": "workspace:*",
     "tmp": "^0.1.0",

--- a/apps/superdb-desktop/src/js/models/program.test.ts
+++ b/apps/superdb-desktop/src/js/models/program.test.ts
@@ -66,45 +66,45 @@ describe("drill down", () => {
   }
 
   test("when there is no leading filter", async () => {
-    const script = await run(result, 'count() by this["i d"]["orig h"]')
-    expect(script).toBe('this["i d"]["orig h"]==192.168.0.54')
+    const script = await run(result, 'from test | count() by this["i d"]["orig h"]')
+    expect(script).toBe('from test | this["i d"]["orig h"]==192.168.0.54')
   })
 
   test("when there is a sort on there", async () => {
     const script = await run(
       result,
-      'name=="james" | count() by proto | sort -r count'
+      'from test | name=="james" | count() by proto | sort -r count'
     )
 
-    expect(script).toBe('name=="james" | proto=="udp"')
+    expect(script).toBe('from test | name=="james" | proto=="udp"')
   })
 
   test("when there is a grep with a star", async () => {
     const script = await run(
       result,
-      'grep("(.*|Elm)", this) | Category=="Furnishings" | count() by proto'
+      'from test | grep("(.*|Elm)", this) | Category=="Furnishings" | count() by proto'
     )
 
     expect(script).toBe(
-      'grep("(.*|Elm)", this) | Category=="Furnishings" | proto=="udp"'
+      'from test | grep("(.*|Elm)", this) | Category=="Furnishings" | proto=="udp"'
     )
   })
 
   test("combines keys in the group by proc", async () => {
     const script = await run(
       result,
-      '_path=="dns" | count() by id.orig_h, proto, query | sort -r'
+      'from test | _path=="dns" | count() by id.orig_h, proto, query | sort -r'
     )
 
     expect(script).toBe(
-      '_path=="dns" | id.orig_h==192.168.0.54 proto=="udp" query=="WPAD"'
+      'from test | _path=="dns" | id.orig_h==192.168.0.54 proto=="udp" query=="WPAD"'
     )
   })
 
   test("easy peasy", async () => {
-    const script = await run(result, 'name=="james" | count() by proto')
+    const script = await run(result, 'from test | name=="james" | count() by proto')
 
-    expect(script).toBe('name=="james" | proto=="udp"')
+    expect(script).toBe('from test | name=="james" | proto=="udp"')
   })
 
   test("count by and filter the same", async () => {
@@ -112,10 +112,10 @@ describe("drill down", () => {
 
     const script = await run(
       result,
-      'md5=="123" | count() by md5 | sort -r | head 5'
+      'from test | md5=="123" | count() by md5 | sort -r | head 5'
     )
 
-    expect(script).toEqual('md5=="123"')
+    expect(script).toEqual('from test | md5=="123" | md5=="123"')
   })
 
   test("filter query", async () => {
@@ -126,11 +126,11 @@ describe("drill down", () => {
 
     const script = await run(
       result,
-      '_path=="files" | filename!="-" | count() by md5,filename | count() by md5 | sort -r | count > 1'
+      'from test | _path=="files" | filename!="-" | count() by md5,filename | count() by md5 | sort -r | count > 1'
     )
 
     expect(script).toEqual(
-      '_path=="files" | filename!="-" | md5=="9f51ef98c42df4430a978e4157c43dd5"'
+      'from test | _path=="files" | filename!="-" | md5=="9f51ef98c42df4430a978e4157c43dd5"'
     )
   })
 })

--- a/packages/superdb-node-client/package.json
+++ b/packages/superdb-node-client/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "fs-extra": "^11.3.0",
-    "super": "brimdata/super#b0dc05915bf5192574aa2d3bf397536d992d67b7",
+    "super": "brimdata/super#a12d23cc5f4bf498d62ee3ba5717cf5306217e4d",
     "superdb-types": "workspace:*"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11952,10 +11952,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"super@brimdata/super#b0dc05915bf5192574aa2d3bf397536d992d67b7":
+"super@brimdata/super#a12d23cc5f4bf498d62ee3ba5717cf5306217e4d":
   version: 0.0.1-dev
-  resolution: "super@https://github.com/brimdata/super.git#commit=b0dc05915bf5192574aa2d3bf397536d992d67b7"
-  checksum: 10/c029682d0cf296cc6019b1df2d0ef0fece9f97abcebb047e0364bd08a9fe271a70205d1f8a6c67e5acefc725060726af5add21c841faa730e62a454a2e5f6ac6
+  resolution: "super@https://github.com/brimdata/super.git#commit=a12d23cc5f4bf498d62ee3ba5717cf5306217e4d"
+  checksum: 10/0c397890b08f3fd0126d4a26a99e99887389b8942686be4916014cceb8f91c3ce2f99decf4cacde69d05d1a08965289f3a2a8cf23f59439c1c8c4f0e933b2fe2
   languageName: node
   linkType: hard
 
@@ -12068,7 +12068,7 @@ __metadata:
     set-tz: "npm:^0.2.0"
     sprintf-js: "npm:^1.1.2"
     styled-components: "npm:^5.3.5"
-    super: "brimdata/super#b0dc05915bf5192574aa2d3bf397536d992d67b7"
+    super: "brimdata/super#a12d23cc5f4bf498d62ee3ba5717cf5306217e4d"
     superdb-node-client: "workspace:*"
     superdb-types: "workspace:*"
     tmp: "npm:^0.1.0"
@@ -12093,7 +12093,7 @@ __metadata:
     jest: "npm:^29.7.0"
     node-fetch: "npm:^2.6.1"
     rimraf: "npm:^6.0.1"
-    super: "brimdata/super#b0dc05915bf5192574aa2d3bf397536d992d67b7"
+    super: "brimdata/super#a12d23cc5f4bf498d62ee3ba5717cf5306217e4d"
     superdb-types: "workspace:*"
     typescript: "npm:5.1.5"
   languageName: unknown


### PR DESCRIPTION
In contemplating #3218, @nwt remarked:

> This ultimately traces back to the change we made to the HTTP API to ignore the pool name zui sends along side a query. That pool was treated as a default source if the query didn't include an explicit source. Without it, you get the null source. And with type checking against the null source instead of a pool, you get errors.

Therefore in this branch I've added explicit leading `from test` to the queries, which gets the tests to pass again with the newer SuperDB dependency.