### PR TITLE
Update PPL link/reference to 1.0.1

### DIFF
--- a/apps/superdb-desktop/CHANGELOG.md
+++ b/apps/superdb-desktop/CHANGELOG.md
@@ -401,7 +401,7 @@ questions.
 **NOTE** - Beginning with this release, a subset of the source code in the
 [github.com/brimdata/brim](https://github.com/brimdata/brim) GitHub repository is
 covered by a source-available style license, the
-[Polyform Perimeter License (PPL)](https://polyformproject.org/licenses/perimeter/1.0.0/).
+[Polyform Perimeter License (PPL)](https://polyformproject.org/licenses/perimeter/1.0.1).
 We've moved the PPL-covered code under a `ppl/` directory in the repository.
 The majority of our source code retains the existing BSD-3-Clause license.
 

--- a/apps/superdb-desktop/LICENSE.txt
+++ b/apps/superdb-desktop/LICENSE.txt
@@ -46,9 +46,9 @@ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# Polyform Perimeter License 1.0.0
+# Polyform Perimeter License 1.0.1
 
-<https://polyformproject.org/licenses/perimeter/1.0.0>
+<https://polyformproject.org/licenses/perimeter/1.0.1>
 
 ## Acceptance
 


### PR DESCRIPTION
## What's Changing

This updates the PPL license reference/links from 1.0.0 to 1.0.1.

## Why

They dropped the link to 1.0.0 a couple days ago and so it's been failing in the link checker.

## Details

From looking at https://github.com/polyformproject/polyform-licenses, the license was actually updated to 1.0.1 more than 3 years ago, but it seems they only now got around to updating it on the web site. The only change was a grammar fix:

1.0.0:

>"…even if it is ported to a different platforms or programming languages…"

1.0.1:

>"…even if it is ported to a different platform or programming language…"